### PR TITLE
Bump nbgitpuller from 1.2.0 to 1.2.1

### DIFF
--- a/python/conda-lock.yml
+++ b/python/conda-lock.yml
@@ -13,7 +13,7 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: c4df4112093e0044334b0ef41c486db1a312cfb380c6fca226bbf2ae52cf580d
+    linux-64: 41958b3e55b024c5c44a49421527ad0a171f002aee979ca176bc5b1e5861aa02
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -63,7 +63,7 @@ package:
   category: main
   optional: false
 - name: adlfs
-  version: 2024.2.0
+  version: 2024.7.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -74,10 +74,10 @@ package:
     azure-storage-blob: '>=12.12.0'
     fsspec: '>=2023.12.0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/adlfs-2024.2.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/adlfs-2024.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 4dfa76ae23a7c27f4ccaf64945b71871
-    sha256: b9ae4843b862ee69a1bfdcbb4604db817dd4f220d598fcbe64987c700b4e4cf4
+    md5: 0d774613255df3ee00340b616d00f0d0
+    sha256: 517d70e2146a5c3cd6f535eba0f358cc290e9d0eb58dd3482f040846a5d3104a
   category: main
   optional: false
 - name: affine
@@ -93,52 +93,51 @@ package:
   category: main
   optional: false
 - name: aiobotocore
-  version: 2.12.1
+  version: 2.15.1
   manager: conda
   platform: linux-64
   dependencies:
-    aiohttp: '>=3.7.4.post0,<4.0.0'
+    aiohttp: '>=3.9.2,<4.0.0'
     aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.34.41,<1.34.52'
+    botocore: '>=1.35.16,<1.35.24'
     python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.12.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.15.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 045560daef58c75a759c2638fbdb5c6a
-    sha256: e7d43681c7c2957b535aac2b3ad90013bcb39ed5514cea3cec52302f624d457a
+    md5: 341f4502c79c3e863adc7273078d2cdb
+    sha256: d888dd7771667862ede7c8bbef09d06c00239e4e5e3caf7fd625d32ab731c35c
   category: main
   optional: false
 - name: aiohttp
-  version: 3.9.3
+  version: 3.9.5
   manager: conda
   platform: linux-64
   dependencies:
     aiosignal: '>=1.1.2'
-    async-timeout: '>=4.0,<5.0'
     attrs: '>=17.3.0'
     frozenlist: '>=1.1.1'
     libgcc-ng: '>=12'
     multidict: '>=4.5,<7.0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.3-py310h2372a71_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.5-py311h459d7ec_0.conda
   hash:
-    md5: dd21c88dfec3253cb9888c0e93fa5cd1
-    sha256: 5e3fda07d48cb5b085eeaca04d63ecdd1f47119f1f9d31ebd11624f2790e82b5
+    md5: 0175d2636cc41dc019b51462c13ce225
+    sha256: 2eb99d920ef0dcd608e195bb852a64634ecf13f74680796959f1b9d9a9650a7b
   category: main
   optional: false
 - name: aioitertools
-  version: 0.11.0
+  version: 0.12.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
     typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 59c40397276a286241c65faec5e1be3c
-    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
+    md5: 222c275312d71dd318108df50d6452a1
+    sha256: b1a2574b136938fc4cc54403766032575a046a611d95899537ba2a6e0b6d98f1
   category: main
   optional: false
 - name: aiosignal
@@ -155,20 +154,20 @@ package:
   category: main
   optional: false
 - name: aiosqlite
-  version: 0.19.0
+  version: 0.20.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
     typing-extensions: '>=3.7.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosqlite-0.19.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosqlite-0.20.0-pyhd8ed1ab_0.conda
   hash:
-    md5: c60a47f9f29057417165a8af579396a8
-    sha256: 2f4b4d70244be67f49db02fca06ac5449593fe5c523791d5185d1cbc807a5af6
+    md5: 4904ac8e78fa697150e874e4b2dbf6e5
+    sha256: 93f6e9dd42c611f1d64efce431844ebe10cb785399de1872bc266067386f2e20
   category: main
   optional: false
 - name: alembic
-  version: 1.13.1
+  version: 1.13.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -178,77 +177,135 @@ package:
     python: '>=3.8'
     sqlalchemy: '>=1.3.0'
     typing-extensions: '>=4'
-  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.13.1-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.13.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b7b0062b0de9f3f71502d31215fcbbb
-    sha256: e4bc9aa5a6e866461274826bb750407a407fed9207a5adb70bf727f6addd7fe6
+    md5: c81dc0d6ce99cf5c46e8b27dc37b5a75
+    sha256: 7e61183ef0476f6e568e7021ba2abe0a566aaf1b9263575838fec6cb50d5eb42
   category: main
   optional: false
 - name: annotated-types
-  version: 0.6.0
+  version: 0.7.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
     typing-extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 997c29372bdbe2afee073dff71f35923
-    sha256: 3a2c98154d95cfd54daba6b7d507d31f5ba07ac2ad955c44eb041b66563193cd
+    md5: 7e9f4612544c8edbfd6afad17f1bd045
+    sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
   category: main
   optional: false
-- name: ansiwrap
-  version: 0.8.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: <3.12.0a0
-    textwrap3: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ansiwrap-0.8.4-py_0.tar.bz2
-  hash:
-    md5: f09557e2a7cbd2470a2ab6353000cebd
-    sha256: 34e2445a78857c7418ab738b3a3c88f3226923676c3c185688dd570a6f9129a4
-  category: main
-  optional: false
-- name: antlr-python-runtime
-  version: 4.13.1
+- name: ansicolors
+  version: 1.1.8
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/antlr-python-runtime-4.13.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ansicolors-1.1.8-pyhd8ed1ab_0.tar.bz2
   hash:
-    md5: ccdf3edb5efc7a6225b5a6a3b7608d27
-    sha256: bd3367bbea0bd3164b189e62da96fb71afe4f87037b61e6187d2f55455f4babf
+    md5: e4929dd673bcb012fab516878e72f6f6
+    sha256: e78147c36ed63f758cc8d39436bc1af89bb07441934cccbb9711d8b3cccc48c0
   category: main
   optional: false
-- name: anyio
-  version: 3.7.1
+- name: antlr-python-runtime
+  version: 4.13.2
   manager: conda
   platform: linux-64
   dependencies:
-    exceptiongroup: ''
-    idna: '>=2.8'
-    python: '>=3.7'
-    sniffio: '>=1.1'
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/antlr-python-runtime-4.13.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b517e7a6f0790337906c055aa97ca49
-    sha256: 62637ac498bcf47783cbf4f48e9b09e4e2f5a6ad42f43ca8f632c353827b94f4
+    md5: c313ebd3419477fbd356c24b984669ba
+    sha256: 906b27bdd26a3a15b1485e9b7ac4c280cd329b5cc33a1c778e6a3ff3510570a1
+  category: main
+  optional: false
+- name: anyio
+  version: 4.6.2.post1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
+    python: '>=3.9'
+    sniffio: '>=1.1'
+    typing_extensions: '>=4.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 688697ec5e9588bdded167d19577625b
+    sha256: 4b54b7ce79d818e3cce54ae4d552dba51b7afac160ceecdefd04b3917a37c502
+  category: main
+  optional: false
+- name: anywidget
+  version: 0.9.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ipywidgets: ''
+    psygnal: ''
+    python: '>=3.7'
+    typing_extensions: ''
+    watchfiles: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5163983551f7a4361b0a6bcc85334e0c
+    sha256: dbe8cd33de4c1eb1edd3578866d54497a6f51b8ee232bc522a2e497e7926bac0
   category: main
   optional: false
 - name: aom
-  version: 3.8.2
+  version: 3.9.1
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.8.2-h59595ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
   hash:
-    md5: 625e1fed28a5139aed71b3a76117ef84
-    sha256: 49b1352e2b9710b7b5400c0f2a86c0bb805091ecfc6c84d3dbf064effe33bfbf
+    md5: 346722a0be40f6edc53f12640d301338
+    sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
+  category: main
+  optional: false
+- name: apache-beam
+  version: 2.60.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cloudpickle: '>=2.2.1,<2.3.dev0'
+    crcmod: '>=1.7,<2.0'
+    dill: '>=0.3.1.1,<0.3.2'
+    fastavro: '>=0.23.6,<2'
+    fasteners: '>=0.3,<1.0'
+    grpcio: '>=1.33.1,<2,!=1.48.0,!=1.59.*,!=1.60.*,!=1.61.*,!=1.62.0,!=1.62.1,<1.66.0'
+    httplib2: '>=0.8,<0.23.0'
+    jsonpickle: '>=3.0.0,<4.0.0'
+    jsonschema: '>=4.0.0,<5.0.0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    numpy: '>=1.23.5,<2.0a0'
+    objsize: '>=0.6.1,<0.8.0'
+    orjson: '>=3.9.7,<4'
+    packaging: '>=22.0'
+    proto-plus: '>=1.7.1,<2'
+    protobuf: '>=3.20.3,<4.26.0,!=4.0.*,!=4.21.*,!=4.22.0,!=4.23.*,!=4.24.*'
+    pyarrow: '>=3.0.0,<17.0.0'
+    pyarrow-hotfix: <1
+    pydot: '>=1.2.0,<2'
+    pymongo: '>=3.8.0,<5.0.0'
+    python: '>=3.11,<3.12.0a0'
+    python-dateutil: '>=2.8.0,<3'
+    python-hdfs: '>=2.1.0,<3.0.0'
+    python_abi: 3.11.*
+    pytz: '>=2018.3'
+    redis-py: '>=5.0.0,<6'
+    regex: '>=2020.6.8'
+    requests: '>=2.24.0,<3.0.0'
+    typing-extensions: '>=3.7.0'
+    zstandard: '>=0.18.0,<1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/apache-beam-2.60.0-py311h6dcdc2f_0.conda
+  hash:
+    md5: c3f162a04d2ebed175c1519f86285715
+    sha256: 171dc56247bdafadbcaa4697c2f5ae438f7cef02c7a86f97ebef5f54f5e8ded3
   category: main
   optional: false
 - name: appdirs
@@ -276,7 +333,7 @@ package:
   category: main
   optional: false
 - name: apprise
-  version: 1.7.5
+  version: 1.9.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -284,26 +341,26 @@ package:
     click: '>=5.0'
     dataclasses: ''
     markdown: ''
-    python: '>=3.6'
+    python: '>=3.7'
     pyyaml: ''
     requests: ''
     requests-oauthlib: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/apprise-1.7.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/apprise-1.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d3170022a9a1123f2774d876b20a8942
-    sha256: 19aa64018e2865a8bba7976447e7d5459c89c9ac03d967d6f414bbd7ae9f5573
+    md5: 943136b2560e6658a96613b063bc1b7c
+    sha256: 7e0e2063d5d79f1fc64787be65019f7c9ec97a724a89a9a52fa746fc420f28af
   category: main
   optional: false
 - name: argcomplete
-  version: 3.2.3
+  version: 3.5.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.2.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b2389c0acadd4d271bcbf727cbd2d57c
-    sha256: 37e7ad3aa9c0d2337f07b03c1b950fbcc60dc9af8cdcf4fbd77445e17ad84044
+    md5: f1f7b435e0e99368020f21447e477b70
+    sha256: b2c1cb869915a96d5e2d922719edf2fc6824a15ecf666ecc18fc281d2177d224
   category: main
   optional: false
 - name: argon2-cffi
@@ -325,14 +382,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cffi: '>=1.0.1'
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h2372a71_4.conda
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
   hash:
-    md5: 68ee85860502d53c8cbfa0e4cef0f6cb
-    sha256: af94cc9b4dcaa164e1cc7e7fa0b9eb56b87ea3dc6e093c8ef6c31cfa02d9ffdf
+    md5: 18143eab7fcd6662c604b85850f0db1e
+    sha256: d1af1fbcb698c2e07b0d1d2b98384dd6021fa55c8bcb920e3652e0b0c393881b
   category: main
   optional: false
 - name: arrow
@@ -376,35 +434,36 @@ package:
   category: main
   optional: false
 - name: astropy
-  version: 6.0.1
+  version: 6.1.4
   manager: conda
   platform: linux-64
   dependencies:
-    astropy-iers-data: '>=0.2024.2.26.0.28.55'
+    __glibc: '>=2.17,<3.0.a0'
+    astropy-iers-data: '>=0.2024.8.27.10.28.29'
     importlib-metadata: ''
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
+    libgcc: '>=13'
+    numpy: '>=1.23'
     packaging: '>=19.0'
     pyerfa: '>=2.0.1.1'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     pyyaml: '>=3.13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-6.0.1-py310h1f7b6fc_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-6.1.4-py311h9f3472d_0.conda
   hash:
-    md5: 2a248c16f1ceb3e59e68b5c9c3a68062
-    sha256: 979de1eed893d64c8ebe06436c240caf8c7b46bf999548dddb11f64e33721bc6
+    md5: 622dc295512e5ee021f07717be622c67
+    sha256: 524de687540f366175b95f1e94b9e0bada51d2d557823cfde8dc38311e939d7f
   category: main
   optional: false
 - name: astropy-iers-data
-  version: 0.2024.4.1.0.33.14
+  version: 0.2024.11.4.0.33.34
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2024.4.1.0.33.14-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2024.11.4.0.33.34-pyhd8ed1ab_0.conda
   hash:
-    md5: 29dea2661cc57fcb94ba16a408bad8ba
-    sha256: c9fc370f5ff48b2c5894bb39e813f3612306e7046442c54e83027dadaa87692c
+    md5: f6bd24ec85da8f1291f221acf8d8a54c
+    sha256: 327cfe1281bfc21869c53d709a36a94fec602a9573af785d6e3739005202854f
   category: main
   optional: false
 - name: asttokens
@@ -418,19 +477,6 @@ package:
   hash:
     md5: 5f25798dcefd8252ce5f9dc494d5f571
     sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
-  category: main
-  optional: false
-- name: astunparse
-  version: 1.6.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    six: '>=1.6.1,<2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/astunparse-1.6.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 000b6f68a0bfaba800ced7500c11780f
-    sha256: e5173d1ed038038e24c0623f0219dc587ee8663cf7efa737e7075128edbc6c60
   category: main
   optional: false
 - name: async-exit-stack
@@ -459,16 +505,16 @@ package:
   category: main
   optional: false
 - name: async-timeout
-  version: 4.0.3
+  version: 5.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
     typing-extensions: '>=3.6.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ce482ec3066e6d809dbbb1d1679f215
-    sha256: bd8b698e7f037a9c6107216646f1191f4f7a7fc6da6c34d1a6d4c211bcca8979
+    md5: 5d798e639a3008d66135a0d91388d4cc
+    sha256: 64f671952350929190615d24d6b533c255590d69da39ba7bfaa052564de1fc17
   category: main
   optional: false
 - name: async_generator
@@ -476,26 +522,40 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/async_generator-1.10-py_0.tar.bz2
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/async_generator-1.10-pyhd8ed1ab_1.conda
   hash:
-    md5: d56c596e61b1c4952acf0a9920856c12
-    sha256: b45a479387f9eab020da572f87f37d55182e5b41c21a7851d6fc7dcb635a3cf0
+    md5: bcee238f99c34ca11add65c1684c5a2d
+    sha256: 8647ec9fba010c7fd34a00c0c2a04902141f1c5c1d55d80e6c7b99649b6a1c72
   category: main
   optional: false
-- name: asyncpg
-  version: 0.29.0
+- name: asyncache
+  version: 0.3.1
   manager: conda
   platform: linux-64
   dependencies:
-    async-timeout: '>=4.0.3'
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/asyncpg-0.29.0-py310h2372a71_0.conda
+    cachetools: '>=5.2.0,<6.0.0'
+    python: '>=3.8,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/asyncache-0.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 61677627d49acfc6694897b87483535c
-    sha256: 42bd09f290b1b21c95a526b291226268d4d90359a7f0cbe3dfe0d4950cc401a4
+    md5: 87bb8184ced6d84991c7c9c439b409fb
+    sha256: b68f5773ba39b310a690414ac36f78de46ed74fb4e27e06a5cf92eb6ca3cdcef
+  category: main
+  optional: false
+- name: asyncpg
+  version: 0.30.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    async-timeout: '>=4.0.3'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/asyncpg-0.30.0-py311h9ecbd09_0.conda
+  hash:
+    md5: 0e3c9a5b00e2e111cf67e68b780e4abc
+    sha256: 2d5f0b271e5f602abe3d1e0d22ddda77881f8a5f214b9fb5847adb44aefebe88
   category: main
   optional: false
 - name: atk-1.0
@@ -504,265 +564,309 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libglib: '>=2.74.1,<3.0a0'
+    libglib: '>=2.80.0,<3.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-hd4edc92_1.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
   hash:
-    md5: 6c72ec3e660a51736913ef6ea68c454b
-    sha256: 2f9314de13c1f0b54510a2afa0cdc02c0e3f828fccfc4277734f9590b11a65f1
+    md5: f730d54ba9cd543666d7220c9f7ed563
+    sha256: df682395d05050cd1222740a42a551281210726a67447e5258968dd55854302e
   category: main
   optional: false
 - name: attrs
-  version: 23.2.0
+  version: 24.2.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
   hash:
-    md5: 5e4c0743c70186509d1412e03c2d8dfa
-    sha256: 77c7d03bdb243a048fff398cedc74327b7dc79169ebe3b4c8448b0331ea55fea
+    md5: 6732fa52eb8e66e5afeb32db8701a791
+    sha256: 28dba85a7e0f7fb57d7315e13f603d1e41b83c5b88aa2a602596b52c833a2ff8
   category: main
   optional: false
 - name: av
-  version: 11.0.0
+  version: 13.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    ffmpeg: '>=6.0.0,<7.0a0'
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    ffmpeg: '>=7.1.0,<8.0a0'
+    libgcc: '>=13'
+    numpy: '>=1.22'
     pillow: ''
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/av-11.0.0-py310h688c1c9_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/av-13.1.0-py311h943d919_0.conda
   hash:
-    md5: ad2d1c834ce2312459154e3932807203
-    sha256: 9564ceadbef45945f67476cce2d30a0d14af9f61ac8e0f6d045974050e5fe309
+    md5: cc92f0be32d8ef03381781fdc15c2185
+    sha256: f8b2b5c6421b6b89e4bdeeda473fe59fee57f60e4ca855c785aa1911ffae3c8a
   category: main
   optional: false
 - name: aws-c-auth
-  version: 0.7.16
+  version: 0.7.31
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    aws-c-http: '>=0.8.1,<0.8.2.0a0'
-    aws-c-io: '>=0.14.6,<0.14.7.0a0'
-    aws-c-sdkutils: '>=0.1.15,<0.1.16.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.16-haed3651_8.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-http: '>=0.8.10,<0.8.11.0a0'
+    aws-c-io: '>=0.14.19,<0.14.20.0a0'
+    aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.31-he1a10d6_2.conda
   hash:
-    md5: ce96c083829ab2727c942243ac93ffe0
-    sha256: 75a540b313e5dc212fc0a6057f8a5bee2dda443f17a5a076bd3ea4d7195d483e
+    md5: 76550a294cc78aaccfca7824bb4814ce
+    sha256: 83fa4b24101cd85da825dcbb7611390c2a6e31a3fc17abb4d1ee5b8c40bdaa5a
   category: main
   optional: false
 - name: aws-c-cal
-  version: 0.6.10
+  version: 0.7.4
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.10-ha9bf9b1_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    libgcc: '>=13'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.4-hae4d56a_2.conda
   hash:
-    md5: ce2471034f5459a39636aacc292c96b6
-    sha256: e45d9f1eb862f566bdea3d3229dfc74f31e647a72198fe04aab58ccc03a30a37
+    md5: cdc628e4ffb4ffcd476e3847267e1689
+    sha256: 4bfed63898a1697364ce9621e1fc09c98f143777b0ca60655eb812efa5bf246d
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.14
+  version: 0.9.29
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.14-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.29-hb9d3cd8_0.conda
   hash:
-    md5: d44fe0d9a6971a4fb245be0055775d9d
-    sha256: c71dd835b1d8c7097c8d152a65680f119a203b73a6a62c5aac414bafe5e997ad
+    md5: acc51b49fd7467c8dfe4343001b812b4
+    sha256: b3b50f518e9afad383f6851bf7000cf8b343d7d3ca71558df233ee7b4bfc2919
   category: main
   optional: false
 - name: aws-c-compression
-  version: 0.2.18
+  version: 0.2.19
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-h4466546_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.19-h2bff981_2.conda
   hash:
-    md5: b0d9153fc7cfa8dc36b8703e1a59f5f3
-    sha256: 7fcc6a924691f9de65c82fd559cb1cb2ebd121c42da544a9a43623d69a284e23
+    md5: 87a059d4d2ab89409496416119dd7152
+    sha256: 908a416ff3f62b09bed436e1f77418f54115412244734d3960b11d586dd0749f
   category: main
   optional: false
 - name: aws-c-event-stream
-  version: 0.4.2
+  version: 0.4.3
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    aws-c-io: '>=0.14.6,<0.14.7.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-he635cd5_6.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-io: '>=0.14.19,<0.14.20.0a0'
+    aws-checksums: '>=0.1.20,<0.1.21.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.3-h19b0707_4.conda
   hash:
-    md5: 58fc78e523e35a08423c913751a51fde
-    sha256: 38a30beabafc1dd86c0264b6746315a1010e541a1b3ed7f97e1702873e5eaa51
+    md5: df38f56123f30d61de24474e600e7d41
+    sha256: 951f96eb45a439a36935dc2099e10c902518ec511a287c1685ca65a88a9accaa
   category: main
   optional: false
 - name: aws-c-http
-  version: 0.8.1
+  version: 0.8.10
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
-    aws-c-io: '>=0.14.6,<0.14.7.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.1-hbfc29b2_7.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-compression: '>=0.2.19,<0.2.20.0a0'
+    aws-c-io: '>=0.14.19,<0.14.20.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.10-h14a7884_2.conda
   hash:
-    md5: 8476ec099649e9a6de52f7f4d916cd2a
-    sha256: 0dc5b73aa31cef3faeeb902a11f12e1244ac241f995d73e4f4e3e0c01622f7a1
+    md5: 6147c6b6cef67adcb85516f5cf775be7
+    sha256: 0561267292739a451d7d389f100330fefafb97859962f617cd5268c96400e3aa
   category: main
   optional: false
 - name: aws-c-io
-  version: 0.14.6
+  version: 0.14.19
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    libgcc-ng: '>=12'
-    s2n: '>=1.4.8,<1.4.9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.6-h96cd748_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    libgcc: '>=13'
+    s2n: '>=1.5.5,<1.5.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.19-hc9e6898_1.conda
   hash:
-    md5: cbf8138080ea12e9d9d66cf7c8bee325
-    sha256: 5d7c7af98276949cee0e731ecedbd7e80135a3c3c3ea8246808ebb270732ae69
+    md5: ec84785f7ae14ed43156a54aec33bb14
+    sha256: 35f9719fb9d5ddf4955a432d73d910261d60754d20b58de2be2701a2e68a9cfb
   category: main
   optional: false
 - name: aws-c-mqtt
-  version: 0.10.3
+  version: 0.10.7
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    aws-c-http: '>=0.8.1,<0.8.2.0a0'
-    aws-c-io: '>=0.14.6,<0.14.7.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.3-hffff1cc_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-http: '>=0.8.10,<0.8.11.0a0'
+    aws-c-io: '>=0.14.19,<0.14.20.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.7-hb8d5873_2.conda
   hash:
-    md5: 14ad8defb307e1edb293c3fc9da8648f
-    sha256: 6b2de4a0e6e907310127b1025a0030d023e1051da48ea5821dcc6db094d69ab7
+    md5: 8dc25ca24c1a50b8295a848c384ede99
+    sha256: b30a3d8ba9352760c30f696b65486fe0e1d3cfe771f114b008a70ad440eb00c0
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.5.4
+  version: 0.6.7
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-auth: '>=0.7.16,<0.7.17.0a0'
-    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    aws-c-http: '>=0.8.1,<0.8.2.0a0'
-    aws-c-io: '>=0.14.6,<0.14.7.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.5.4-h4893938_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-auth: '>=0.7.31,<0.7.32.0a0'
+    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-http: '>=0.8.10,<0.8.11.0a0'
+    aws-c-io: '>=0.14.19,<0.14.20.0a0'
+    aws-checksums: '>=0.1.20,<0.1.21.0a0'
+    libgcc: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.7-h666547d_0.conda
   hash:
-    md5: 4ccee5dfb44ad34d8bb30429f62273cc
-    sha256: a0a6d23c1e4522d5ad11f9590c7356d548c0ab6800527fa18c129c4eedce2282
+    md5: 7f59dcbbd4eab14ca9256f20b43849eb
+    sha256: fe006f58bd9349ab7cd4cd864dd4e83409e89764b10d9d7eb7ec148e2f964465
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.1.15
+  version: 0.1.19
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.15-h4466546_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-h2bff981_4.conda
   hash:
-    md5: 258194cedccd33fd8a7b95a8aa105015
-    sha256: 349a05cf5fbcb3f6f358fc05098b210aa7da4ec3ab6d4719c79bb93b50a629f8
+    md5: 5a8afd37e2dfe464d68e63d1c38b08c5
+    sha256: ef65ca9eb9f32ada6fb1b47759374e7ef4f85db002f2265ebc8fd61718284cbc
   category: main
   optional: false
 - name: aws-checksums
-  version: 0.1.18
+  version: 0.1.20
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h4466546_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.20-h2bff981_1.conda
   hash:
-    md5: 8a04fc5a5ecaba31f66904b47dcc7797
-    sha256: 9080f064f572ac1747d32b4dff30452ff44ef2df399e6ec7bf9730da1eb99bba
+    md5: 8b424cf6b3cfc5cffe98bf4d16c032fb
+    sha256: e1793f2e52fe04ef3a6b2069abda7960d061c6f7af1f0d5f616d43e7a7c40e3c
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.26.4
+  version: 0.28.3
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-auth: '>=0.7.16,<0.7.17.0a0'
-    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
-    aws-c-http: '>=0.8.1,<0.8.2.0a0'
-    aws-c-io: '>=0.14.6,<0.14.7.0a0'
-    aws-c-mqtt: '>=0.10.3,<0.10.4.0a0'
-    aws-c-s3: '>=0.5.4,<0.5.5.0a0'
-    aws-c-sdkutils: '>=0.1.15,<0.1.16.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.4-hba3594f_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-auth: '>=0.7.31,<0.7.32.0a0'
+    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
+    aws-c-http: '>=0.8.10,<0.8.11.0a0'
+    aws-c-io: '>=0.14.19,<0.14.20.0a0'
+    aws-c-mqtt: '>=0.10.7,<0.10.8.0a0'
+    aws-c-s3: '>=0.6.7,<0.6.8.0a0'
+    aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.28.3-hbe26082_8.conda
   hash:
-    md5: d464ebd32bea6638216bae1d406e2b15
-    sha256: dfd54ab6a312c599d7b3d78f4e2d23121d7c8e412441a7d41877b47bb5ae1c40
+    md5: 80d5fac04be0e6c2774f57eb7529f145
+    sha256: a9c23a685929b24fcd032daae36b61c4862912abf0a0a8735aeef53418c5bce6
   category: main
   optional: false
 - name: aws-sdk-cpp
-  version: 1.11.267
+  version: 1.11.407
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.14,<0.9.15.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
-    libcurl: '>=8.6.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.267-hb1af6a8_4.conda
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
+    aws-checksums: '>=0.1.20,<0.1.21.0a0'
+    aws-crt-cpp: '>=0.28.3,<0.28.4.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.407-h25d6d5c_1.conda
   hash:
-    md5: 3e735ae06073894080acd78365e78936
-    sha256: b5515e6012fc858c6dd3ccf36009470d4ab6e3ba283934809112cca2874fb185
+    md5: 0f2bd0128d59a45c9fd56151eab0b37e
+    sha256: f05d43f3204887cec9a9853a9217f06562b28161950b5485aed1f8afe42aad17
   category: main
   optional: false
 - name: awscli
-  version: 1.32.51
+  version: 2.19.1
   manager: conda
   platform: linux-64
   dependencies:
-    botocore: 1.34.51
-    colorama: '>=0.2.5,<0.4.5'
-    docutils: '>=0.10,<0.17'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    pyyaml: '>=3.10,<6.1'
-    rsa: '>=3.1.2,<4.8'
-    s3transfer: '>=0.10.0,<0.11.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.32.51-py310hff52083_0.conda
+    awscrt: '>=0.19.18,<=0.22.0'
+    colorama: '>=0.2.5,<0.4.7'
+    cryptography: '>=40.0.0,<43.0.2'
+    distro: '>=1.5.0,<1.9.0'
+    docutils: '>=0.10,<0.20'
+    jmespath: '>=0.7.1,<1.1.0'
+    prompt_toolkit: '>=3.0.24,<3.0.39'
+    python: '>=3.11,<3.12.0a0'
+    python-dateutil: '>=2.1,<=2.9.0'
+    python_abi: 3.11.*
+    ruamel.yaml: '>=0.15.0,<=0.17.21'
+    ruamel.yaml.clib: '>=0.2.0,<=0.2.8'
+    urllib3: '>=1.25.4,<1.27'
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.19.1-py311h38be061_0.conda
   hash:
-    md5: c8fbd482d656eff34e0d2473aa0a5f00
-    sha256: d9722859ce53260d1f208cbeb4874fe88b119ce469e6b1d21f515b18701dc047
+    md5: ff3e22bf2cd2b10a03c1488149a4be97
+    sha256: f912ee31c4277c49a129342cd8bb5aa5c22ce82d6c9d6a43679bbd6031394567
+  category: main
+  optional: false
+- name: awscrt
+  version: 0.22.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-auth: '>=0.7.31,<0.7.32.0a0'
+    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
+    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
+    aws-c-http: '>=0.8.10,<0.8.11.0a0'
+    aws-c-io: '>=0.14.19,<0.14.20.0a0'
+    aws-c-mqtt: '>=0.10.7,<0.10.8.0a0'
+    aws-c-s3: '>=0.6.7,<0.6.8.0a0'
+    aws-checksums: '>=0.1.20,<0.1.21.0a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    s2n: '>=1.5.5,<1.5.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.22.0-py311h8061850_5.conda
+  hash:
+    md5: a63d29f5085c2fb6bed22f6b406aa261
+    sha256: 79b84e02d3678a2aa1d5e7fc7d7b71df638cd6416807aeeb2075eb1222603beb
   category: main
   optional: false
 - name: azure-cli-core
@@ -805,13 +909,13 @@ package:
   dependencies:
     applicationinsights: '>=0.11.1'
     portalocker: 1.2.1
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-cli-telemetry-1.0.2-py310hff52083_4.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-cli-telemetry-1.0.2-py311h38be061_4.tar.bz2
   hash:
-    md5: 7e93b7ecebed6668566a00e5f4de628c
-    sha256: a998855d79a07c5be5968ac10668e0ca10fa4a8ede9546ac4a069136e6c72a82
+    md5: 011267b984d37f7bf8b686493245ccfc
+    sha256: 7f81a862ee5fcb50c9e49fead4036f15b8515f987af1b55610d5a1ef5e6bc113
   category: main
   optional: false
 - name: azure-common
@@ -827,7 +931,7 @@ package:
   category: main
   optional: false
 - name: azure-core
-  version: 1.30.1
+  version: 1.31.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -835,25 +939,26 @@ package:
     requests: '>=2.21.0'
     six: '>=1.11.0'
     typing-extensions: '>=4.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.30.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.31.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 690b51eb2dbc703e8f9ba2f7ce298363
-    sha256: c70bef5f28ee9efead58f5a4992e2b1dc120c66d24e4c9678356c123e031553f
+    md5: 33af32b1c21eb1fa7f0e2d9ecd0ea231
+    sha256: 289290d374c5ff2cfb58e429c5ca35f31f180bdc65c6c17437cdf4990831e579
   category: main
   optional: false
 - name: azure-core-cpp
-  version: 1.11.1
+  version: 1.13.0
   manager: conda
   platform: linux-64
   dependencies:
-    libcurl: '>=8.5.0,<9.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libcurl: '>=8.8.0,<9.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.11.1-h91d86a7_1.conda
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.13.0-h935415a_0.conda
   hash:
-    md5: 2dbab1d281b7e1da05eee544cbdc8af6
-    sha256: 810a890bf66d6368637399ef415dcc8152acd28f4b4b61d4048b7be7cba17d4c
+    md5: debd1677c2fea41eb2233a260f48a298
+    sha256: b7e0a22295db2e1955f89c69cefc32810309b3af66df986d9fb75d89f98a80f7
   category: main
   optional: false
 - name: azure-data-tables
@@ -888,19 +993,36 @@ package:
   category: main
   optional: false
 - name: azure-identity
-  version: 1.15.0
+  version: 1.17.1
   manager: conda
   platform: linux-64
   dependencies:
-    azure-core: <2.0.0,>=1.23.0
+    azure-core: '>=1.23.0'
     cryptography: '>=2.5'
-    msal: <2.0.0,>=1.24.0
-    msal_extensions: <2.0.0,>=0.3.0
+    msal: '>=1.24.0'
+    msal_extensions: '>=0.3.0'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-identity-1.15.0-pyhd8ed1ab_0.conda
+    typing-extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-identity-1.17.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d1ef208ae2a355e5bb9cdce337644ce9
-    sha256: a7a80ce603b0b2af0670e676b0ce96cc3fddd7c59f8f2c4d5767f5cfda7a74e9
+    md5: 137b53f8ac9b81798f07bdcf2248fab4
+    sha256: d57802f1f3b96c57d867cfb0b782c103936fb62fa9da3c456ebe17a202b045fc
+  category: main
+  optional: false
+- name: azure-identity-cpp
+  version: 1.8.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hd126650_2.conda
+  hash:
+    md5: 36df3cf05459de5d0a41c77c4329634b
+    sha256: f85452eca3ae0e156b1d1a321a1a9f4f58d44ff45236c0d8602ab96aaad3c6ba
   category: main
   optional: false
 - name: azure-mgmt-resource
@@ -918,50 +1040,69 @@ package:
   category: main
   optional: false
 - name: azure-storage-blob
-  version: 12.19.1
+  version: 12.23.1
   manager: conda
   platform: linux-64
   dependencies:
-    azure-core: <2.0.0,>=1.28.0
+    azure-core: '>=1.30.0'
     cryptography: '>=2.1.4'
     isodate: '>=0.6.1'
-    python: '>=3.7'
-    typing-extensions: '>=4.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-storage-blob-12.19.1-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    typing-extensions: '>=4.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-storage-blob-12.23.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 57fdaf60fb362bb31c685b0f5e2b1f3a
-    sha256: fe43dcceec8cea87f1c5fcf3c155fb0e5c0c1a9d3656112ec4da232c053edaca
+    md5: 1e9f92b04ddfb72ba0cd6f2298422a5a
+    sha256: e2c84cc661d8cde7727bbd002fb5d4be22a22271d71e0dda018c723506987ff6
   category: main
   optional: false
 - name: azure-storage-blobs-cpp
-  version: 12.10.0
+  version: 12.12.0
   manager: conda
   platform: linux-64
   dependencies:
-    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
-    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
+    azure-storage-common-cpp: '>=12.7.0,<12.7.1.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.10.0-h00ab1b0_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.12.0-hd2e3451_0.conda
   hash:
-    md5: 1e63d3866554a4d2e3d1cba5f21a2841
-    sha256: c88f6bc72ef42fd09471d4c4b2293fa17f730e3ba10290a0bb86de0ff7e9b195
+    md5: 61f1c193452f0daa582f39634627ea33
+    sha256: 69a0f5c2a08a1a40524b343060debb8d92295e2cc5805c3db56dad7a41246a93
   category: main
   optional: false
 - name: azure-storage-common-cpp
-  version: 12.5.0
+  version: 12.7.0
   manager: conda
   platform: linux-64
   dependencies:
-    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.5,<3.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.5.0-h94269e2_4.conda
+    libxml2: '>=2.12.7,<3.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.7.0-h10ac4d7_1.conda
   hash:
-    md5: f364272cb4c2f4ce2341067107b82865
-    sha256: 7143e85cfadcc3c789c879e66c3e6dbf8b6d5822d1d75b5b3063955279348233
+    md5: ab6d507ad16dbe2157920451d662e4a1
+    sha256: 1030fa54497a73eb78c509d451f25701e2e781dc182e7647f55719f1e1f9bee8
+  category: main
+  optional: false
+- name: azure-storage-files-datalake-cpp
+  version: 12.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
+    azure-storage-blobs-cpp: '>=12.12.0,<12.12.1.0a0'
+    azure-storage-common-cpp: '>=12.7.0,<12.7.1.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.11.0-h325d260_1.conda
+  hash:
+    md5: 11d926d1f4a75a1b03d1c053ca20424b
+    sha256: 1726fa324bb402e52d63227d6cb3f849957cd6841f8cb8aed58bb0c81203befb
   category: main
   optional: false
 - name: babel
@@ -979,17 +1120,18 @@ package:
   category: main
   optional: false
 - name: bcrypt
-  version: 4.1.2
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.1.2-py310hcb5633a_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.2.0-py311h9e33e62_1.conda
   hash:
-    md5: 6dd3d49f65ceb05dbd527a5b6301611b
-    sha256: df399f6daedb506d2f0d2d0cc2619969b9042455c1f4314eee526bbf6f4d7aba
+    md5: 20a2ce70d703e1d2b619aa07363961a1
+    sha256: e0bebfacdb16886ee8087c7cc3cb167bc20dbe3ecd7b85d674edabc408f1864a
   category: main
   optional: false
 - name: beautifulsoup4
@@ -1006,110 +1148,86 @@ package:
   category: main
   optional: false
 - name: binutils
-  version: '2.40'
+  version: '2.43'
   manager: conda
   platform: linux-64
   dependencies:
-    binutils_impl_linux-64: '>=2.40,<2.41.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
+    binutils_impl_linux-64: '>=2.43,<2.44.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_2.conda
   hash:
-    md5: ccc940fddbc3fcd3d79cd4c654c4b5c4
-    sha256: 35f3b042f295fd7387de11cf426ca8ee5257e5c98b88560c6c5ad4ef3c85d38c
+    md5: 348619f90eee04901f4a70615efff35b
+    sha256: 92be0f8ccd501ceeb3c782e2182e6ea04dca46799038176de40a57bca45512c5
   category: main
   optional: false
 - name: binutils_impl_linux-64
-  version: '2.40'
+  version: '2.43'
   manager: conda
   platform: linux-64
   dependencies:
-    ld_impl_linux-64: '2.40'
+    ld_impl_linux-64: '2.43'
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_2.conda
   hash:
-    md5: 33084421a8c0af6aef1b439707f7662a
-    sha256: a7e0ea2b71a5b03d82e5a58fb6b612ab1c44d72ce161f9aa441f7ba467cd4c8d
+    md5: cf0c5521ac2a20dfa6c662a4009eeef6
+    sha256: 267e78990247369b13234bda270f31beb56a600b4851a8244e31dd9ad85b3b17
   category: main
   optional: false
 - name: binutils_linux-64
-  version: '2.40'
+  version: '2.43'
   manager: conda
   platform: linux-64
   dependencies:
-    binutils_impl_linux-64: 2.40.*
-    sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hdade7a5_3.conda
+    binutils_impl_linux-64: '2.43'
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_2.conda
   hash:
-    md5: 2d9a60578bc28469d9aeef9aea5520c3
-    sha256: d114b825acef51c1d065ca0a17f97e0e856c48765aecf2f8f164935635013dd2
-  category: main
-  optional: false
-- name: black
-  version: 24.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: '>=8.0.0'
-    mypy_extensions: '>=0.4.3'
-    packaging: '>=22.0'
-    pathspec: '>=0.9'
-    platformdirs: '>=2'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    tomli: '>=1.1.0'
-    typing_extensions: '>=4.0.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.3.0-py310hff52083_0.conda
-  hash:
-    md5: 12960fe9118cbb71fb802a52870f7874
-    sha256: f077d0cfd2da414b09427e7b024a2ddc717303fbb088e3b1f0185a9dc1fe3a2f
+    md5: 18aba879ddf1f8f28145ca6fcb873d8c
+    sha256: df52bd8b8b2a20a0c529d9ad08aaf66093ac318aa8a33d270f18274341a77062
   category: main
   optional: false
 - name: bleach
-  version: 6.1.0
+  version: 6.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    packaging: ''
-    python: '>=3.6'
-    setuptools: ''
-    six: '>=1.9.0'
+    python: '>=3.9'
     webencodings: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
-    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
+    md5: 461bcfab8e65c166e297222ae919a2d4
+    sha256: 01be7fb5163e7c31356a18c259ddc19a5431b8b974dc65e2427b88c2d30034f3
   category: main
   optional: false
 - name: blinker
-  version: 1.7.0
+  version: 1.8.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.8.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 550da20b2c2e38be9cc44bb819fda5d5
-    sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
+    md5: cf85c002319c15e9721934104aaa1137
+    sha256: 8ca3cd8f78d0607df28c9f76adb9800348f8f2dc8aa49d188a995a0acdc4477d
   category: main
   optional: false
 - name: blosc
-  version: 1.21.5
+  version: 1.21.6
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
+    snappy: '>=1.2.0,<1.3.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
   hash:
-    md5: 009521b7ed97cca25f8f997f9e745976
-    sha256: e2b15b017775d1bda8edbb1bc48e545e45364edefa4d926732fc5488cc600731
+    md5: 54fe76ab3d0189acaef95156874db7f9
+    sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
   category: main
   optional: false
 - name: bokeh
-  version: 3.4.0
+  version: 3.5.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -1119,14 +1237,14 @@ package:
     packaging: '>=16.8'
     pandas: '>=1.2'
     pillow: '>=7.1.0'
-    python: '>=3.9'
+    python: '>=3.10'
     pyyaml: '>=3.10'
     tornado: '>=6.2'
     xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: eebbbfdb7eb885ddc751c790c3d0ad64
-    sha256: a980687100456202425af0936185ef95c53309044e271daa60d2eeb009410f73
+    md5: 38d785787ec83d0431b3855328395113
+    sha256: 8af284264eb1cb9c08586ac8c212dcafc929ef1de3db9d0d7f8ca75190a30f4b
   category: main
   optional: false
 - name: boltons
@@ -1142,48 +1260,49 @@ package:
   category: main
   optional: false
 - name: boto3
-  version: 1.34.51
+  version: 1.35.23
   manager: conda
   platform: linux-64
   dependencies:
-    botocore: '>=1.34.51,<1.35.0'
+    botocore: '>=1.35.23,<1.36.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.8'
     s3transfer: '>=0.10.0,<0.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.51-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.23-pyhd8ed1ab_0.conda
   hash:
-    md5: bd19311f73611626b31afc608af438cd
-    sha256: c546e164f823eb41e1f5a10e113d38c57e5ecf609f99ed31c503f0018db7063c
+    md5: 5d644d9ab2fefa60752d3b89ee100360
+    sha256: cdf46f5fb3cca71155e4d3d36cacfe053917cd34cc892ab2851336eca710f615
   category: main
   optional: false
 - name: botocore
-  version: 1.34.51
+  version: 1.35.23
   manager: conda
   platform: linux-64
   dependencies:
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
-    urllib3: '>=1.25.4,<2.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.51-pyge310_1234567_0.conda
+    urllib3: '>=1.25.4,!=2.2.0,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.23-pyge310_1234567_0.conda
   hash:
-    md5: f8980578a765dd28417953dddfefe5bc
-    sha256: 22da81ae34f947d3f875687b3953c0b4de46a065a3ec7b9e00154d2fca6a6e27
+    md5: 8bc6cc86e95ae59192bdf6d27bfffb37
+    sha256: 4af3e09e19d2858bdf05bcfdd07179772eb9580367b3f9453629453e533b0fe1
   category: main
   optional: false
 - name: bottleneck
-  version: 1.3.8
+  version: 1.4.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/bottleneck-1.3.8-py310h1f7b6fc_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.21,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/bottleneck-1.4.2-py311h9f3472d_0.conda
   hash:
-    md5: f99a3c02ed1e4f89fcd3b6628de372aa
-    sha256: 1b987944059419e3e3c422d282b68f98a2bd489f41f69d6eae9e588885830966
+    md5: c638796964b0d9fdb6575537021f23e3
+    sha256: f05bfc44fd54bac267da2d2b364f6b49ca2a7e8026434ee34a7bcdd7a1d95ed7
   category: main
   optional: false
 - name: bqplot
@@ -1204,16 +1323,16 @@ package:
   category: main
   optional: false
 - name: branca
-  version: 0.7.1
+  version: 0.7.2
   manager: conda
   platform: linux-64
   dependencies:
     jinja2: '>=3'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 35fa1bfd27c4d4c3cd46501a9ca7bd78
-    sha256: 4053ce4389a524e226eea020e2e507335e908a45d324b4f48d4b4407b17c88e3
+    md5: 5f1c719f1cac0aee5e6bd6ca7d54a7fa
+    sha256: 9f7df349cb5a8852804d5bb1f5f49e3076a55ac7229b9c114bb5f7461f497ba7
   category: main
   optional: false
 - name: brotli
@@ -1221,14 +1340,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     brotli-bin: 1.1.0
     libbrotlidec: 1.1.0
     libbrotlienc: 1.1.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
   hash:
-    md5: f27a24d46e3ea7b70a1f98e50c62508f
-    sha256: f2d918d351edd06c55a6c2d84b488fe392f85ea018ff227daac07db22b408f6b
+    md5: 98514fe74548d768907ce7a13f680e8f
+    sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
   category: main
   optional: false
 - name: brotli-bin
@@ -1236,13 +1356,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libbrotlidec: 1.1.0
     libbrotlienc: 1.1.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
   hash:
-    md5: 39f910d205726805a958da408ca194ba
-    sha256: a641abfbaec54f454c8434061fffa7fdaa9c695e8a5a400ed96b4f07c0c00677
+    md5: c63b5e52939e795ba8d26e35d767a843
+    sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
   category: main
   optional: false
 - name: brotli-python
@@ -1250,14 +1371,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
   hash:
-    md5: 1f95722c94f00b69af69a066c7433714
-    sha256: e22268d81905338570786921b3def88e55f9ed6d0ccdd17d9fbae31a02fbef69
+    md5: d21daab070d76490cb39a8f1d1729d79
+    sha256: 949913bbd1f74d1af202d3e4bff2e0a4e792ec00271dc4dd08641d4221aa2e12
   category: main
   optional: false
 - name: brunsli
@@ -1279,64 +1401,67 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
   hash:
-    md5: 69b8b6202a07720f448be700e300ccf4
-    sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
+    md5: 62ee74e96c5ebb0af99386de58cf9553
+    sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
   category: main
   optional: false
 - name: c-ares
-  version: 1.28.1
+  version: 1.34.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
+    __glibc: '>=2.28,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
   hash:
-    md5: dcde58ff9a1f30b0037a2315d1846d1f
-    sha256: cb25063f3342149c7924b21544109696197a9d774f1407567477d4f3026bf38a
+    md5: 2b780c0338fc0ffa678ac82c54af51fd
+    sha256: c2a515e623ac3e17a56027c06098fbd5ab47afefefbd386b4c21289f2ec55139
   category: main
   optional: false
 - name: c-blosc2
-  version: 2.14.0
+  version: 2.15.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    zlib-ng: '>=2.0.7,<2.1.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.14.0-hb4ffafa_0.conda
+    zlib-ng: '>=2.2.1,<2.3.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.15.1-hc57e6cf_0.conda
   hash:
-    md5: ffe4b89c7e3335f2e12faf13fa077115
-    sha256: 00e0865d2d4885f66a3713c2546dee846c7d013beaa98217aeea2ed7325d2bfd
+    md5: 5f84961d86d0ef78851cb34f9d5e31fe
+    sha256: 6b11cae208878fbf621fbc22135a7912fd0ef19301d0b654858ae16b972410dc
   category: main
   optional: false
 - name: c-compiler
-  version: 1.7.0
+  version: 1.8.0
   manager: conda
   platform: linux-64
   dependencies:
     binutils: ''
     gcc: ''
-    gcc_linux-64: 12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.7.0-hd590300_0.conda
+    gcc_linux-64: 13.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.8.0-h2b85faf_1.conda
   hash:
-    md5: fad1d0a651bf929c6c16fbf1f6ccfa7c
-    sha256: 19343f6cdefd0a2e36c4f0da81ed9ea964e5b4e82a2304809afd8f151bf2ac8c
+    md5: fa7b3bf2965b9d74a81a0702d9bb49ee
+    sha256: 009fced27be14e5ac750a04111a07eda79d73f80009300c1538cb83d5da71879
   category: main
   optional: false
 - name: ca-certificates
-  version: 2024.2.2
+  version: 2024.8.30
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
   hash:
-    md5: 2f4327a1cbe7f022401b236e915a5fef
-    sha256: 91d81bfecdbb142c15066df70cc952590ae8991670198f92c66b62019b251aeb
+    md5: c27d1c142233b5bc9ca570c6e2e0c244
+    sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
   category: main
   optional: false
 - name: cached-property
@@ -1364,15 +1489,15 @@ package:
   category: main
   optional: false
 - name: cachetools
-  version: 5.3.3
+  version: 5.5.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: cd4c26c702a9bcdc70ff05b609ddacbe
-    sha256: 561b860cba68da76cab8c6504bb5bfb4756ecb2ec9f124d0c17e76caad4f6dfd
+    md5: 5bad039db72bd8f134a5cff3ebaa190d
+    sha256: 0abdbbfc2e9c21079a943f42a2dcd950b1a8093ec474fc017e83da0ec4e6cbf4
   category: main
   optional: false
 - name: cachey
@@ -1393,52 +1518,54 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     fontconfig: '>=2.14.2,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
+    icu: '>=75.1,<76.0a0'
     libgcc-ng: '>=12'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
+    libglib: '>=2.80.3,<3.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
     libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    pixman: '>=0.42.2,<1.0a0'
+    libxcb: '>=1.16,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pixman: '>=0.43.2,<1.0a0'
     xorg-libice: '>=1.1.1,<2.0a0'
     xorg-libsm: '>=1.2.4,<2.0a0'
-    xorg-libx11: '>=1.8.6,<2.0a0'
+    xorg-libx11: '>=1.8.9,<2.0a0'
     xorg-libxext: '>=1.3.4,<2.0a0'
     xorg-libxrender: '>=0.9.11,<0.10.0a0'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
   hash:
-    md5: f907bb958910dc404647326ca80c263e
-    sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
+    md5: fceaedf1cdbcb02df9699a0d9b005292
+    sha256: aee5b9e6ef71cdfb2aee9beae3ea91910ca761c01c0ef32052e3f94a252fa173
   category: main
   optional: false
 - name: cartopy
-  version: 0.22.0
+  version: 0.24.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    matplotlib-base: '>=3.4'
-    numpy: '>=1.22.4,<2.0a0'
-    packaging: '>=20'
-    pyproj: '>=3.1.0'
-    pyshp: '>=2.1'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    shapely: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.22.0-py310hcc13569_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    matplotlib-base: '>=3.6'
+    numpy: '>=1.19,<3'
+    packaging: '>=21'
+    pyproj: '>=3.3.1'
+    pyshp: '>=2.3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    shapely: '>=1.8'
+  url: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.24.0-py311h7db5c69_0.conda
   hash:
-    md5: 31ef447724fb19066a9d00a660dab1bd
-    sha256: ec73372b3945634920c115f9d04b4543cc2d459c583df329aa32be813ca21380
+    md5: 20ba399d57a2b5de789a5b24341481a1
+    sha256: 992dd015dcb428c7bbd92f1de18fa3eb1f2cb084625ccf676a91727172361f2d
   category: main
   optional: false
 - name: cattrs
-  version: 23.2.3
+  version: 24.1.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -1446,10 +1573,10 @@ package:
     exceptiongroup: '>=1.1.1'
     python: '>=3.8'
     typing-extensions: '>=4.1.0,!=4.6.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/cattrs-23.2.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cattrs-24.1.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 91fc4700dcce4a46d439900a132fe4e5
-    sha256: 7fbcf6487856c4b777926112dccc3385cbd2eeae181825f77eed261abe83c1df
+    md5: ac582de2324988b79870b50c89c91c75
+    sha256: 51abcd19174028e3745ae7c16969ae66c321f047f20bc4383b9f6a692e770364
   category: main
   optional: false
 - name: cchardet
@@ -1459,91 +1586,71 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cchardet-2.1.7-py310hc6cd4ac_5.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/cchardet-2.1.7-py311hb755f60_5.conda
   hash:
-    md5: bc3e5e7988096e397a48362d64c035af
-    sha256: 2d2ed513a253a1932bd9b80bb0ff3acee790cff2b73bf5c9f35ed96f67480169
-  category: main
-  optional: false
-- name: ceres-solver
-  version: 2.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    eigen: ''
-    gflags: '>=2.2.2,<2.3.0a0'
-    glog: '>=0.7.0,<0.8.0a0'
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    suitesparse: '>=5.10.1,<6.0a0'
-    tbb: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/ceres-solver-2.2.0-h30ec75d_2.conda
-  hash:
-    md5: 3e22f317903149ec5220795a9bc32aad
-    sha256: 8db7b51a75ab27410738b826d4803ae90e8fb445cd614c79129b7b4abfcaabd4
+    md5: 7e2bfbfc5c66756cc026984c25c9ec18
+    sha256: 54ab2875189fe15abcb4811c663a969a7d188299f245be468d5be4c262d552dc
   category: main
   optional: false
 - name: certifi
-  version: 2024.2.2
+  version: 2024.8.30
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
   hash:
-    md5: 0876280e409658fc6f9e75d035960333
-    sha256: f1faca020f988696e6b6ee47c82524c7806380b37cfdd1def32f92c326caca54
+    md5: 12f7d00853807b0531775e9be891cb11
+    sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
   category: main
   optional: false
 - name: certipy
-  version: 0.1.3
+  version: 0.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    pyopenssl: ''
-    python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/certipy-0.1.3-py_0.tar.bz2
+    cryptography: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/certipy-0.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 23486713ef5712923e7c57cae609b22e
-    sha256: f9ab82559881f22e9096562e33be6a9d1c0b705b039ee9e433b99ff96b069e36
+    md5: 7566bb010833e59fb579ed520b9a7bc5
+    sha256: be226c66b57f28be62b019e175a6c7fd477d33bbbdc7bdc45559b786be2e82b1
   category: main
   optional: false
 - name: cf_xarray
-  version: 0.9.0
+  version: 0.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-    xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.9.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+    xarray: '>=2022.03.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 33070a578d45591f242a254f78f86f10
-    sha256: 89a987a314e2c4290cc1aea0e5429f70225b08eb1a7859bdfd7a959a9bd871e7
+    md5: 9437cfe346eab83b011b4def99f0e879
+    sha256: 9733b1e42114f8f4be88005d89ecb39d56738750510601941e2197e1ba76efbc
   category: main
   optional: false
 - name: cffi
-  version: 1.16.0
+  version: 1.17.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     pycparser: ''
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
   hash:
-    md5: 45846a970e71ac98fd327da5d40a0a2c
-    sha256: 007e7f69ab45553b7bf11f2c1b8d3f3a13fd42997266a0d57795f41c7d38df36
+    md5: 55553ecd5328336368db611f350b7039
+    sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
   category: main
   optional: false
 - name: cfgrib
-  version: 0.9.10.4
+  version: 0.9.14.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -1555,42 +1662,44 @@ package:
     python-eccodes: '>=0.9.8'
     setuptools: ''
     xarray: '>=0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/cfgrib-0.9.10.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cfgrib-0.9.14.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 9deb1bf75ecf0ab13ed71d6fd8057185
-    sha256: 8e19819c45d37963fc166e51fbcc219d9ca9e67d05c2d762b21327acd4e61405
+    md5: 1870fe8c9bd8967429e227be28ab94d2
+    sha256: fca594ecc55659a47f03111d2a13a5a7b8d341465b01efedd529a68ccf183297
   category: main
   optional: false
 - name: cfitsio
-  version: 4.4.0
+  version: 4.4.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.0-hbdc6101_0.conda
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libgfortran: ''
+    libgfortran5: '>=13.3.0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.1-ha728647_2.conda
   hash:
-    md5: 446ac3db6cb017e3dd067cc35cf51442
-    sha256: fe50510b705d2adf6f7c162293f788ee7fa2eebd33adf30856723667e6a45586
+    md5: dab65ce7f9da0b25f53f0ec0d37ee09c
+    sha256: 985f6dd1346b3cdc6658ec9b17d794d8a5859f966e8e5b2a886a2bdc84c39975
   category: main
   optional: false
 - name: cftime
-  version: 1.6.3
+  version: 1.6.4
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.3-py310h1f7b6fc_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.4-py311h9f3472d_1.conda
   hash:
-    md5: 31beda75384647959d5792a1a7dc571a
-    sha256: 0983d88068e4bd589031582769ef7d05617edda3a7daa1f4847492f4c3538aad
+    md5: 2c3c4f115d28ed9e001a271d5d8585aa
+    sha256: 8fa32d106c8757eac936105a5a14eb2eac0c66398cfa954855cb0bd220f003a5
   category: main
   optional: false
 - name: cgen
@@ -1599,13 +1708,13 @@ package:
   platform: linux-64
   dependencies:
     numpy: ''
-    python: ''
+    python: '>=3.8'
     pytools: ''
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cgen-2020.1-py_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/cgen-2020.1-pyhd8ed1ab_1.conda
   hash:
-    md5: f51cf23f72dcc18e07f44feb5a152d6e
-    sha256: 15ad63ac0b34cf29ca530ab71d48085cb03e2d9629b4585dea00376325bc0c19
+    md5: df7c0886811b366401c3a7c300ce49af
+    sha256: 4d0369ef562504c496b8c61a5ab585e28fc3637282ca33023e23bad3b2e986bc
   category: main
   optional: false
 - name: charls
@@ -1622,31 +1731,46 @@ package:
   category: main
   optional: false
 - name: charset-normalizer
-  version: 3.3.2
+  version: 3.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7f4a9e3fcff3f6356ae99244a014da6a
-    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+    md5: a374efa97290b8799046df7c5ca17164
+    sha256: 1873ac45ea61f95750cb0b4e5e675d1c5b3def937e80c7eebb19297f76810be8
   category: main
   optional: false
 - name: ciso
-  version: 0.2.0
+  version: 0.2.2
   manager: conda
   platform: linux-64
   dependencies:
-    cython: ''
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ciso-0.2.0-py310h1f7b6fc_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/ciso-0.2.2-py311h9f3472d_1.conda
   hash:
-    md5: 43fa57efd4a68405f1ad82c838844f5d
-    sha256: 2b731c0ea4d96c39d219160967846a3c09e4970a0fef9e69602c75183097eeaf
+    md5: 329437e19fb05f5e2ab094706187c926
+    sha256: 1cef4b85ecbfbeafae0b3bdf3ec395a8b31e5473875c561e3e60abd7726801bf
+  category: main
+  optional: false
+- name: ciso8601
+  version: 2.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/ciso8601-2.3.1-py311h9ecbd09_1.conda
+  hash:
+    md5: c21e76a52ca3b23daa43a10c07d6117e
+    sha256: ae5a2c1a00cf48ad647bc537a886790f5464381ccd567a8dd39902c253d00856
   category: main
   optional: false
 - name: click
@@ -1701,7 +1825,7 @@ package:
   category: main
   optional: false
 - name: cmocean
-  version: 3.1.3
+  version: 4.0.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -1710,37 +1834,38 @@ package:
     numpy: ''
     packaging: ''
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cmocean-3.1.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cmocean-4.0.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 671543f081d6be0b6b3e99b586386b44
-    sha256: 289ff41aed248125e99bf6bc30a0ce98f4fb62d5a23c522c612ec8b1f3088ebb
+    md5: 53df00540de0348ed1b2a62684dd912b
+    sha256: c32b9dddcfc5ce3aa2e4a84ff73b9eff67fe2cff64b5dc885ddd13e2bfab9978
   category: main
   optional: false
 - name: color-operations
-  version: 0.1.3
+  version: 0.1.5
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/color-operations-0.1.3-py310h1f7b6fc_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/color-operations-0.1.5-py311h9f3472d_2.conda
   hash:
-    md5: 990e18b1e108450ab2d812adbf51cfae
-    sha256: 7b1a18e9582d7ed8c36e22d65a46f2a0b50834da23b21e0579b81bca26c8d439
+    md5: f0942477dfd1c060854bbaed544dcae4
+    sha256: f8e945701e9facf570a62a56604e6c493b2c887eff8b8c5f811c3ab61e0ad656
   category: main
   optional: false
 - name: colorama
-  version: 0.4.4
+  version: 0.4.6
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.4-pyh9f0ad1d_0.tar.bz2
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
   hash:
-    md5: c08b4c1326b880ed44f3ffb04803332f
-    sha256: ddf1749f0fd5a098a7954d98267cebca83a36b86719ce4ab6fc4aa94ef518432
+    md5: 3faab06a954c2a04039983f2c4a50d99
+    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
   category: main
   optional: false
 - name: colorcet
@@ -1794,20 +1919,20 @@ package:
   category: main
   optional: false
 - name: configobj
-  version: 5.0.8
+  version: 5.0.9
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.9-pyhd8ed1ab_0.conda
   hash:
-    md5: 04c71f400324538d4396407ea2ffb34f
-    sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
+    md5: 0f20a9d96ded9cbd14b4cbfd18e45cfa
+    sha256: 97bf14ac9ec3ec203985edbc40e276dae6c4066173c81b8615087e1c8bd1f21a
   category: main
   optional: false
 - name: contextily
-  version: 1.6.0
+  version: 1.6.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -1820,26 +1945,27 @@ package:
     rasterio: ''
     requests: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.2-pyhd8ed1ab_0.conda
   hash:
-    md5: a3e5ccece003758e379be05cb5a08dff
-    sha256: 3e70e8cdffc1b6134076f720e864caa29250160a2c4f726dbf557210554fbf46
+    md5: 98e67488fd805cddb232a7246c915b4f
+    sha256: 8ea64368876654f4fe4ad6d39fd8df51462080e9647f8b9d42f5949600640c96
   category: main
   optional: false
 - name: contourpy
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.20,<2'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.0-py310hd41b1e2_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    numpy: '>=1.23'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.0-py311hd18a35c_2.conda
   hash:
-    md5: 85d2aaa7af046528d339da1e813c3a9f
-    sha256: 73dd7868bfd98fa9e4d2cc524687b5c5c8f9d427d4e521875aacfe152eae4715
+    md5: 66266cd4f20e47dc1de458c93fb4d2a9
+    sha256: 9d0abbb1f3bbfdd9070afbe389d6f9bf71e33bd53c0b3d1dcf12e63084f7993b
   category: main
   optional: false
 - name: coolname
@@ -1852,6 +1978,37 @@ package:
   hash:
     md5: 25aac2e9aa64518428dcd7b4aa872808
     sha256: 1e1651c5e2a6ea6488c204f2310da3a281c872db1c9be4f879511790662dadcb
+  category: main
+  optional: false
+- name: cramjam
+  version: 2.8.4rc3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/cramjam-2.8.4rc3-py311ha8c6e60_2.conda
+  hash:
+    md5: df564e7715f2f17d1f341c5a75cf2b79
+    sha256: 0100e13ffd47c8492249996e9c4b2305ad0b5100e55c06dba17386aa4559abc8
+  category: main
+  optional: false
+- name: crcmod
+  version: '1.7'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/crcmod-1.7-py311h9ecbd09_1011.conda
+  hash:
+    md5: 2692f79b04c81775e9edd46e9fce08d9
+    sha256: a36bef725681ada2eb4b8f7358f2b00ef28a1e2052acd990a88c534c5d2daaf8
   category: main
   optional: false
 - name: croniter
@@ -1868,37 +2025,20 @@ package:
   category: main
   optional: false
 - name: cryptography
-  version: 42.0.5
+  version: 43.0.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cffi: '>=1.12'
-    libgcc-ng: '>=12'
-    openssl: '>=3.2.1,<4.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.5-py310h75e40e8_0.conda
+    libgcc: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-43.0.1-py311hafd3f86_0.conda
   hash:
-    md5: 47e6ea7109182e9e48f8c5839f1bded7
-    sha256: eb514beb1c96969ebd299bb1979d6ccbf78087eb2a3772c364b94f778b8326ec
-  category: main
-  optional: false
-- name: curl
-  version: 8.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libcurl: 8.7.1
-    libgcc-ng: '>=12'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/curl-8.7.1-hca28451_0.conda
-  hash:
-    md5: d2dd5466be2ce818f8097847341da63d
-    sha256: 30935854620a6d48a3b5f1b940aefb19aeb37cef02bf58cd38288bbf620fc74d
+    md5: 2653b58a992032d6c3ff4d82fc1c6c82
+    sha256: 9a63941972809ca9c4397b60f4e1a71a5014b3ae92995e12f94baaf743642561
   category: main
   optional: false
 - name: cycler
@@ -1913,34 +2053,36 @@ package:
     sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   category: main
   optional: false
-- name: cython
-  version: 3.0.10
+- name: cyrus-sasl
+  version: 2.1.27
   manager: conda
   platform: linux-64
   dependencies:
+    krb5: '>=1.21.1,<1.22.0a0'
     libgcc-ng: '>=12'
+    libntlm: ''
     libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.10-py310hc6cd4ac_0.conda
+    openssl: '>=3.1.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.27-h54b06d7_7.conda
   hash:
-    md5: bd1d71ee240be36f1d85c86177d6964f
-    sha256: cf88d00fa4383a9a7f1becff6990a8a6adac72c2aa650edb738abcbe46d1e45b
+    md5: dce22f70b4e5a407ce88f2be046f4ceb
+    sha256: d2ea5e52da745c4249e1a818095a28f9c57bd4df22cbfc645352defa468e86c2
   category: main
   optional: false
 - name: cytoolz
-  version: 0.12.3
+  version: 1.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.12.3-py310h2372a71_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py311h9ecbd09_1.conda
   hash:
-    md5: 21362970a6fea90ca507c253c20465f2
-    sha256: a75c195a71b8a1676f057a785515d1f78515d4f59389d5ac6d3cd9a08880566a
+    md5: 765c19c0b6df9c143ac8f959d1a1a238
+    sha256: 42544e13dc4bb018cec0579ad7a6158c1f296e32fa0995ffd8abb116734dc427
   category: main
   optional: false
 - name: dask
@@ -1955,7 +2097,7 @@ package:
     distributed: '>=2024.3.1,<2024.3.2.0a0'
     jinja2: '>=2.10.3'
     lz4: '>=4.3.2'
-    numpy: '>=1.21'
+    numpy: '>=1.21,<2.0a0'
     pandas: '>=1.3'
     pyarrow: '>=7.0'
     pyarrow-hotfix: ''
@@ -1967,7 +2109,7 @@ package:
   category: main
   optional: false
 - name: dask-cloudprovider
-  version: 2022.10.0
+  version: 2024.9.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -1975,10 +2117,10 @@ package:
     dask: '>=2.2.0'
     distributed: '>=2.3.1'
     python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-cloudprovider-2022.10.0-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-cloudprovider-2024.9.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b0f64c7a9e674fd503c34164d78bcf2e
-    sha256: 6000554a08d03fd4bcf5aaf9719ada366ef585580c151995e9f486eee9438836
+    md5: eaec51d42c61cbdff40e6185565448b0
+    sha256: 77b78ac32704483e514608f67a0581ad5d38701870b935072b16a3633fdf2d05
   category: main
   optional: false
 - name: dask-core
@@ -2035,18 +2177,19 @@ package:
   category: main
   optional: false
 - name: dask-geopandas
-  version: 0.3.1
+  version: 0.4.2
   manager: conda
   platform: linux-64
   dependencies:
-    dask-core: '>=2021.06.0'
-    geopandas-base: '>=0.10'
+    dask-core: '>=2022.06.0'
+    geopandas-base: '>=0.12'
     packaging: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-geopandas-0.3.1-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+    shapely: '>=2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-geopandas-0.4.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 681faac0aa117819bcddf654eee56b07
-    sha256: 6a0789e1c616b70750d303fcb0f10a8c9a4e33b0923c497b3b85a6b57fe9d4b4
+    md5: c740384fd876fb385e8988ab446c332c
+    sha256: dd1bd2b7eb92307d0d392fcfb3c5b2f6bc9e29be2eea8b4ea51587599fdcb0a1
   category: main
   optional: false
 - name: dask-glm
@@ -2068,7 +2211,7 @@ package:
   category: main
   optional: false
 - name: dask-image
-  version: 2023.8.1
+  version: 2024.5.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -2079,30 +2222,30 @@ package:
     python: '>=3.9'
     scipy: '>=0.19.1'
     tifffile: '>=2018.10.18'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-image-2023.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-image-2024.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 71d4a0caa78791994c8121f72def87a7
-    sha256: 5b8e9113a7df43d982cbe540855ea1a4d9292cb3bd8e67e72f9ae6b21487a064
+    md5: 32d8c803defa8539fce282317d4eb4d7
+    sha256: 0f619d1f62e7724237596285909a23a0f60cab56320a231f47e984c155309ada
   category: main
   optional: false
 - name: dask-kubernetes
-  version: 2024.3.1
+  version: 2024.9.0
   manager: conda
   platform: linux-64
   dependencies:
     dask-core: '>=2022.08.1'
     distributed: '>=2022.08.1'
     kopf: '>=1.35.3'
-    kr8s: 0.9.0
+    kr8s: 0.17.*
     kubernetes_asyncio: '>=12.0.1'
     pykube-ng: '>=22.9.0'
     python: '>=3.9'
     python-kubernetes: '>=12.0.1'
     rich: '>=12.5.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-kubernetes-2024.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-kubernetes-2024.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5ac32097ce1e399f033c25614809b6fe
-    sha256: aa925a17cb2798739f7643d48e01c394a27152ce591ba42028691c29ef9a52f2
+    md5: 1b495b6af8934e6fb7ec39990956bfaf
+    sha256: 06d14a64b167397f21ac8ca0a241bdfc6bbac8c96dfb1dc5e4d3a00e166af7e9
   category: main
   optional: false
 - name: dask-labextension
@@ -2122,7 +2265,7 @@ package:
   category: main
   optional: false
 - name: dask-ml
-  version: 2024.3.20
+  version: 2024.4.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -2137,11 +2280,10 @@ package:
     python: '>=3.8'
     scikit-learn: '>=1.2.0'
     scipy: ''
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2024.3.20-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2024.4.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 1b12da57787f1c699535d60cbe1607ae
-    sha256: d5dfea86f2745abc33ad4cfd8926845def2db91984959edb76501cf0ccae9501
+    md5: 5fc5ed918fa9a9f63001c06bdf21d53e
+    sha256: af9b810e3f4c0af06fdeaa6c76332bb768ff078832d3bc62ead022dd935d20ad
   category: main
   optional: false
 - name: dataclasses
@@ -2157,7 +2299,7 @@ package:
   category: main
   optional: false
 - name: datacube
-  version: 1.8.18
+  version: 1.8.19
   manager: conda
   platform: linux-64
   dependencies:
@@ -2189,14 +2331,14 @@ package:
     sqlalchemy: <2.0
     toolz: ''
     xarray: '>2022.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/datacube-1.8.18-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/datacube-1.8.19-pyhd8ed1ab_0.conda
   hash:
-    md5: 13d38b86f28dacefe74d725103a25a3e
-    sha256: cc15c67858a92f7f399da0f09f1994b8414b09857a0659dd1852f75de3a50999
+    md5: 108c0ca016e1f84928e348aca18e9fd6
+    sha256: 78ebd2c1111984083e9848794c89cfae4aceb8b400423ac250d7bf2d15c8e4da
   category: main
   optional: false
 - name: datashader
-  version: 0.16.0
+  version: 0.16.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -2205,6 +2347,7 @@ package:
     multipledispatch: ''
     numba: ''
     numpy: ''
+    packaging: ''
     pandas: ''
     param: ''
     pillow: ''
@@ -2214,10 +2357,10 @@ package:
     scipy: ''
     toolz: ''
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 2bcf7e080c7a702f6a5387b57dbf404f
-    sha256: a705df42edde70be101c0523867f0ac25bd99a25ce2e96bbfb879d9541de68fb
+    md5: 1316959270592fbf8e2278a336de3ab9
+    sha256: 8f35e2d76173d300f5e5f504d67238097c16457267d421a8ab10d1e5bd9b734d
   category: main
   optional: false
 - name: dateparser
@@ -2249,18 +2392,19 @@ package:
   category: main
   optional: false
 - name: debugpy
-  version: 1.8.1
+  version: 1.8.7
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.1-py310hc6cd4ac_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.7-py311hfdbb021_0.conda
   hash:
-    md5: 1ea80564b80390fa25da16e4211eb801
-    sha256: 69d3970a9bb62d4e1e187f82248cc1cc924589c06100a6f1a065e063f4155978
+    md5: e02dac14097eb3605342cd35c13f0a26
+    sha256: 540d6b509d68ba77f6ad06f3bc419ba42930f1b3139ab4fda0476e12de8d7f4d
   category: main
   optional: false
 - name: decorator
@@ -2287,17 +2431,35 @@ package:
     sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
   category: main
   optional: false
-- name: deprecat
-  version: 2.1.1
+- name: deltalake
+  version: 0.21.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-    wrapt: '>=1.10,<2'
-  url: https://conda.anaconda.org/conda-forge/noarch/deprecat-2.1.1-pyhd8ed1ab_0.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    pyarrow: '>=16'
+    pyarrow-hotfix: ''
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/deltalake-0.21.0-py311he65840e_1.conda
   hash:
-    md5: 4379c3181f87829ed26a50c0e8c21e27
-    sha256: a1b1d6977dbb5d17cd52d2f5387879aaae25b8e729a339245c5692dce02b19ca
+    md5: 6a78358ebec9e4956a9be81de1c7e0a0
+    sha256: 66ac2b7d3a4125d04bd43cf596d54e88983628c4720e0a85b62ef182468ead6c
+  category: main
+  optional: false
+- name: deprecat
+  version: 2.1.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    wrapt: <2,>=1.10
+  url: https://conda.anaconda.org/conda-forge/noarch/deprecat-2.1.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 92f2a15689a66879d5a7bbe2348faa9c
+    sha256: 195e351cd04f0061aab6d8affe2de18843723881ddf756f09740ed5b1a56f136
   category: main
   optional: false
 - name: deprecated
@@ -2324,6 +2486,18 @@ package:
   hash:
     md5: 32fa3526c15250ccf353f1ce905f50b3
     sha256: b0b73c09a69e775f50541861622ea54e8342ae7c4b0ca7713967acb902263c74
+  category: main
+  optional: false
+- name: dill
+  version: 0.3.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.1.1-pyhd8ed1ab_2.tar.bz2
+  hash:
+    md5: dd31e651e9a38205c86447c1bb3a1607
+    sha256: 1efc782a99ab39d868a831ee7197f71cfb9edfcfa1c4daccd8549a4aa7ebca6b
   category: main
   optional: false
 - name: distributed
@@ -2354,22 +2528,46 @@ package:
     sha256: f587da3ff040968fecac7f424b88c5bc5fe16fe92fe08643fb5be8318d05c275
   category: main
   optional: false
-- name: docker-py
-  version: 6.1.3
+- name: distro
+  version: 1.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    packaging: '>=14.0'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 67999c5465064480fa8016d00ac768f6
+    sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
+  category: main
+  optional: false
+- name: dnspython
+  version: 2.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9.0,<4.0.0'
+    sniffio: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.7.0-pyhff2d567_0.conda
+  hash:
+    md5: 0adf8f63d500d20418656289249533f9
+    sha256: 3e2ea1bfd90969e0e1f152bb1f969c56661278ad6bfaa3272027b1ff0d9a1a23
+  category: main
+  optional: false
+- name: docker-py
+  version: 7.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
     paramiko: '>=2.4.3'
-    python: '>=3.7'
+    python: '>=3.8'
     pywin32-on-windows: ''
     requests: '>=2.26.0'
     urllib3: '>=1.26.0'
     websocket-client: '>=0.32.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-6.1.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: c95d23d8bae7e21491868cc7772d7c73
-    sha256: 7c3031602e92fd7682302ef98a45bdf7374d48a849cdd3900b7c68a32d162177
+    md5: 3e547e36de765ca8f28a7623fb3f255a
+    sha256: eca0bf5605a6ce79021afa1cd234cc74093a239f86cd311872e4d9b0972b5a85
   category: main
   optional: false
 - name: docopt
@@ -2382,6 +2580,18 @@ package:
   hash:
     md5: a9ed63e45579cfef026a916af2bc27c9
     sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
+  category: main
+  optional: false
+- name: docopt-ng
+  version: 0.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/docopt-ng-0.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d69e9163b8c89b27df532b988843c8de
+    sha256: e65fa4cb44aa41051bb48d90814f33593223daca0a8d2151e0d11f677550e5e0
   category: main
   optional: false
 - name: docrep
@@ -2410,88 +2620,63 @@ package:
   category: main
   optional: false
 - name: docutils
-  version: '0.16'
+  version: '0.19'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.16-py310hff52083_4.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.19-py311h38be061_1.tar.bz2
   hash:
-    md5: 19663973a2d658b48204e36f5f1c2e1d
-    sha256: 87aff25e62a3ccdf356ecc1ae1cf328b6be208b220225dbbff1341cc5eb76807
+    md5: 599159b0740e9b82e7eef0e8471be3c2
+    sha256: ec7760e5a1d065b97ac32d12f7c70f19937040d8bb52a9f16573b65c6832c67a
   category: main
   optional: false
 - name: donfig
-  version: 0.8.1.post0
+  version: 0.8.1.post1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     pyyaml: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_0.conda
   hash:
-    md5: 99618fa8b2109fc3bb51605ef93d1d60
-    sha256: 4b66e359bc706b711359b8adafa19f79c85497797b13de85a20a6d937c50677f
-  category: main
-  optional: false
-- name: draco
-  version: 1.5.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/draco-1.5.7-h00ab1b0_0.conda
-  hash:
-    md5: 9cb0f7901c5279c48f1e3506c8d6cb94
-    sha256: 97722216c26379b2d9fe9ceed783074d6f84b2594ebc2fc0b0cad084ca50aa3d
+    md5: 8e4275fd4414d3f03cf5f19cb824bcd5
+    sha256: 93185f9494e4461c852ca4ad19059acc6b34e7ebbb28bd01a6d4fcc99d7dc26c
   category: main
   optional: false
 - name: eccodes
-  version: 2.34.1
+  version: 2.38.3
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     hdf5: '>=1.14.3,<1.14.4.0a0'
-    jasper: '>=4.2.1,<5.0a0'
-    libaec: '>=1.1.2,<2.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
+    jasper: '>=4.2.4,<5.0a0'
+    libaec: '>=1.1.3,<2.0a0'
+    libgcc: '>=13'
+    libgfortran: ''
+    libgfortran5: '>=13.3.0'
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.34.1-he84ddb8_0.conda
+    libpng: '>=1.6.44,<1.7.0a0'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.38.3-h8bb6dbc_1.conda
   hash:
-    md5: f12ca97c38833a5a179adc172155d15d
-    sha256: 964b3b53ca1c116fa0480912ec85fe182d8db6866607448b5b3ae73b0bf370e8
-  category: main
-  optional: false
-- name: eigen
-  version: 3.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
-  hash:
-    md5: b1b879d6d093f55dd40d58b5eb2f0699
-    sha256: 53b15a98aadbe0704479bacaf7a5618fcb32d1577be320630674574241639b34
+    md5: 73265d4acc551063cc5c5beab37f33c5
+    sha256: d1100e23310be460d5c8c8a67047af121e0b0295b97502173b213f2f0ba9f566
   category: main
   optional: false
 - name: elementpath
-  version: 4.4.0
+  version: 4.5.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/elementpath-4.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/elementpath-4.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 84cfa3bf4cc350b9f125569ac32a7fa8
-    sha256: 024cca8b594a655f6b312566506bc04393cba121d5a585c7d2c782c4c5d401f2
+    md5: 13a6a89b80473588d14cdba61773fc05
+    sha256: d6d1cd1c4024cd3df42ac956fdc9065c4889366f450ce4ccc290155dd7f16caa
   category: main
   optional: false
 - name: entrypoints
@@ -2520,105 +2705,105 @@ package:
   category: main
   optional: false
 - name: erddapy
-  version: 2.2.0
+  version: 2.2.3
   manager: conda
   platform: linux-64
   dependencies:
     httpx: ''
     pandas: <3,>=0.25.2
-    python: '>=3.8'
+    python: '>=3.10'
     pytz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/erddapy-2.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/erddapy-2.2.3-pyhd8ed1ab_0.conda
   hash:
-    md5: ff7354c3bb305f54715d719b99146977
-    sha256: 551059f05aeb9b18f0148da0d406e3a1c19e42aea6357356ec2228d193da146b
+    md5: 07d5c713a8d62836b91e6053b3fc1bf4
+    sha256: 47a585be11c73b0b92c45ee34bfb03e9eb43997b5012ab8a55f677f796f65287
   category: main
   optional: false
 - name: esmf
-  version: 8.6.0
+  version: 8.6.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
+    libgcc: '>=13'
+    libgfortran: ''
+    libgfortran5: '>=13.3.0'
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libstdcxx-ng: '>=12'
-    mpich: '>=4.1.2,<5.0a0'
+    libstdcxx: '>=13'
     netcdf-fortran: '>=4.6.1,<4.7.0a0'
-    parallelio: '>=2.6.2,<2.6.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.6.0-mpi_mpich_hadf67bb_100.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.6.1-nompi_h4441c20_3.conda
   hash:
-    md5: 86ff17ba25cee0ea30b85b1826b4715f
-    sha256: 97886a9725253bb23fbb352389bd18018014b7d7ea9d703b71d37e0ccea865bf
+    md5: 1afc1e85414e228916732df2b8c5d93b
+    sha256: 2e007ba0d94cb0a9e88306b346527e1233681833cfad13010ce653edda7cfeb1
   category: main
   optional: false
 - name: esmpy
-  version: 8.6.0
+  version: 8.6.1
   manager: conda
   platform: linux-64
   dependencies:
-    esmf: 8.6.0.*
+    esmf: 8.6.1.*
     numpy: ''
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/esmpy-8.6.0-pyhc1e730c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/esmpy-8.6.1-pyhc1e730c_0.conda
   hash:
-    md5: 60404b48ef1ccfb92cfd055f8844b700
-    sha256: ce78ee804eae7a574075b3c3f0fece7ac3a80b4876bca9ba75cf7d483c100cd3
+    md5: 25a9661177fd68bfdb4314fd658e5c3b
+    sha256: 692d823ce05ff60cd9648a6f98b778a9944f79ecd0aaa20110fa368340ec4982
   category: main
   optional: false
 - name: exceptiongroup
-  version: 1.2.0
+  version: 1.2.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
+    md5: d02ae936e42063ca46af6cdad2dbd1e0
+    sha256: e0edd30c4b7144406bb4da975e6bb97d6bc9c0e999aa4efe66ae108cada5d5b5
   category: main
   optional: false
 - name: executing
-  version: 2.0.1
+  version: 2.1.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
-  category: main
-  optional: false
-- name: expat
-  version: 2.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libexpat: 2.6.2
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
-  hash:
-    md5: 53fb86322bdb89496d7579fe3f02fd61
-    sha256: 89916c536ae5b85bb8bf0cfa27d751e274ea0911f04e4a928744735c14ef5155
+    md5: d0441db20c827c11721889a241df1220
+    sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
   category: main
   optional: false
 - name: fastapi
-  version: 0.106.0
+  version: 0.103.0
   manager: conda
   platform: linux-64
   dependencies:
-    anyio: '>=3.7.1,<4.0.0'
     pydantic: '>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0'
-    python: '>=3.8'
+    python: '>=3.7'
     starlette: '>=0.27.0,<0.28.0'
-    typing-extensions: '>=4.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.106.0-pyhd8ed1ab_0.conda
+    typing-extensions: '>=4.5.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.103.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 251ee219b0c895fa7d0ccc869144ed28
-    sha256: 94882c40453dc57b9eb3ba1384cdd8fddd10bf2de541b431fd9d7f9d7e9435d0
+    md5: c1db008f2554adcb1883d1e58c33529f
+    sha256: 657b7781ad340519ce6b5817c3c6cd62ac094363776095a62d131b0bb3ae39a5
+  category: main
+  optional: false
+- name: fastavro
+  version: 1.9.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/fastavro-1.9.7-py311h9ecbd09_3.conda
+  hash:
+    md5: c069c71321b9825b4554a4c78f199ecb
+    sha256: f8f6723c49c7f37a446af9badc2e6b80ed81f9b84d9a81422da58d04f5628323
   category: main
   optional: false
 - name: fasteners
@@ -2646,6 +2831,26 @@ package:
     sha256: 6f423bb9049ea2ad9ddf04815b4b82e9b87569670a86cbda44cf9c9dc91219f2
   category: main
   optional: false
+- name: fastparquet
+  version: 2024.5.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cramjam: '>=2.3'
+    fsspec: ''
+    libgcc: '>=13'
+    numpy: '>=1.20.3'
+    packaging: ''
+    pandas: '>=1.5.0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/fastparquet-2024.5.0-py311h9f3472d_2.conda
+  hash:
+    md5: de60889fdf79370f423c621f3427efb4
+    sha256: 579056abb96527b5811f074cdcf0b4964de78ea6cceb2b023163c8f3b1e03a25
+  category: main
+  optional: false
 - name: fastprogress
   version: 1.0.3
   manager: conda
@@ -2659,62 +2864,68 @@ package:
   category: main
   optional: false
 - name: ffmpeg
-  version: 6.1.1
+  version: 7.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    aom: '>=3.8.1,<3.9.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    aom: '>=3.9.1,<3.10.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     dav1d: '>=1.2.1,<1.2.2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     gmp: '>=6.3.0,<7.0a0'
-    gnutls: '>=3.7.9,<3.8.0a0'
-    harfbuzz: '>=8.3.0,<9.0a0'
+    harfbuzz: '>=9.0.0,<10.0a0'
     lame: '>=3.100,<3.101.0a0'
-    libass: '>=0.17.1,<0.17.2.0a0'
+    libass: '>=0.17.3,<0.17.4.0a0'
+    libexpat: '>=2.6.3,<3.0a0'
+    libgcc: '>=13'
     libiconv: '>=1.17,<2.0a0'
-    libopenvino: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-auto-batch-plugin: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-auto-plugin: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-hetero-plugin: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-intel-cpu-plugin: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-intel-gpu-plugin: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-ir-frontend: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-onnx-frontend: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-paddle-frontend: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-pytorch-frontend: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-tensorflow-frontend: '>=2024.0.0,<2024.0.1.0a0'
-    libopenvino-tensorflow-lite-frontend: '>=2024.0.0,<2024.0.1.0a0'
+    libopenvino: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-auto-batch-plugin: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-auto-plugin: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-hetero-plugin: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-intel-cpu-plugin: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-intel-gpu-plugin: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-intel-npu-plugin: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-ir-frontend: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-onnx-frontend: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-paddle-frontend: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-pytorch-frontend: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-tensorflow-frontend: '>=2024.4.0,<2024.4.1.0a0'
+    libopenvino-tensorflow-lite-frontend: '>=2024.4.0,<2024.4.1.0a0'
     libopus: '>=1.3.1,<2.0a0'
-    libva: '>=2.20.0,<3.0a0'
-    libvpx: '>=1.14.0,<1.15.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    libxml2: '>=2.12.5,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    librsvg: '>=2.58.4,<3.0a0'
+    libstdcxx: '>=13'
+    libva: '>=2.22.0,<3.0a0'
+    libvpx: '>=1.14.1,<1.15.0a0'
+    libxcb: '>=1.17.0,<2.0a0'
+    libxml2: '>=2.13.4,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     openh264: '>=2.4.1,<2.4.2.0a0'
-    svt-av1: '>=1.8.0,<1.8.1.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+    svt-av1: '>=2.3.0,<2.3.1.0a0'
     x264: '>=1!164.3095,<1!165'
     x265: '>=3.5,<3.6.0a0'
-    xorg-libx11: '>=1.8.7,<2.0a0'
+    xorg-libx11: '>=1.8.10,<2.0a0'
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.1-gpl_h38e077a_106.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_hbb807a5_703.conda
   hash:
-    md5: 23fe0f8b47e7b5527bcc1dfb6087dba6
-    sha256: 394dbcac10a6d65c8dae456bc4a2a2717005f598f86a423fe11235392a9d00ea
+    md5: ebcb1e523d36a81af8f0910856c06946
+    sha256: b3c25c9eeee63f39ebff7dc1840734aab3e784a084a8352d5099aa9a9c07e42f
   category: main
   optional: false
 - name: filelock
-  version: 3.13.3
+  version: 3.16.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_0.conda
   hash:
-    md5: ff15f46b0d34308f4d40c1c51df07592
-    sha256: 3bb2b4b8b97160ee7d2ed40b9dbc78555932274e82ef314c8a400a1d17aa4626
+    md5: 916f8ec5dd4128cd5f207a3c4c07b2c6
+    sha256: 1da766da9dba05091af87977922fe60dc7464091a9ccffb3765d403189d39be4
   category: main
   optional: false
 - name: findlibs
@@ -2730,32 +2941,58 @@ package:
   category: main
   optional: false
 - name: fiona
-  version: 1.9.6
+  version: 1.10.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     attrs: '>=19.2.0'
-    certifi: ''
     click: '>=8.0,<9.dev0'
     click-plugins: '>=1.0'
     cligj: '>=0.5'
     gdal: ''
-    libgcc-ng: '>=12'
-    libgdal: '>=3.8.4,<3.9.0a0'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    libgcc: '>=13'
+    libgdal: '>=3.9.2,<3.10.0a0'
+    libgdal-core: '>=3.9.2,<3.10.0a0'
+    libstdcxx: '>=13'
+    pyparsing: ''
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     shapely: ''
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.9.6-py310h0a1e91f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.10.1-py311h35c0331_1.conda
   hash:
-    md5: 2c6c0c252c2363034d9d1019429c21c0
-    sha256: e9bd24134bd4b0cd1822517006da11f51a889e32d683b975fcba8dde6973a51d
+    md5: 397b8ffbf59397157d3f55e84b4a7e19
+    sha256: cdda9988ed6f7e79648f0aaf8d98b32153a064f98e8efe6cb08de8191d5afca9
+  category: main
+  optional: false
+- name: flexcache
+  version: '0.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6ed8dc449e0da09c5aaa4e71eb91059a
+    sha256: 482edded5645290f1acd844dd05e5d51427f5ca8ada0b7a08cf0b6c7c7f1ce6b
+  category: main
+  optional: false
+- name: flexparser
+  version: 0.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 41ccc584228bb4c185cd0c92c5712741
+    sha256: b9b22b2018491c422abd7e274aebbd1e3a967def87f1f5110ec7e1512d299bc8
   category: main
   optional: false
 - name: flox
-  version: 0.9.6
+  version: 0.9.12
   manager: conda
   platform: linux-64
   dependencies:
@@ -2763,43 +3000,44 @@ package:
     numpy_groupies: '>=0.9.19'
     packaging: '>=21.3'
     pandas: '>=1.5'
-    python: '>=3.9'
+    python: '>=3.10'
     scipy: '>=1.9'
     toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/flox-0.9.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/flox-0.9.12-pyhd8ed1ab_0.conda
   hash:
-    md5: 5d72bc60a144513a5390201a6e8c7ba2
-    sha256: 3b4ad33aa7f171dfcd734c0bd2ffed260ffb2f9611eea1240fccebee8946cee9
+    md5: d1d00fd23d8f38389fce355ef049639a
+    sha256: ecbef23e1f4eceadf290a7ff3a0dd0125035477a7a0191a10875ef6d13dff463
   category: main
   optional: false
 - name: fmt
-  version: 10.2.1
+  version: 11.0.2
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fmt-10.2.1-h00ab1b0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h434a139_0.conda
   hash:
-    md5: 35ef8bc24bd34074ebae3c943d551728
-    sha256: 7b9ba098a3661e023c3555e01554354ac4891af8f8998e85f0fcbfdac79fc0d4
+    md5: 995f7e13598497691c1dc476d889bc04
+    sha256: c620e2ab084948985ae9b8848d841f603e8055655513340e04b6cf129099b5ca
   category: main
   optional: false
 - name: folium
-  version: 0.16.0
+  version: 0.18.0
   manager: conda
   platform: linux-64
   dependencies:
     branca: '>=0.6.0'
     jinja2: '>=2.9'
     numpy: ''
-    python: '>=3.7'
+    python: '>=3.8'
     requests: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.18.0-pyhd8ed1ab_0.conda
   hash:
-    md5: cb1d2aa705a5b1f0fbdabd1beebce205
-    sha256: 9696ffafd873a40815312e9ea245a863b7796b73dd2759f93174cd65d6bf2144
+    md5: 26a1457f3e698dc0c9e656874cc6b623
+    sha256: b0692047888db2875cbdb3280aec69e9d88c229adf830c4f88357796d35ce006
   category: main
   optional: false
 - name: font-ttf-dejavu-sans-mono
@@ -2840,26 +3078,27 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
   hash:
-    md5: 6185f640c43843e5ad6fd1c5372c3f80
-    sha256: 056c85b482d58faab5fd4670b6c1f5df0986314cca3bc831d458b22e4ef2c792
+    md5: 49023d73832ef61042f6a237cb2687e7
+    sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
   category: main
   optional: false
 - name: fontconfig
-  version: 2.14.2
+  version: 2.15.0
   manager: conda
   platform: linux-64
   dependencies:
-    expat: '>=2.5.0,<3.0a0'
+    __glibc: '>=2.17,<3.0.a0'
     freetype: '>=2.12.1,<3.0a0'
-    libgcc-ng: '>=12'
-    libuuid: '>=2.32.1,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+    libexpat: '>=2.6.3,<3.0a0'
+    libgcc: '>=13'
+    libuuid: '>=2.38.1,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
   hash:
-    md5: 0f69b688f52ff6da70bccb7ff7001d1d
-    sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
+    md5: 8f5b0b297b59e1ac160ad4beec99dbee
+    sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
   category: main
   optional: false
 - name: fonts-conda-ecosystem
@@ -2890,20 +3129,21 @@ package:
   category: main
   optional: false
 - name: fonttools
-  version: 4.50.0
+  version: 4.54.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     brotli: ''
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     munkres: ''
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    unicodedata2: '>=14.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.50.0-py310h2372a71_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    unicodedata2: '>=15.1.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.54.1-py311h2dc5d0c_1.conda
   hash:
-    md5: 85c48c98c9f2b72b384fb11c9004920b
-    sha256: 182fa59da123c0e23f61e5d37cc667c53ad49883243db26a4cfff64d0a9252c2
+    md5: 7336fc1b2ead4cbdda1268dd6b7a6c38
+    sha256: cdef0c6c6597a759b7db2c31eeab773c1097f053ab40f81f0919e2b2a2f56293
   category: main
   optional: false
 - name: fqdn
@@ -2926,16 +3166,16 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    xorg-libx11: '>=1.8.4,<2.0a0'
+    libxcb: '>=1.16,<2.0.0a0'
+    xorg-libx11: '>=1.8.9,<2.0a0'
     xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxext: '>=1.3.4,<2.0a0'
     xorg-libxfixes: ''
     xorg-libxi: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-hac7e632_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
   hash:
-    md5: 6e553df297f6e64668efb54302e0f139
-    sha256: 6dc7be5d0853ea5bcbb2b1921baf7d069605594c207e8ce36a662f447cd81a3f
+    md5: 84ec3f5b46f3076be49f2cf3f1cfbf02
+    sha256: 676540a8e7f73a894cb1fcb870e7bec623ec1c0a2d277094fd713261a02d8d56
   category: main
   optional: false
 - name: freetype
@@ -2945,7 +3185,7 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
   hash:
     md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
@@ -2980,29 +3220,30 @@ package:
   category: main
   optional: false
 - name: frozenlist
-  version: 1.4.1
+  version: 1.5.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py310h2372a71_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.5.0-py311h9ecbd09_0.conda
   hash:
-    md5: f20cd4d9c1f4a8377d0818c819918bbb
-    sha256: 496d0ae05e81be0bd8e046bc48a3346f867caaad65041aa14ee2f3717af70db6
+    md5: 75424a18fb275a18b288c099b869c3bc
+    sha256: 5bde4e41dd1bdf42488f1b86039f38914e87f4a6b46c15224c217651f964de8b
   category: main
   optional: false
 - name: fsspec
-  version: 2024.3.1
+  version: 2024.10.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.3.1-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
   hash:
-    md5: b7f0662ef2c9d4404f0af9eef5ed2fde
-    sha256: b8621151939bb5ea4ea4aa84f010e6130a47b1453cd9178283f335816b72a895
+    md5: 816dbc4679a64e4417cd1385d661bb31
+    sha256: 40bb76981dd49d5869b48925a8975bb7bbe4e33e1e40af4ec06f6bf4a62effd7
   category: main
   optional: false
 - name: future
@@ -3018,105 +3259,106 @@ package:
   category: main
   optional: false
 - name: gcc
-  version: 12.3.0
+  version: 13.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    gcc_impl_linux-64: 12.3.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h95e488c_3.conda
+    gcc_impl_linux-64: 13.3.0.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_1.conda
   hash:
-    md5: 413e326f8a01d041ffbfbb51cea46a93
-    sha256: 60669bb79c79d6f6929c67b334acd9dc885dccfb7371e41de7626090dc06e408
+    md5: 606924335b5bcdf90e9aed9a2f5d22ed
+    sha256: d0161362430183cbdbc3db9cf95f9a1af1793027f3ab8755b3d3586deb28bf84
   category: main
   optional: false
 - name: gcc_impl_linux-64
-  version: 12.3.0
+  version: 13.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    binutils_impl_linux-64: '>=2.39'
-    libgcc-devel_linux-64: 12.3.0
-    libgcc-ng: '>=12.3.0'
-    libgomp: '>=12.3.0'
-    libsanitizer: 12.3.0
-    libstdcxx-ng: '>=12.3.0'
+    binutils_impl_linux-64: '>=2.40'
+    libgcc: '>=13.3.0'
+    libgcc-devel_linux-64: 13.3.0
+    libgomp: '>=13.3.0'
+    libsanitizer: 13.3.0
+    libstdcxx: '>=13.3.0'
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-hfea6d02_1.conda
   hash:
-    md5: e89827619e73df59496c708b94f6f3d5
-    sha256: a87826c55e6aa2ed5d17f267e6a583f7951658afaa4bf45cd5ba97f5583608b9
+    md5: 0d043dbc126b64f79d915a0e96d3a1d5
+    sha256: 998ade1d487e93fc8a7a16b90e2af69ebb227355bf4646488661f7ae5887873c
   category: main
   optional: false
 - name: gcc_linux-64
-  version: 12.3.0
+  version: 13.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    binutils_linux-64: '2.40'
-    gcc_impl_linux-64: 12.3.0.*
+    binutils_linux-64: ''
+    gcc_impl_linux-64: 13.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h6477408_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-hc28eda2_5.conda
   hash:
-    md5: 7a53f84c45bdf4656ba27b9e9ed68b3d
-    sha256: 836692c3d4948f25a19f9071db40f7788edcb342d771786a206a6a122f92365d
+    md5: ffbadbbc3345d9a315ba31c8a9188d4c
+    sha256: 6778f93159cfd967320f60473447b19e320f303378d4c9da0784caa40073fafa
   category: main
   optional: false
 - name: gcsfs
-  version: 2024.3.1
+  version: 2024.10.0
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: ''
     decorator: '>4.1.2'
-    fsspec: 2024.3.1
+    fsspec: 2024.10.0
     google-auth: '>=1.2'
     google-auth-oauthlib: ''
     google-cloud-storage: '>1.40'
     python: '>=3.7'
     requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/gcsfs-2024.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gcsfs-2024.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2a794cb30f494b38dd57ece3af30ed6a
-    sha256: 3db31215462e399848d49c5258ce03f6c3e72e7c20fb488ad0b1ebbe6a359607
+    md5: 955421eb32ce3fbeed9a83b20ecc76d3
+    sha256: 1a42711efffe728eb2f462a1c08dd749c86d91255fc7b993fdae420e4e2e2036
   category: main
   optional: false
 - name: gdal
-  version: 3.8.4
+  version: 3.9.2
   manager: conda
   platform: linux-64
   dependencies:
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc-ng: '>=12'
-    libgdal: 3.8.4
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.6,<3.0a0'
-    numpy: '>=1.22.4,<2.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.8.4-py310he073c5f_5.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgdal-core: 3.9.2.*
+    libkml: '>=1.3.0,<1.4.0a0'
+    libstdcxx: '>=13'
+    libxml2: '>=2.12.7,<3.0a0'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.2-py311h5159542_7.conda
   hash:
-    md5: 5ddb766a316116abbf5011be870c488f
-    sha256: d9974fcc07222737c7460ee30de2c63f1395a288db4db571a726be3e94922740
+    md5: 4c0e5ccdde2f0d2bf65547287f018865
+    sha256: 935b15f700644105b23d78ad28a6d81be00bca37b76252b85d6c5b0e33dbb07c
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.42.10
+  version: 2.42.12
   manager: conda
   platform: linux-64
   dependencies:
-    libglib: '>=2.78.4,<3.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.80.2,<3.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.10-h829c605_5.conda
+    libtiff: '>=4.6.0,<4.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
   hash:
-    md5: 8fdb82e5d9694dd8e9ed9ac8fdf48a26
-    sha256: bacd1cc3ed77699dec11ea5a670160db3cf701f1b19f34f1a19be36cae25c396
+    md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
+    sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
   category: main
   optional: false
 - name: gdown
-  version: 5.1.0
+  version: 5.2.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3125,34 +3367,34 @@ package:
     python: '>=3.8'
     requests: ''
     tqdm: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/gdown-5.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gdown-5.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6f880647c0270648f710f334c60bc76c
-    sha256: 1ab1e5cf5c851f91abebfc6a6c094bc6e2afa3639e6586f6ff890acc8551a63d
+    md5: 29903392720ea0d6162b772ff97235c3
+    sha256: 5a645ec883846558db8b6c3ea370602a7b2783e8c9d1c9b59f385a7f43f8f26c
   category: main
   optional: false
 - name: geoalchemy2
-  version: 0.14.7
+  version: 0.15.2
   manager: conda
   platform: linux-64
   dependencies:
     packaging: ''
     python: '>=3.7'
     sqlalchemy: '>=1.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/geoalchemy2-0.14.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geoalchemy2-0.15.2-pyhd8ed1ab_0.conda
   hash:
-    md5: cd8dc1a33d01206386edaee118d02d6e
-    sha256: 1bb827474d43d6d9e17d178272d9a1156a4bc159921e4a79c4179fe893e7152f
+    md5: f0c41912cf8fef3dac8bfa6096b6ade0
+    sha256: 5b0b1230635ee2238d9897d23b2c8667b41cad8bf55e96acab24614c65c0928a
   category: main
   optional: false
 - name: geocube
-  version: 0.5.1
+  version: 0.7.0
   manager: conda
   platform: linux-64
   dependencies:
     appdirs: ''
     click: '>=6.0'
-    geopandas: '>=0.7'
+    geopandas: '>=1'
     numpy: '>=1.20'
     odc-geo: ''
     pyproj: '>=2'
@@ -3161,28 +3403,28 @@ package:
     rioxarray: '>=0.4'
     scipy: ''
     xarray: '>=0.17'
-  url: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geocube-0.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2caf80e079028b28c0d6cd0685f67059
-    sha256: cfbd1da7368e59f7635568da3cdbc641f3b47c6265da365848b41318f782babf
+    md5: 8887c687ee10662fbf1b22fc5b7e7dba
+    sha256: 88ac10e11363ecf99561ef4ff9260983b348a8845431aec125f14df0d174e96c
   category: main
   optional: false
 - name: geogif
-  version: 0.1.5
+  version: '0.2'
   manager: conda
   platform: linux-64
   dependencies:
     dask-core: '>=2021.4.1'
     matplotlib-base: '>=3.4.1,<4.0.0'
     numpy: '>=1.20.2,<2.0.0'
-    pillow: '>=10.0.0,<11.0.0'
+    pillow: '>=10.1.0,<11.0.0'
     python: '>=3.8.0,<4.0.0'
     typing_extensions: ''
     xarray: '>=0.18'
-  url: https://conda.anaconda.org/conda-forge/noarch/geogif-0.1.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geogif-0.2-pyhd8ed1ab_0.conda
   hash:
-    md5: c93faea5968947b3c18518355e11b5f5
-    sha256: 1cf76efeb6c385d9f56f0fdbaa81ce5b1207b67e5f1f080591c2429224bdb459
+    md5: 02b01f1e7aba0b1aaa1fe1fb2f9e9af0
+    sha256: 2da085947ad1c27ada14ae5fc2768ed4265552cd7e5f8a4600a8e37988fd22fd
   category: main
   optional: false
 - name: geographiclib
@@ -3210,38 +3452,38 @@ package:
   category: main
   optional: false
 - name: geopandas
-  version: 0.14.3
+  version: 1.0.1
   manager: conda
   platform: linux-64
   dependencies:
-    fiona: '>=1.8.21'
     folium: ''
-    geopandas-base: 0.14.3
+    geopandas-base: 1.0.1
     mapclassify: '>=2.4.0'
     matplotlib-base: ''
+    pyogrio: '>=0.7.2'
+    pyproj: '>=3.3.0'
     python: '>=3.9'
-    rtree: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_1.conda
   hash:
-    md5: d8e208e375441bf1404e9693f13f3c25
-    sha256: 15bdc3d85ffa9c6601f57dd5e2780dbcbe52ca5da70164fb5bb1bb4c72b92010
+    md5: 79a9a8d2fd39ecb4081c0df0c10135dc
+    sha256: ea0e200967b93a1342670bee137917e93d04742f3c3c626fe435ebb29462bbd7
   category: main
   optional: false
 - name: geopandas-base
-  version: 0.14.3
+  version: 1.0.1
   manager: conda
   platform: linux-64
   dependencies:
+    numpy: '>=1.22'
     packaging: ''
     pandas: '>=1.4.0'
-    pyproj: '>=3.3.0'
     python: '>=3.9'
-    shapely: '>=1.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
+    shapely: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
   hash:
-    md5: fbac4b2194c962b97324a3f5dd7d2696
-    sha256: 0a8fb5a368d19fd08f7f65dfcff563322cb34e47947cabab8fc7f187d9bc9269
+    md5: cad8d8e1583463e7642adc72a76dc3c5
+    sha256: 1b0853491a299e95d57ccf3f3c9053a1b7e49fc9b2ad959f321b0717e567e249
   category: main
   optional: false
 - name: geopy
@@ -3258,63 +3500,58 @@ package:
   category: main
   optional: false
 - name: geos
-  version: 3.12.1
+  version: 3.13.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.1-h59595ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
   hash:
-    md5: 8c0f4f71f5a59ceb0c6fa9f51501066d
-    sha256: 2593b255cb9c4639d6ea261c47aaed1380216a366546f0468e95c36c2afd1c1a
+    md5: 40b4ab956c90390e407bb177f8a58bab
+    sha256: 5c70d6d16e044859edca85feb9d4f1c3c6062aaf88d650826f5ccdf8c44336de
   category: main
   optional: false
 - name: geotiff
-  version: 1.7.1
+  version: 1.7.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    proj: '>=9.3.1,<9.3.2.0a0'
+    libstdcxx: '>=13'
+    libtiff: '>=4.6.0,<4.8.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    proj: '>=9.5.0,<9.6.0a0'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.1-h6b2125f_15.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
   hash:
-    md5: 218a726155bd9ae1787b26054eed8566
-    sha256: f7dcc865f5522713048397702490ba917abf9d2fbfe89d6b703e0ea333a27b01
+    md5: 4eb52aecb43e7c72f8e4fca0c386354e
+    sha256: 94c7d002c70a4802a78ac2925ad6b36327cff85e0af6af2825b11a968c81ec20
   category: main
   optional: false
 - name: geoviews-core
-  version: 1.8.2
+  version: 1.13.0
   manager: conda
   platform: linux-64
   dependencies:
-    bokeh: '>=2.1.0'
-    cartopy: '>=0.17.0'
-    holoviews: '>=1.13.0'
+    bokeh: '>=3.5.0,<3.6.0'
+    cartopy: '>=0.18.0'
+    holoviews: '>=1.16.0'
     numpy: '>=1.0'
+    packaging: ''
+    panel: '>=1.0.0'
     param: '>=1.9.3'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.8.2-py_0.tar.bz2
+    pyproj: ''
+    python: '>=3.10'
+    shapely: ''
+    xyzservices: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.0-pyha770c72_0.conda
   hash:
-    md5: 63dd61f554577d1ecc7687b0e073a8b4
-    sha256: 26d2fd340b1b3c37c251e2150733c87ca3e1548e34280719eceb79d8df05a873
-  category: main
-  optional: false
-- name: gettext
-  version: 0.21.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
-  hash:
-    md5: 14947d8770185e5153fdd04d4673ed37
-    sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
+    md5: e59925a00efb42c08cf0fef58f779bb4
+    sha256: a2453b6df701d38c5d141247946e0d21814fa1f056c6e85aa4003ede2f20d82e
   category: main
   optional: false
 - name: gflags
@@ -3322,24 +3559,25 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    libstdcxx-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
   hash:
-    md5: cddaf2c63ea4a5901cf09524c490ecdc
-    sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
+    md5: d411fc29e338efb48c5fd4576d71d881
+    sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
   category: main
   optional: false
 - name: giflib
-  version: 5.2.1
+  version: 5.2.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.1-h0b41bf4_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
   hash:
-    md5: 96f3b11872ef6fad973eac856cd2624f
-    sha256: 41ec165704ccce2faa0437f4f53c03c06261a2cc9ff7614828e51427d9261f4b
+    md5: 3bf7b9fd5a7136126e0234db4b87c8b6
+    sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
   category: main
   optional: false
 - name: gitdb
@@ -3370,17 +3608,17 @@ package:
   category: main
   optional: false
 - name: glog
-  version: 0.7.0
+  version: 0.7.1
   manager: conda
   platform: linux-64
   dependencies:
     gflags: '>=2.2.2,<2.3.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.0-hed5481d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
   hash:
-    md5: a9ea19c48e11754899299f8123070f4e
-    sha256: 19f41db8f189ed9caec68ffb9ec97d5518b5ee6b58e0636d185f392f688a84a1
+    md5: ff862eebdfeb2fd048ae9dc92510baca
+    sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
   category: main
   optional: false
 - name: gmp
@@ -3390,48 +3628,31 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
   hash:
-    md5: e358c7c5f6824c272b5034b3816438a7
-    sha256: cfc4202c23d6895d9c84042d08d5cda47d597772df870d4d2a10fc86dded5576
-  category: main
-  optional: false
-- name: gnutls
-  version: 3.7.9
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libidn2: '>=2,<3.0a0'
-    libstdcxx-ng: '>=12'
-    libtasn1: '>=4.19.0,<5.0a0'
-    nettle: '>=3.9.1,<3.10.0a0'
-    p11-kit: '>=0.24.1,<0.25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
-  hash:
-    md5: 33eded89024f21659b1975886a4acf70
-    sha256: 52d824a5d2b8a5566cd469cae6ad6920469b5a15b3e0ddc609dd29151be71be2
+    md5: c94a5994ef49749880a8139cf9afcbe1
+    sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
   category: main
   optional: false
 - name: google-api-core
-  version: 2.18.0
+  version: 2.22.0
   manager: conda
   platform: linux-64
   dependencies:
     google-auth: '>=2.14.1,<3.0.dev0'
     googleapis-common-protos: '>=1.56.2,<2.0.dev0'
-    proto-plus: '>=1.22.3,<2.0.0dev'
-    protobuf: '>=3.19.5,<5.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    proto-plus: '>=1.25.0,<2.0.0dev'
+    protobuf: '>=3.19.5,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
     python: '>=3.7'
     requests: '>=2.18.0,<3.0.0.dev0'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.18.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.22.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 58d10fd3977fa2142cc64c5d9c7a9d20
-    sha256: 29ea75a93c596466ebc3954ac05e1c3298bf9d95296bc4769fdc95c71e53a19e
+    md5: 43ac2eb76299f388c89a360e9a23fb5a
+    sha256: 0fb95fb51d25645d412150f25fb37e2cb6aac5d9fcedf6a2750cbe40ff816ef8
   category: main
   optional: false
 - name: google-auth
-  version: 2.29.0
+  version: 2.35.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3444,14 +3665,14 @@ package:
     pyu2f: '>=0.1.5'
     requests: '>=2.20.0,<3.0.0'
     rsa: '>=3.1.4,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.29.0-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.35.0-pyhff2d567_0.conda
   hash:
-    md5: a12a2abc807053bc378b218a2a525c7d
-    sha256: 1eaa741eba0a6d34c80f68438cb8283b2d9d2adf8629d024df14222c0fc0b397
+    md5: 7a6b4c81d9062a9e92b9ef0548aebc06
+    sha256: 62533066d372fd2f5bb9f38e8a44465f404a116210703ec75b88d34c28cc4caa
   category: main
   optional: false
 - name: google-auth-oauthlib
-  version: 1.2.0
+  version: 1.2.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -3459,10 +3680,10 @@ package:
     google-auth: '>=2.15.0'
     python: '>=3.6'
     requests-oauthlib: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 2057f12885a73b4d621c075423cec969
-    sha256: 39d031780d9ac2da430ead078a40ff67db3ad57e24ab1e3c68b4e0f2b48a2311
+    md5: b252850143cd2080d87060f891d3b288
+    sha256: 2eadaa93ef72136b872ee2d4775f0bc193e411a1b46b7af4e25805aed7f2e1e8
   category: main
   optional: false
 - name: google-cloud-core
@@ -3481,7 +3702,7 @@ package:
   category: main
   optional: false
 - name: google-cloud-storage
-  version: 2.16.0
+  version: 2.18.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -3489,14 +3710,14 @@ package:
     google-auth: '>=2.26.1,<3.0dev'
     google-cloud-core: '>=2.3.0,<3.0dev'
     google-crc32c: '>=1.0,<2.0dev'
-    google-resumable-media: '>=2.6.0'
-    protobuf: <5.0.0dev
+    google-resumable-media: '>=2.7.2'
+    protobuf: <6.0.0dev
     python: '>=3.7'
     requests: '>=2.18.0,<3.0.0dev'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-2.16.0-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-2.18.2-pyhff2d567_0.conda
   hash:
-    md5: a465dd6977e00f7fd955f03e787a745b
-    sha256: 7c196842cb591516d10af4f90fbf046085f459a326b9cf0e3946f5ec8cae2fbd
+    md5: 75a712b2dad63711cbc1133232b469ae
+    sha256: cfb493c7771a82ea57ad66a2e8589eee45c21480dafe0613012ef7834eb60f02
   category: main
   optional: false
 - name: google-crc32c
@@ -3504,41 +3725,43 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cffi: '>=1.0.0'
     libcrc32c: '>=1.1.2,<1.2.0a0'
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.1.2-py310hc5c09a0_5.conda
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.1.2-py311h0973507_6.conda
   hash:
-    md5: 51be1aa46205e84e9b339ee511583243
-    sha256: 9b7cc732e10b0a9d82a932005a2c2f951df63fe34ee19f79c1734a6b4b7b2327
+    md5: f13523958e139aad5e6081a2ac00231b
+    sha256: c79efe917b0c753130fb240f6592bdd927e3d65767cca544151d2128b1d3bfcd
   category: main
   optional: false
 - name: google-resumable-media
-  version: 2.7.0
+  version: 2.7.2
   manager: conda
   platform: linux-64
   dependencies:
-    google-crc32c: '>=1.0,<2.0.0dev'
+    google-crc32c: '>=1.0,<2.0dev'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-resumable-media-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-resumable-media-2.7.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 28d1e160d8b2e405b16bb40773135225
-    sha256: b7f08e89a491cfaa904328b96c1700da18d2cc33affefc2d15077e03ad4ec8bf
+    md5: 357cb6c361778650356349769e4c834b
+    sha256: 2ff33f5e48df03d86c2ca839afc3168b641106fa57603f7b39431524a595b661
   category: main
   optional: false
 - name: googleapis-common-protos
-  version: 1.63.0
+  version: 1.65.0
   manager: conda
   platform: linux-64
   dependencies:
-    protobuf: '>=3.19.5,<5.0.0dev0,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    protobuf: '>=3.20.2,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.63.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.65.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 058e77f4f0285aa4945c5539de931ff0
-    sha256: 41d3eea46623836e2be7234bdbfc0e7a42fc0853229c687cea6d7b652bb4a4fa
+    md5: f5bdd5dd4ad1fd075a6f25670bdda1b6
+    sha256: 093e899196b6bedb761c707677a3bc7161a04371084eb26f489327e8aa8d6f25
   category: main
   optional: false
 - name: graphite2
@@ -3555,89 +3778,91 @@ package:
   category: main
   optional: false
 - name: graphviz
-  version: 9.0.0
+  version: 12.0.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.0,<2.0a0'
     fonts-conda-ecosystem: ''
-    gdk-pixbuf: '>=2.42.10,<3.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
     gtk2: ''
     gts: '>=0.7.6,<0.8.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
+    libexpat: '>=2.6.2,<3.0a0'
     libgcc-ng: '>=12'
     libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.78.1,<3.0a0'
-    librsvg: '>=2.56.3,<3.0a0'
+    libglib: '>=2.80.3,<3.0a0'
+    librsvg: '>=2.58.2,<3.0a0'
     libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphviz-9.0.0-h78e8752_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.0.0-hba01fac_0.conda
   hash:
-    md5: a3f4cd4a512ec5db35ffbf25ba11f537
-    sha256: 1813800d655c120a3941d543a6fc64e3c178c737f1c84f6b7ebe1f19f27fa4fb
+    md5: 953e31ea00d46beb7e64a79fc291ec44
+    sha256: 2eb794ae1de42b688f89811113ae3dcb63698272ee8f87029abce5f77c742c2a
   category: main
   optional: false
 - name: greenlet
-  version: 3.0.3
+  version: 3.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.0.3-py310hc6cd4ac_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.1.1-py311hfdbb021_0.conda
   hash:
-    md5: fb478fd83c001cbf8ab01c29b857262e
-    sha256: 18a3ed470b6c4bf4ee5dea3ce134a36f4eda9dafa172acc3799d7465727d57f5
+    md5: 7cfbc8bdc38951bee4f8e74a08cc0af3
+    sha256: 00d5ecec1b7898f209d2e3459a2acb02393a75fa8030025b553bf75c27397324
   category: main
   optional: false
 - name: griffe
-  version: 0.42.1
+  version: 1.5.1
   manager: conda
   platform: linux-64
   dependencies:
-    astunparse: '>=1.6'
     colorama: '>=0.4'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.42.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/griffe-1.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c6adb089706beaef0673bc32953913e8
-    sha256: cdb9afdb4eb66b6c43c6f34ed14da4a4d8686e51f3fafc23e2846e4a166ce700
+    md5: 87db2aa0738c4acc5f565388d519fb25
+    sha256: 591bf3247a0872b76e2cf57cbdb71762913568390f5a745fe0f3f779a16459a9
   category: main
   optional: false
 - name: grpcio
-  version: 1.62.1
+  version: 1.62.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libgrpc: 1.62.1
+    libgrpc: 1.62.2
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.62.1-py310h1b8f574_0.conda
+    libzlib: '>=1.2.13,<2.0.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.62.2-py311ha6695c7_0.conda
   hash:
-    md5: 12d953659f34036237738a4e104b7da5
-    sha256: 4e149efa7471186c232f6f066ce744ee3d1a2c2023cd3a7307dc49d34c5450e0
+    md5: 5256f630309144ad1a6e4ec1736f5d66
+    sha256: 1cd5f900102255e33f9cae37b9b79b210cb92f46922fefff09bd70c4ca5159ab
   category: main
   optional: false
 - name: gsw
-  version: 3.6.17
+  version: 3.6.19
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gsw-3.6.17-py310h1f7b6fc_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/gsw-3.6.19-py311h9f3472d_1.conda
   hash:
-    md5: 16efb4c45350266da69f1658d4f39569
-    sha256: f9ebbd10233d0749a763d2a1cf670d94ebf219bbf1557e19a5c4799aa5671471
+    md5: a86c00b576419e61805446e071192a68
+    sha256: 402f827446c4192185ace176ba80ef41db52a06cfe9386ee7590e04e7760a199
   category: main
   optional: false
 - name: gtk2
@@ -3645,23 +3870,24 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     atk-1.0: '>=2.38.0'
     cairo: '>=1.18.0,<2.0a0'
     fontconfig: '>=2.14.2,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
-    gdk-pixbuf: '>=2.42.10,<3.0a0'
-    harfbuzz: '>=8.3.0,<9.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    harfbuzz: '>=9.0.0,<10.0a0'
     libgcc-ng: '>=12'
-    libglib: '>=2.78.4,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-    xorg-libx11: '>=1.8.7,<2.0a0'
+    libglib: '>=2.80.3,<3.0a0'
+    pango: '>=1.54.0,<2.0a0'
+    xorg-libx11: '>=1.8.9,<2.0a0'
     xorg-libxext: '>=1.3.4,<2.0a0'
     xorg-libxrender: '>=0.9.11,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h280cfa0_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h6470451_5.conda
   hash:
-    md5: 410f86e58e880dcc7b0e910a8e89c05c
-    sha256: b946ba60d177d72157cad8af51723f1d081a4794741d35debe53f8b2c807f3af
+    md5: 1483ba046164be27df7f6eddbcec3a12
+    sha256: 16644d036321b32635369c183502974c8b989fa516c313bd379f9aa4adcdf642
   category: main
   optional: false
 - name: gts
@@ -3706,52 +3932,54 @@ package:
   category: main
   optional: false
 - name: h5netcdf
-  version: 1.3.0
+  version: 1.4.0
   manager: conda
   platform: linux-64
   dependencies:
     h5py: ''
     packaging: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6890388078d9a3a20ef793c5ffb169ed
-    sha256: 0195b109e6b18d7efa06124d268fd5dd426f67e2feaee50a358211ba4a4b219b
+    md5: 09654b6e08a38977b2ccab5136673871
+    sha256: 313bcfe1d25da44d82c3ffa1d2d4addacab1e7ad12d9c21be63ad056398e9cc4
   category: main
   optional: false
 - name: h5py
-  version: 3.10.0
+  version: 3.12.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cached-property: ''
     hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.10.0-nompi_py310h65828d5_101.conda
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.12.1-nompi_py311hb639ac4_102.conda
   hash:
-    md5: 44c185c5b133ad6d1d449839407aa863
-    sha256: 42ca5cdf60ee7c1a246ecce0d42a180c03a3d6401dae9e484dbc55b93cd96429
+    md5: c2438b0f0016fbd7ea93e872c9b93309
+    sha256: a21932ada1e7a9f95433e4b29980316dac72428bedd738e1af73cb269ed36e2a
   category: main
   optional: false
 - name: harfbuzz
-  version: 8.3.0
+  version: 9.0.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.0,<2.0a0'
     freetype: '>=2.12.1,<3.0a0'
     graphite2: ''
-    icu: '>=73.2,<74.0a0'
+    icu: '>=75.1,<76.0a0'
     libgcc-ng: '>=12'
-    libglib: '>=2.78.1,<3.0a0'
+    libglib: '>=2.80.3,<3.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
   hash:
-    md5: 5a6f6c00ef982a9bc83558d9ac8f64a0
-    sha256: 4b55aea03b18a4084b750eee531ad978d4a3690f63019132c26c6ad26bbe3aed
+    md5: 76b32dcf243444aea9c6b804bcfa40b8
+    sha256: 973afa37840b4e55e2540018902255cfb0d953aaed6353bb83a4d120f5256767
   category: main
   optional: false
 - name: hdf4
@@ -3762,7 +3990,7 @@ package:
     libgcc-ng: '>=12'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
   hash:
     md5: bd77f8da987968ec3927990495dc22e4
@@ -3774,19 +4002,18 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libaec: '>=1.1.2,<2.0a0'
-    libcurl: '>=8.4.0,<9.0a0'
+    libaec: '>=1.1.3,<2.0a0'
+    libcurl: '>=8.8.0,<9.0a0'
     libgcc-ng: '>=12'
     libgfortran-ng: ''
     libgfortran5: '>=12.3.0'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    mpich: '>=4.1.2,<5.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-mpi_mpich_ha2c2bf8_0.conda
+    libzlib: '>=1.2.13,<2.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
   hash:
-    md5: 12662900b822f215d6f3d86a188824c9
-    sha256: 9b859e76679b852f565d1a48c85cba3861a414bd96b28abd4d8e335926180657
+    md5: 7e1729554e209627636a0f6fabcdd115
+    sha256: 2278fa07da6f96e807d402cd55480624d67d2dee202191aaaf278ce5ab23605a
   category: main
   optional: false
 - name: heapdict
@@ -3794,32 +4021,32 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-py_0.tar.bz2
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 77242bfb1e74a627fb06319b5a2d3b95
-    sha256: 37e5013a0bfbd5d446b06d125b2a9ba2de0e65a9195f0ef0aecd8d9da1355d17
+    md5: 6543d34623a84f005528d73adae8535a
+    sha256: 06128b641132ea40b479371f8b1334d006e171910414031e8690ffe030bdbb17
   category: main
   optional: false
 - name: holoviews
-  version: 1.18.3
+  version: 1.19.1
   manager: conda
   platform: linux-64
   dependencies:
     bokeh: '>=3.1'
     colorcet: ''
     matplotlib-base: '>=3.0'
-    numpy: '>=1.0'
+    numpy: '>=1.21'
     packaging: ''
-    pandas: '>=0.20.0'
+    pandas: '>=1.3'
     panel: '>=1.0'
-    param: '>=1.12.0,<3.0'
+    param: '>=2.0,<3.0'
     python: '>=3.9'
-    pyviz_comms: '>=0.7.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.18.3-pyhd8ed1ab_0.conda
+    pyviz_comms: '>=2.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.19.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 9ef488130ebee714d0c5c4a1adde34cc
-    sha256: ab74a8e2664aeb4dd1e703b2b7db34b03137f0b42ebd4e22536c67f6191ff407
+    md5: 7ab8cd2286271685ab4dc40a8997faa8
+    sha256: f1ac92cf18b339b387f71150cfd5ebd05292a4edf002f42ddeb1997ecbdc8d34
   category: main
   optional: false
 - name: hpack
@@ -3835,7 +4062,7 @@ package:
   category: main
   optional: false
 - name: httpcore
-  version: 1.0.5
+  version: 1.0.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -3845,14 +4072,27 @@ package:
     h2: '>=3,<5'
     python: '>=3.8'
     sniffio: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
   hash:
-    md5: a6b9a0158301e697e4d0a36a3d60e133
-    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
+    md5: b8e1901ef9a215fc41ecfb6bef7e0943
+    sha256: 8952c3f1eb18bf4d7e813176c3b23e0af4e863e8b05087e73f74f371d73077ca
+  category: main
+  optional: false
+- name: httplib2
+  version: 0.22.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    pyparsing: '>=2.4.2,<4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/httplib2-0.22.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 75362ef538813bab1cfec370bb09e41f
+    sha256: b3b4205aa0f5017c58a9468e443a187b5c73a3b9f18bae146feceed6c0d4a81a
   category: main
   optional: false
 - name: httpx
-  version: 0.27.0
+  version: 0.27.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -3862,10 +4102,26 @@ package:
     idna: ''
     python: '>=3.8'
     sniffio: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 9f359af5a886fd6ca6b2b6ea02e58332
-    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
+    md5: 7e9ac3faeebdbd7b53b462c41891e7f7
+    sha256: 1a33f160548bf447e15c0273899d27e4473f1d5b7ca1441232ec2d9d07c56d03
+  category: main
+  optional: false
+- name: httpx-ws
+  version: 0.6.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    anyio: '>=4'
+    httpcore: '>=1.0.4'
+    httpx: '>=0.23.1'
+    python: '>=3.8'
+    wsproto: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-ws-0.6.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: dc4d538daf367fbf39026a6c882c8413
+    sha256: 66ed8a57c5fa34f6c9b7c274a48e0153d630364c22d24c043b2443da1ef04d76
   category: main
   optional: false
 - name: humanfriendly
@@ -3881,24 +4137,36 @@ package:
     sha256: cd93d5d4b1d98f7ce76a8658c35de9c63e17b3a40e52f40fa2f459e0da83d0b1
   category: main
   optional: false
-- name: hvplot
-  version: 0.9.2
+- name: humanize
+  version: 4.11.0
   manager: conda
   platform: linux-64
   dependencies:
-    bokeh: '>=1.0.0'
-    colorcet: '>=2'
-    holoviews: '>=1.11.0'
-    numpy: '>=1.15'
-    packaging: ''
-    pandas: ''
-    panel: '>=0.11.0'
-    param: '>=1.12.0,<3.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.9.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/humanize-4.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 315c77260e5c94788c3efad025d16142
-    sha256: 713b5195a6b49b4ea048b51680cf3f7309cbb70dbadf6131766645407212c45d
+    md5: 85b19c6cf705a85845172ade61e05a43
+    sha256: aeb87c0a422f5f68930041330ab34a784425e13933ba9fa25b0a9771a704ff66
+  category: main
+  optional: false
+- name: hvplot
+  version: 0.11.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    bokeh: '>=3.1'
+    colorcet: '>=2'
+    holoviews: '>=1.19.0'
+    numpy: '>=1.21'
+    packaging: ''
+    pandas: '>=1.3'
+    panel: '>=1.0'
+    param: '>=1.12.0,<3.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: dbc57da07daee81a9cd76586217c7cbb
+    sha256: a0fb47776b6816990b94eab6e1a27025f643fa94646b845277d3aa8bce8fb2f1
   category: main
   optional: false
 - name: hyperframe
@@ -3914,137 +4182,140 @@ package:
   category: main
   optional: false
 - name: icu
-  version: '73.2'
+  version: '75.1'
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
   hash:
-    md5: cc47e1facc155f91abd89b11e48e72ff
-    sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+    md5: 8b189310083baabfb622af68fd9d3ae3
+    sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
   category: main
   optional: false
 - name: idna
-  version: '3.6'
+  version: '3.10'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
   hash:
-    md5: 1a76f09108576397c41c0b0c5bd84134
-    sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
+    md5: 7ba2ede0e7c795ff95088daf0dc59753
+    sha256: 8c57fd68e6be5eecba4462e983aed7e85761a519aab80e834bbd7794d4b545b2
   category: main
   optional: false
 - name: imagecodecs
-  version: 2024.1.1
+  version: 2024.9.22
   manager: conda
   platform: linux-64
   dependencies:
-    blosc: '>=1.21.5,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    blosc: '>=1.21.6,<2.0a0'
     brunsli: '>=0.1,<1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    c-blosc2: '>=2.13.2,<3.0a0'
+    c-blosc2: '>=2.15.1,<2.16.0a0'
     charls: '>=2.4.2,<2.5.0a0'
-    giflib: '>=5.2.1,<5.3.0a0'
+    giflib: '>=5.2.2,<5.3.0a0'
     jxrlib: '>=1.1,<1.2.0a0'
     lcms2: '>=2.16,<3.0a0'
     lerc: '>=4.0.0,<5.0a0'
     libaec: '>=1.1.3,<2.0a0'
-    libavif16: '>=1.0.1,<2.0a0'
+    libavif16: '>=1.1.1,<2.0a0'
     libbrotlicommon: '>=1.1.0,<1.2.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libdeflate: '>=1.20,<1.21.0a0'
-    libgcc-ng: '>=12'
+    libdeflate: '>=1.22,<1.23.0a0'
+    libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libjxl: '>=0.10,<0.11.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libjxl: '>=0.11,<0.12.0a0'
+    libpng: '>=1.6.44,<1.7.0a0'
+    libstdcxx: '>=13'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     libzopfli: '>=1.0.3,<1.1.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    numpy: '>=1.22.4,<2.0a0'
+    numpy: '>=1.19,<3'
     openjpeg: '>=2.5.2,<3.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    snappy: '>=1.1.10,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    snappy: '>=1.2.1,<1.3.0a0'
     xz: '>=5.2.6,<6.0a0'
     zfp: '>=1.0.1,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2024.1.1-py310h68afbfc_3.conda
+    zlib-ng: '>=2.2.2,<2.3.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2024.9.22-py311h7d28041_0.conda
   hash:
-    md5: 8dba3c31c41671cb37e8579602fd9a16
-    sha256: b0a7239448cae0c81be261ccbeed4e3a1694076f2dafdda59cea3aac78ff006c
+    md5: 9fc1d5bcefdf9e5d121ea03212ce2b4d
+    sha256: 8537f68f4e908ff5cc4fb259505a5d18348979ea94bcc2c68f29cf23fd61dc0d
   category: main
   optional: false
 - name: imageio
-  version: 2.34.0
+  version: 2.36.0
   manager: conda
   platform: linux-64
   dependencies:
     numpy: ''
     pillow: '>=8.3.2'
     python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/imageio-2.34.0-pyh4b66e23_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/imageio-2.36.0-pyh12aca89_1.conda
   hash:
-    md5: b8853659d596f967c661f544dd89ede7
-    sha256: be0eecc8b3ee49ffe3c38dedc4d3c121e18627624926f7d1d998e8027bce4266
+    md5: 36349844ff73fcd0140ee7f30745f0bf
+    sha256: 1fbe1bdbef2c19643c6f4e2c216305d8d54860db80968fecfa7566277518132f
   category: main
   optional: false
 - name: importlib-metadata
-  version: 7.1.0
+  version: 8.5.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.1.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
   hash:
-    md5: 0896606848b2dc5cebdf111b6543aa04
-    sha256: cc2e7d1f7f01cede30feafc1118b7aefa244d0a12224513734e24165ae12ba49
+    md5: 54198435fce4d64d8a89af22573012a8
+    sha256: 7194700ce1a5ad2621fd68e894dd8c1ceaff9a38723e6e0e5298fdef13017b1c
   category: main
   optional: false
 - name: importlib-resources
-  version: 6.4.0
+  version: 6.4.5
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_resources: '>=6.4.0,<6.4.1.0a0'
+    importlib_resources: '>=6.4.5,<6.4.6.0a0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.5-pyhd8ed1ab_0.conda
   hash:
-    md5: dcbadab7a68738a028e195ab68ab2d2e
-    sha256: 38db827f445ae437a15d50a94816ae67a48285d0700f736af3eb90800a71f079
+    md5: 67f4772681cf86652f3e2261794cf045
+    sha256: b5a63a3e2bc2c8d3e5978a6ef4efaf2d6b02803c1bce3c2eb42e238dd91afe0b
   category: main
   optional: false
 - name: importlib_metadata
-  version: 7.1.0
+  version: 8.5.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: '>=7.1.0,<7.1.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.1.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.5.0,<8.5.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
   hash:
-    md5: 6ef2b72d291b39e479d7694efa2b2b98
-    sha256: 01dc057a45dedcc742a71599f67c7383ae2bf873be6018ebcbd06ac8d994dedb
+    md5: 2a92e152208121afadf85a5e1f3a5f4d
+    sha256: 313b8a05211bacd6b15ab2621cb73d7f41ea5c6cae98db53367d47833f03fef1
   category: main
   optional: false
 - name: importlib_resources
-  version: 6.4.0
+  version: 6.4.5
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
   hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+    md5: c808991d29b9838fb4d96ce8267ec9ec
+    sha256: 2cb9db3e40033c3df72d3defc678a012840378fd55a67e4351363d4b321a0dc1
   category: main
   optional: false
 - name: iniconfig
@@ -4060,50 +4331,41 @@ package:
   category: main
   optional: false
 - name: intake
-  version: 0.7.0
+  version: 2.0.7
   manager: conda
   platform: linux-64
   dependencies:
-    appdirs: ''
-    cloudpickle: '>=0.2.2'
-    dask: '>=1.0'
-    entrypoints: ''
-    fsspec: '>=0.7.4'
-    jinja2: ''
-    msgpack-python: ''
-    numpy: ''
-    partd: '>=0.3.10'
-    python: '>=3.6'
+    fsspec: '>=2023.0.0'
+    networkx: ''
+    platformdirs: ''
+    python: '>=3.8'
     pyyaml: ''
-    requests: ''
-    toolz: '>=0.8.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/intake-0.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-2.0.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 310f0fdaec6eecd9cc7833a788bafb1f
-    sha256: 8dba632e81a11347d959bb11367f6b0184e2dcc9aeab550de156beac5fa6091b
+    md5: 60d4141073985bace34703a9de4c9b24
+    sha256: 7fe91841c9aee259b10f41cf239577ebe2c471d1fb3ffc360e2ade8b327574d6
   category: main
   optional: false
 - name: intake-esm
-  version: 2024.2.6
+  version: 2023.11.10
   manager: conda
   platform: linux-64
   dependencies:
     dask: '>=2022.02.0'
-    dask-core: '>=2022.02.0'
     fastprogress: '>=1.0.0'
     fsspec: '>=2022.11.0'
-    intake: '>=0.6.6,<2'
+    intake: '>=0.6.6'
     netcdf4: '>=1.5.5'
     pandas: '>=2.1.0'
     pydantic: '>=2.0'
-    python: '>=3.10'
+    python: '>=3.9'
     requests: '>=2.24.0'
     xarray: '>=2022.06'
     zarr: '>=2.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/intake-esm-2024.2.6-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-esm-2023.11.10-pyhd8ed1ab_0.conda
   hash:
-    md5: 0578b8be014ecf92e1578ed1c8e093c1
-    sha256: a1fd3d1822fc092a7de0a92da205acdddb13f365adcde8a834bafd5614056837
+    md5: e0c73b7dc6419a243c5fe104ec241a48
+    sha256: 671857e0d7d385053a9b4bb7f5bce44105356fd1bee7ba2f0f7ea3d6165e82b1
   category: main
   optional: false
 - name: intake-geopandas
@@ -4167,7 +4429,7 @@ package:
   category: main
   optional: false
 - name: ipykernel
-  version: 6.29.3
+  version: 6.29.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -4185,26 +4447,27 @@ package:
     pyzmq: '>=24'
     tornado: '>=6.1'
     traitlets: '>=5.4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyhd33586a_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
   hash:
-    md5: e0deff12c601ce5cb7476f93718f3168
-    sha256: 0314f15e666fd9a4fb653aae37d2cf4dc6bc3a18c0d9c2671a6a0783146adcfa
+    md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+    sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
   category: main
   optional: false
 - name: ipyleaflet
-  version: 0.18.2
+  version: 0.19.2
   manager: conda
   platform: linux-64
   dependencies:
     branca: '>=0.5.0'
     ipywidgets: '>=7.6.0,<9'
-    python: '>=3.7'
+    jupyter_leaflet: ''
+    python: '>=3.8'
     traittypes: '>=0.2.1,<0.3.0'
     xyzservices: '>=2021.8.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipyleaflet-0.18.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipyleaflet-0.19.2-pyhd8ed1ab_0.conda
   hash:
-    md5: fd0b34363a06a30ce7b1caa62de657e1
-    sha256: 6151e64d06b138fd7e32b087d24eedbeb91c844c6cd3b01894d94d5c7d48db22
+    md5: afbe890e677f76d347730edcb60167fa
+    sha256: 503c3de87d5803b63244c2b2e9905a770fa15f26f7c1ac9d2728d4a292a26fa9
   category: main
   optional: false
 - name: ipysheet
@@ -4222,27 +4485,27 @@ package:
   category: main
   optional: false
 - name: ipython
-  version: 8.22.2
+  version: 8.17.2
   manager: conda
   platform: linux-64
   dependencies:
-    __unix: ''
+    __linux: ''
     decorator: ''
     exceptiongroup: ''
     jedi: '>=0.16'
     matplotlib-inline: ''
     pexpect: '>4.3'
     pickleshare: ''
-    prompt-toolkit: '>=3.0.41,<3.1.0'
+    prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
     pygments: '>=2.4.0'
-    python: '>=3.10'
+    python: '>=3.9'
     stack_data: ''
-    traitlets: '>=5.13.0'
+    traitlets: '>=5'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.2-pyh707e725_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh41d4057_0.conda
   hash:
-    md5: f0abe827c8a7c6d91bccdf90cb1fbee3
-    sha256: 7740505317669f094c881537a643ed26977e209510965164d84942799c997d42
+    md5: f39d0b60e268fe547f1367edbab457d4
+    sha256: 31322d58f412787f5beeb01db4d16f10f8ae4e0cc2ec99fafef1e690374fe298
   category: main
   optional: false
 - name: ipytree
@@ -4258,21 +4521,48 @@ package:
     sha256: 5045747a2d02ef8595dc2fa9f8e74c6702da41bb656e35f8ca794570dcf2aa93
   category: main
   optional: false
+- name: ipyvue
+  version: 1.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ipywidgets: '>=7.0.0'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipyvue-1.11.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e0c654ff60f028f281db145e8a9a2d20
+    sha256: 209c0dbd73f13712daed69474af7b9d0c7809766718938cb70d96a186dbaaaad
+  category: main
+  optional: false
+- name: ipyvuetify
+  version: 1.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ipyvue: '>=1.5,<2'
+    ipywidgets: '>=7.0.0'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipyvuetify-1.10.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a29a71d67465f289802fcea4c9b4b945
+    sha256: f26c7218dbcffdb2724f9b45da9fc0f2d5f45a6e1a22d48c77d71738f9adddb2
+  category: main
+  optional: false
 - name: ipywidgets
-  version: 8.1.2
+  version: 8.1.5
   manager: conda
   platform: linux-64
   dependencies:
     comm: '>=0.1.3'
     ipython: '>=6.1.0'
-    jupyterlab_widgets: '>=3.0.10,<3.1.0'
+    jupyterlab_widgets: '>=3.0.13,<3.1.0'
     python: '>=3.7'
     traitlets: '>=4.3.1'
-    widgetsnbextension: '>=4.0.10,<4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.2-pyhd8ed1ab_0.conda
+    widgetsnbextension: '>=4.0.13,<4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 67f86478c78637f68c1f3858973021f2
-    sha256: 0be846f1374faa2d9b6f5e100187d56afa9268221f7c7815265f30aa008da8ca
+    md5: a022d34163147d16b27de86dc53e93fc
+    sha256: ae27447f300c85a184d5d4fa08674eaa93931c12275daca981eb986f5d7795b3
   category: main
   optional: false
 - name: iso8601
@@ -4288,16 +4578,15 @@ package:
   category: main
   optional: false
 - name: isodate
-  version: 0.6.1
+  version: 0.7.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.6.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 4a62c93c1b5c0b920508ae3fd285eaf5
-    sha256: af8f801e093da52a50ca0ea0510dfaf6898fea37e66d08d335e370235dede9fc
+    md5: d68d25aca67d1a06bf6f5b43aea9430d
+    sha256: 5bf70eb750654eba73d0624a21dccbda982fb77070b3ff457dc2abd67c4e0a27
   category: main
   optional: false
 - name: isoduration
@@ -4314,7 +4603,7 @@ package:
   category: main
   optional: false
 - name: jasper
-  version: 4.2.3
+  version: 4.2.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -4322,10 +4611,10 @@ package:
     libgcc-ng: '>=12'
     libglu: '>=9.0.0,<10.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.3-he6dfbbe_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
   hash:
-    md5: 05c1609de571f7a9a40e6d7d4116c21a
-    sha256: 5cc5e2ae5127d655747a377e267ff40856c262a00f52cc6840238cfdb52368c4
+    md5: 9518ab7016cf4564778aef08b6bd8792
+    sha256: 0a5ca92ea0261f435c27a3c3c5c5bc5e8b4b1af1343b21ef0cbc7c33b62f5239
   category: main
   optional: false
 - name: jdcal
@@ -4354,34 +4643,48 @@ package:
   category: main
   optional: false
 - name: jedi-language-server
-  version: 0.41.3
+  version: 0.41.4
   manager: conda
   platform: linux-64
   dependencies:
     cattrs: '>=23.1.2'
     docstring-to-markdown: '>=0.4,<1.0'
     jedi: '>=0.19.1,<0.20.0'
-    lsprotocol: '>=2022.0.0a9'
+    lsprotocol: '>=2023.0.1'
     pygls: '>=1.1.0,<2.0.0'
     python: '>=3.8'
     typing_extensions: '>=4.5.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-language-server-0.41.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-language-server-0.41.4-pyhd8ed1ab_0.conda
   hash:
-    md5: fbc7081cf8fc2d7015253be7c50cf7c8
-    sha256: 4bc7a73ac4964fa0cdeecfe9f27c4af24bf961f6965fb58d1780120392d4423d
+    md5: ee3e8f555cbcb3cf1d456e7cc8d86894
+    sha256: 300801accbaa421d8240a3d61319a42b68d7b2f3015eff2cacc9676e7a5922aa
   category: main
   optional: false
 - name: jinja2
-  version: 3.1.3
+  version: 3.1.4
   manager: conda
   platform: linux-64
   dependencies:
     markupsafe: '>=2.0'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
   hash:
-    md5: e7d8df6509ba635247ff9aea31134262
-    sha256: fd517b7dd3a61eca34f8a6f9f92f306397149cae1204fce72ac3d227107dafdc
+    md5: 7b86ecb7d3557821c649b3c31e3eb9f2
+    sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
+  category: main
+  optional: false
+- name: jinja2-humanize-extension
+  version: 0.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    humanize: '>=3.14.0'
+    jinja2: ''
+    python: '>=3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-humanize-extension-0.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a97d26d0c873821fccaa41a74b58774c
+    sha256: abe466cbb753037708de2c72db17cf72e5098affd71746c2ed1e7e3d80e32033
   category: main
   optional: false
 - name: jmespath
@@ -4397,40 +4700,41 @@ package:
   category: main
   optional: false
 - name: joblib
-  version: 1.3.2
+  version: 1.4.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 4da50d410f553db77e62ab62ffaa1abc
-    sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
+    md5: 25df261d4523d9f9783bcdb7208d872f
+    sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
   category: main
   optional: false
 - name: json-c
-  version: '0.17'
+  version: '0.18'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.17-h7ab15ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
   hash:
-    md5: 9961b1f100c3b6852bd97c9233d06979
-    sha256: 5646496ca07dfa1486d27ed07282967007811dfc63d6394652e87f94166ecae3
+    md5: 38f5dbc9ac808e31c00650f7be1db93f
+    sha256: 09e706cb388d3ea977fabcee8e28384bdaad8ce1fc49340df5f868a2bd95a7da
   category: main
   optional: false
 - name: json5
-  version: 0.9.24
+  version: 0.9.25
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.24-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.25-pyhd8ed1ab_0.conda
   hash:
-    md5: fc9780a517b51ea3798fc011c17ffd51
-    sha256: 148a427d4867ecd367b2bb9c2ef11ae7795abeabc8454f802f28ff692b3ce1aa
+    md5: 5d8c241a9261e720a34a07a3e1ac4109
+    sha256: 0c75e428970e8bb72ba1dd3a6dc32b8d68f6534b4fe16b38e53364963fdc8e38
   category: main
   optional: false
 - name: jsonpatch
@@ -4462,33 +4766,33 @@ package:
   category: main
   optional: false
 - name: jsonpickle
-  version: 3.0.2
+  version: 3.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_metadata: ''
+    importlib-metadata: ''
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-3.0.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-3.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f351864256e291b24b5a3bedda184bff
-    sha256: c947f2a64e4f06c722973894afb8e26df3aa2212e2e742def3506ccbad42141b
+    md5: 5c7ff89993a8f1474b3ef0a3a3442d6a
+    sha256: 4d31153667782810c86e3ab46e4bcbdaed3e315b613eb34e4eeee282f6e812c5
   category: main
   optional: false
 - name: jsonpointer
-  version: '2.4'
+  version: 3.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py310hff52083_3.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
   hash:
-    md5: 08ec1463dbc5c806a32fc431874032ca
-    sha256: 316db08863469a56cdbfd030de5a2cc11ec7649ed7c50eff507e9caa0070ccaa
+    md5: 5ca76f61b00a15a9be0612d4d883badc
+    sha256: 2f082f7b12a7c6824e051321c1029452562ad6d496ad2e8c8b7b3dea1c8feb92
   category: main
   optional: false
 - name: jsonschema
-  version: 4.21.1
+  version: 4.23.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4499,28 +4803,27 @@ package:
     python: '>=3.8'
     referencing: '>=0.28.4'
     rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 8a3a3d01629da20befa340919e3dd2c4
-    sha256: c5c1b4e08e91fdd697289015be1a176409b4e63942899a43b276f1f250be8129
+    md5: da304c192ad59975202859b367d0f6a2
+    sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
   category: main
   optional: false
 - name: jsonschema-specifications
-  version: 2023.12.1
+  version: 2024.10.1
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_resources: '>=1.4.0'
     python: '>=3.8'
     referencing: '>=0.31.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a0e4efb5f35786a05af4809a2fb1f855
-    sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
+    md5: 720745920222587ef942acfbc578b584
+    sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
   category: main
   optional: false
 - name: jsonschema-with-format-nongpl
-  version: 4.21.1
+  version: 4.23.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4528,30 +4831,29 @@ package:
     idna: ''
     isoduration: ''
     jsonpointer: '>1.13'
-    jsonschema: '>=4.21.1,<4.21.2.0a0'
-    python: ''
+    jsonschema: '>=4.23.0,<4.23.1.0a0'
     rfc3339-validator: ''
     rfc3986-validator: '>0.1.0'
     uri-template: ''
-    webcolors: '>=1.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
+    webcolors: '>=24.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
   hash:
-    md5: 26bce4b5405738c09304d4f4796b2c2a
-    sha256: 6e458c325c097956ac4605ef386f0d67bad5223041cedd66819892988b72f83a
+    md5: 16b37612b3a2fd77f409329e213b530c
+    sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
   category: main
   optional: false
 - name: jupyter-lsp
-  version: 2.2.4
+  version: 2.2.5
   manager: conda
   platform: linux-64
   dependencies:
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 91f93e1ebf6535be518715432d89fd92
-    sha256: 8000b1904a2a10cf039b46305781128e1a93da4c2fd857445b4924ecf3535bdb
+    md5: 885867f6adab3d7ecdf8ab6ca0785f51
+    sha256: 2151c2c63e0442a4c69ee0ad8a634195eedab10b7b74c0ec8266471842239a93
   category: main
   optional: false
 - name: jupyter-panel-proxy
@@ -4569,7 +4871,7 @@ package:
   category: main
   optional: false
 - name: jupyter-resource-usage
-  version: 1.0.2
+  version: 1.1.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4577,10 +4879,10 @@ package:
     psutil: '>=5.6.0,<6'
     python: '>=3.8'
     pyzmq: '>=19'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-resource-usage-1.0.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-resource-usage-1.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: dec5f3f95c6bef50591d552d00c22c0c
-    sha256: 6b0ad1fcf1a30ed1954556b58c81bc2501d9f986e9c3af9c99a72c1ad6d5ed19
+    md5: c64f9b9f15a79239b864c455cc0a67d4
+    sha256: 163a265b237d1896539b75e79288c117bdc9e7eec47aac5087c3b0a737b5511f
   category: main
   optional: false
 - name: jupyter-server-mathjax
@@ -4597,53 +4899,53 @@ package:
   category: main
   optional: false
 - name: jupyter-server-proxy
-  version: 4.1.2
+  version: 4.4.0
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: ''
-    importlib_metadata: '>=4.8.3'
-    jupyter_server: '>=1.0'
+    importlib-metadata: '>=4.8.3'
+    jupyter_server: '>=1.24.0'
     python: '>=3.8'
-    simpervisor: '>=1.0'
-    tornado: '>=5.1'
-    traitlets: '>=4.2.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-server-proxy-4.1.2-pyhd8ed1ab_0.conda
+    simpervisor: '>=1.0.0'
+    tornado: '>=6.1.0'
+    traitlets: '>=5.1.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-server-proxy-4.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3671520b52215a5a084de08003e6d8cd
-    sha256: 4552703a544c20f1b1b5a81d19c8e889b3e1b0e120cf80554ca272b2e8558365
+    md5: f84c359ab53d51c125319b25bd09a887
+    sha256: 51955e791d7cb60ad1efabf0802cb9f55905bab74709ec0f096d3b5bc9e9815e
   category: main
   optional: false
 - name: jupyter-vscode-proxy
-  version: '0.5'
+  version: '0.6'
   manager: conda
   platform: linux-64
   dependencies:
     jupyter-server-proxy: ''
     python: '>=3'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-vscode-proxy-0.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-vscode-proxy-0.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 97e6ff376f730a316fb9d74c5c54c5a1
-    sha256: 7022fb918e663318a78da451f1991b006ea1f1f5298d4318784d7f704f3b84c6
+    md5: 15af47d9ba08dc87c4dcb09eb5000b05
+    sha256: 160a692440d8310efbe65f375e46b59b54ef03609017585f5e25b6a4c30b6dd1
   category: main
   optional: false
 - name: jupyter_client
-  version: 8.6.1
+  version: 8.6.3
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_metadata: '>=4.8.3'
+    importlib-metadata: '>=4.8.3'
     jupyter_core: '>=4.12,!=5.0.*'
     python: '>=3.8'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=23.0'
     tornado: '>=6.2'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: c03972cfce69ad913d520c652e5ed908
-    sha256: c7d10d7941fd2e61480e49d3b2b21a530af4ae4b0d449a1746a72a38bacb63e2
+    md5: a14218cfb29662b4a19ceb04e93e298e
+    sha256: 4419c85e209a715f551a5c9bead746f29ee9d0fc41e772a76db3868622795671
   category: main
   optional: false
 - name: jupyter_core
@@ -4651,14 +4953,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __unix: ''
     platformdirs: '>=2.5'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.8'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.7.2-py310hff52083_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
   hash:
-    md5: cb92c27600d5716fd526a206aa43342c
-    sha256: 837039256d39a249b5bec850f87948e1967c47c9e747056df8155d80c4d3b094
+    md5: 0a2980dada0dd7fd0998f0342308b1b1
+    sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
   category: main
   optional: false
 - name: jupyter_events
@@ -4680,34 +4982,46 @@ package:
     sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
   category: main
   optional: false
+- name: jupyter_leaflet
+  version: 0.19.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_leaflet-0.19.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: aafc37674dd1409e2e218f89a9020291
+    sha256: ab1b7f0cb32790dedb502deb2000ef1f28e158f25fea1a5d5c0ee73d22ceb8e0
+  category: main
+  optional: false
 - name: jupyter_server
-  version: 2.13.0
+  version: 2.14.2
   manager: conda
   platform: linux-64
   dependencies:
     anyio: '>=3.1.0'
-    argon2-cffi: ''
-    jinja2: ''
+    argon2-cffi: '>=21.1'
+    jinja2: '>=3.0.3'
     jupyter_client: '>=7.4.4'
     jupyter_core: '>=4.12,!=5.0.*'
     jupyter_events: '>=0.9.0'
-    jupyter_server_terminals: ''
+    jupyter_server_terminals: '>=0.4.4'
     nbconvert-core: '>=6.4.4'
     nbformat: '>=5.3.0'
-    overrides: ''
-    packaging: ''
-    prometheus_client: ''
+    overrides: '>=5.0'
+    packaging: '>=22.0'
+    prometheus_client: '>=0.9'
     python: '>=3.8'
     pyzmq: '>=24'
     send2trash: '>=1.8.2'
     terminado: '>=0.8.3'
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
-    websocket-client: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.13.0-pyhd8ed1ab_0.conda
+    websocket-client: '>=1.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
   hash:
-    md5: e242df505f194c4932fbb840a99207e2
-    sha256: 7e3259506b1b8500ebac4b4b097629ca8c32ee70d1c1df122052fea65c7cbae0
+    md5: ca23c71f70a7c7935b3d03f0f1a5801d
+    sha256: edab71a05feceac54bdb90e755a257545af7832b9911607c1a70f09be44ba985
   category: main
   optional: false
 - name: jupyter_server_terminals
@@ -4822,7 +5136,7 @@ package:
   category: main
   optional: false
 - name: jupyterlab-git
-  version: 0.50.0
+  version: 0.50.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -4833,23 +5147,23 @@ package:
     pexpect: ''
     python: '>=3.6,<4.0'
     traitlets: '>=5.0,<6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-git-0.50.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-git-0.50.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 5020cacc18e3d5f62a81513f26ac2cac
-    sha256: 690f493904a89b550d636e1e727fffec240ae90f28cf275ef21a0f45ea034e66
+    md5: ceef639ca7744eae72138fb5cff033ad
+    sha256: d436cb217a2367b3122169e276ed6f73912e3c2c66381f45683391f78ba342bc
   category: main
   optional: false
 - name: jupyterlab_code_formatter
-  version: 2.2.1
+  version: 3.0.2
   manager: conda
   platform: linux-64
   dependencies:
     jupyter_server: '>=1.21,<3'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_code_formatter-2.2.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_code_formatter-3.0.2-pyhd8ed1ab_0.conda
   hash:
-    md5: d67b33450635a2ad1b55d48838eb1eca
-    sha256: 8873858a9d3b730a1d6a199be6d4fa67367837d6fa55aa8fe464040522cd906d
+    md5: bd108b7352ce3f9ec42bb9518df10629
+    sha256: 3b8e956697bd3b8135f3b4a669b2961b38ece7bae272746f8ea6bee61644d0e1
   category: main
   optional: false
 - name: jupyterlab_pygments
@@ -4866,7 +5180,7 @@ package:
   category: main
   optional: false
 - name: jupyterlab_server
-  version: 2.25.4
+  version: 2.27.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -4879,22 +5193,22 @@ package:
     packaging: '>=21.3'
     python: '>=3.8'
     requests: '>=2.31'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
   hash:
-    md5: ffd61670ae09d2d3c637f6afd29db443
-    sha256: d0336d0c0223a66d648b24cfd1512fd7aebc85550d47f55ad5edbd53f482e7e5
+    md5: af8239bf1ba7e8c69b689f780f653488
+    sha256: a23b26d1a35bccdb91b9232119e5f402624e1e1a252b0e64cc20c6eb5b87cefb
   category: main
   optional: false
 - name: jupyterlab_widgets
-  version: 3.0.10
+  version: 3.0.13
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.10-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 16b73b2c4ff7dda8bbecf88aadfe2027
-    sha256: 7c14d0b377ddd2e21f23d2f55fbd827aca726860e504a131b67ef936aef2b8c4
+    md5: ccea946e6dce9f330fbf7fca97fe8de7
+    sha256: 0e7ec7936d766f39d5a0a8eafc63f5543f488883ad3645246bc22db6d632566e
   category: main
   optional: false
 - name: jxrlib
@@ -4914,17 +5228,18 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-h2f55d51_0.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-hf8d3e68_2.conda
   hash:
-    md5: f7e7077802927590efc8bf7328208f12
-    sha256: ee0934ff426d3cab015055808bed33eb9d20f635ec14bc421c596f4b70927102
+    md5: ffe68c611ae0ccfda4e7a605195e22b3
+    sha256: a45cb038fce2b6fa154cf0c71485a75b59cb1d8d6b0465bdcb23736aca6bf2ac
   category: main
   optional: false
 - name: kerchunk
-  version: 0.2.4
+  version: 0.2.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -4933,21 +5248,21 @@ package:
     python: '>=3.7'
     ujson: ''
     zarr: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.4-pyhd8ed1ab_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.6-pyhd8ed1ab_0.conda
   hash:
-    md5: a173861d7c57fbda3db5e3dbee69050d
-    sha256: addac1a67dc5f89d9add93abcd31a5294fc85c34679a31997e852740249bbd12
+    md5: 1e8d30ede5a3b9146551532091dc23cd
+    sha256: 3d988302b89dec9419c72158ae9545c3caa1034fdaf1a699f11279ab8c168fa4
   category: main
   optional: false
 - name: kernel-headers_linux-64
-  version: 2.6.32
+  version: 3.10.0
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_17.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
   hash:
-    md5: d731b543793afc0433c4fd593e693fce
-    sha256: fb39d64b48f3d9d1acc3df208911a41f25b6a00bd54935d5973b4739a9edd5b6
+    md5: ad8527bf134a90e1c9ed35fa0b64318c
+    sha256: a922841ad80bd7b222502e65c07ecb67e4176c4fa5b03678a005f39fcc98be4b
   category: main
   optional: false
 - name: keyutils
@@ -4963,18 +5278,19 @@ package:
   category: main
   optional: false
 - name: kiwisolver
-  version: 1.4.5
+  version: 1.4.7
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
   hash:
-    md5: b8d67603d43b23ce7e988a5d81a7ab79
-    sha256: bb51906639bced3de1d4d7740ac284cdaa89e2f22e0b1ec796378b090b0648ba
+    md5: be34c90cce87090d24da64a7c239ca96
+    sha256: 4af11cbc063096a284fe1689b33424e7e49732a27fd396d74c7dee03d1e788ee
   category: main
   optional: false
 - name: knack
@@ -4997,7 +5313,7 @@ package:
   category: main
   optional: false
 - name: kopf
-  version: 1.37.1
+  version: 1.37.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -5010,32 +5326,35 @@ package:
     python-json-logger: ''
     pyyaml: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/kopf-1.37.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kopf-1.37.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 18f16a0a6327661a391d530dc0fe5758
-    sha256: 14cd2b2c0c731d685984c90c3829dc072e1dc947feb1617dc6a38c307231183a
+    md5: c14f5c7dab8c72f4fb01ce6c8622f4e7
+    sha256: f067301001928d856071c972c5951ac156eda58e92e4043400a00bf1c0be898c
   category: main
   optional: false
 - name: kr8s
-  version: 0.9.0
+  version: 0.17.4
   manager: conda
   platform: linux-64
   dependencies:
-    aiohttp: '>=3.8.4'
     anyio: '>=3.7.0'
+    asyncache: '>=0.3.1'
+    cryptography: '>=35'
+    exceptiongroup: '>=1.2.0'
     httpx: '>=0.24.1'
+    httpx-ws: '>=0.5.2'
     python: '>=3.8'
     python-box: '>=7.0.1'
     python-jsonpath: '>=0.7.1'
     pyyaml: '>=6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/kr8s-0.9.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kr8s-0.17.4-pyhd8ed1ab_0.conda
   hash:
-    md5: b5f425bbe85aa15512c166fa7bb3cd73
-    sha256: 3c1140b56e5c60ce221b46636db27a125cb303a6f915778757e652f0741a831a
+    md5: 05dd0523db4d50afc1db946817cf7d9b
+    sha256: 3ef5197f8953ab10fe279757bc6d63788fe4ac0f2b76690f7ab306d139dc0626
   category: main
   optional: false
 - name: krb5
-  version: 1.21.2
+  version: 1.21.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -5043,69 +5362,69 @@ package:
     libedit: '>=3.1.20191231,<4.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    openssl: '>=3.1.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   hash:
-    md5: cd95826dbd331ed1be26bdf401432844
-    sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
+    md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+    sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
   category: main
   optional: false
 - name: kubernetes
-  version: 1.25.3
+  version: 1.31.2
   manager: conda
   platform: linux-64
   dependencies:
-    kubernetes-client: 1.25.3
-    kubernetes-node: 1.25.3
-    kubernetes-server: 1.25.3
-  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-1.25.3-ha770c72_0.conda
+    kubernetes-client: 1.31.2
+    kubernetes-node: 1.31.2
+    kubernetes-server: 1.31.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-1.31.2-ha770c72_0.conda
   hash:
-    md5: d9c3df17c3020b839d47f252ba6885fd
-    sha256: 624ee9537664756032437b6378497b9cbd90d9a6bbca6e805615615314a6d480
+    md5: bccd3efc98845486828fe4d136a5ebd0
+    sha256: 040d454954ea1864a6fd2d673dbb1a2027e02a714c1cfd5622a101264af8bc79
   category: main
   optional: false
 - name: kubernetes-client
-  version: 1.25.3
+  version: 1.31.2
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-client-1.25.3-h449c3f6_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-client-1.31.2-h6d84b8b_0.conda
   hash:
-    md5: 53a9490aea421c6b43605c17b3fbb26c
-    sha256: b6baddbf7fe6e53e71cf8998d225fa8e6d187b60dc0e466d34fbfe876aec9a5c
+    md5: 1e1cb15ed7882b4fb991c7d93b4cfd28
+    sha256: 95d60c817bf3a37edd9ff2bb686738933a4e4dd6438b65d420ec060d510a86fc
   category: main
   optional: false
 - name: kubernetes-node
-  version: 1.25.3
+  version: 1.31.2
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-node-1.25.3-h449c3f6_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-node-1.31.2-h6d84b8b_0.conda
   hash:
-    md5: f706346637b6175a91d7fc3b5c04db16
-    sha256: 9be6b6d2fc4fc90741e2efb12a7e3b60f3bb44e6c458ef6e6fe8824635020c87
+    md5: 1db263fc25e8b0acca27ffcdb7260add
+    sha256: 751748a7b613dd5baa56fa82af64f6f8f26f19c6d34842a7f561b477b6984bee
   category: main
   optional: false
 - name: kubernetes-server
-  version: 1.25.3
+  version: 1.31.2
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17'
-    kubernetes-node: 1.25.3
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-server-1.25.3-h449c3f6_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    kubernetes-node: 1.31.2
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-server-1.31.2-h6d84b8b_0.conda
   hash:
-    md5: c7df8e51b39ffb41d2f3c9a3c782ef6d
-    sha256: 3b8410040ff355d871ce90bcbccc6fba8482d097411da99a73d7bfb7e13bf264
+    md5: 513b8ebfd4cb36ae1a0494ef6aafc318
+    sha256: 2666fc468113cb23c8676ac1cb318650375b9d70877b00fd433a98d5033960e3
   category: main
   optional: false
 - name: kubernetes_asyncio
-  version: 29.0.0
+  version: 31.1.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5117,10 +5436,10 @@ package:
     setuptools: '>=21.0.0'
     six: '>=1.9.0'
     urllib3: '>=1.24.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/kubernetes_asyncio-29.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kubernetes_asyncio-31.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 9197a9d12cccf2dce9941395deaf5e70
-    sha256: 38a57b7c6929d50894f5587bc490224817e62c28e7718c731a51d3d0b86883cb
+    md5: dac971db6b739fd41302dede1fe5e801
+    sha256: c207aba82e0afb60b2e8b68d06ece266d4fd44818f87d8b0aaa6af10ba78566e
   category: main
   optional: false
 - name: lame
@@ -5136,27 +5455,42 @@ package:
   category: main
   optional: false
 - name: lark
-  version: 1.1.9
+  version: 1.2.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/lark-1.1.9-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/lark-1.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: f5b35b5ad9b6b4bfcfd300d66fd4f173
-    sha256: a9529f428ef27ac7c99b5826730d4fbbc33220b748955b908826c2bbc1fce8c5
+    md5: e69ddc63e66565bc5283b169b350a851
+    sha256: a71d0e5c0975803b43c93df9b4e92850fc291c6fc3dd6c6e38aeacc64cc43737
+  category: main
+  optional: false
+- name: lazy-loader
+  version: '0.4'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    importlib-metadata: ''
+    packaging: ''
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 4809b9f4c6ce106d443c3f90b8e10db2
+    sha256: c1ca8dc910d7c32d431d8ef4acdea8da2e876c62f096b99591f712fd62cf7269
   category: main
   optional: false
 - name: lazy_loader
-  version: '0.3'
+  version: '0.4'
   manager: conda
   platform: linux-64
   dependencies:
+    lazy-loader: '0.4'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 69ea1d0fa7ab33b48c88394ad1dead65
-    sha256: fa32bafbf7f9238a9cb8f0aa1fb17d2fdcefa607c217b86c38c3b670c58d1ac6
+    md5: ec6f70b8a5242936567d4f886726a372
+    sha256: bf5a563f4e7d2bd5d3ec0644c0cb452b1e9e4ee68a221f6c9718872a22d4fa7a
   category: main
   optional: false
 - name: lcms2
@@ -5166,7 +5500,7 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
   hash:
     md5: 51bb7010fc86f70eee639b4bb7a894f5
@@ -5174,49 +5508,67 @@ package:
   category: main
   optional: false
 - name: ld_impl_linux-64
-  version: '2.40'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
-  hash:
-    md5: 7aca3059a1729aa76c597603f10b0dd3
-    sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
-  category: main
-  optional: false
-- name: leafmap
-  version: 0.31.6
+  version: '2.43'
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+  hash:
+    md5: 048b02e3962f066da18efe3a21b77672
+    sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
+  category: main
+  optional: false
+- name: leafmap
+  version: 0.38.16
+  manager: conda
+  platform: linux-64
+  dependencies:
+    anywidget: ''
     bqplot: ''
     colour: ''
     folium: ''
     gdown: ''
     geojson: ''
+    geopandas: ''
     ipyevents: ''
     ipyfilechooser: ''
     ipyleaflet: ''
     ipysheet: ''
+    ipyvuetify: ''
     ipywidgets: ''
     jupyterlab: ''
     matplotlib-base: ''
     numpy: ''
     pandas: ''
     plotly: ''
+    pmtiles: ''
+    pyarrow: ''
     pycrs: ''
     pyshp: ''
     pystac-client: ''
-    python: '>=3.7'
+    python: '>=3.9'
     python-box: ''
     python-duckdb: ''
     scooby: ''
     whiteboxgui: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/leafmap-0.31.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/leafmap-0.38.16-pyhd8ed1ab_0.conda
   hash:
-    md5: 93ab4c2a6be7af8a2d42f5d5e379c582
-    sha256: 1568714261c7ed2e884afbbeb53f1df1200dc76f789ce2780feb000679357af3
+    md5: 2f4167dd305186e0d49633e17cb5372d
+    sha256: 85ce712be2e23b8b8d336cce71daee0cfbddf2270df508f15c73efb87bdac011
+  category: main
+  optional: false
+- name: legacy-cgi
+  version: 2.6.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.10.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/legacy-cgi-2.6.1-pyh5b84bb0_3.conda
+  hash:
+    md5: f258b7f54b5d9ddd02441f10c4dca2ac
+    sha256: 4e46bf5a8f7d3bbe89f2884539b31877c367e09d63fbe54979319f4bb9e62c1b
   category: main
   optional: false
 - name: lerc
@@ -5233,16 +5585,17 @@ package:
   category: main
   optional: false
 - name: libabseil
-  version: '20240116.1'
+  version: '20240116.2'
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_he02047a_1.conda
   hash:
-    md5: 75648bc5dd3b8eab22406876c24d81ec
-    sha256: 9951421311285dd4335ad3aceffb223a4d3bc90fb804245508cd27aceb184a29
+    md5: c48fc56ec03229f294176923c3265c05
+    sha256: 945396726cadae174a661ce006e3f74d71dbd719219faf7cc74696b267f7b0b5
   category: main
   optional: false
 - name: libaec
@@ -5259,189 +5612,147 @@ package:
   category: main
   optional: false
 - name: libarchive
-  version: 3.7.2
+  version: 3.7.4
   manager: conda
   platform: linux-64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
     libgcc-ng: '>=12'
-    libxml2: '>=2.12.2,<3.0.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libxml2: '>=2.12.7,<3.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.3.0,<4.0a0'
     xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.2-h2aa1ff5_1.conda
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
   hash:
-    md5: 3bf887827d1968275978361a6e405e4f
-    sha256: 340ed0bb02fe26a2b2e29cedf6559e2999b820f434e745c108e788d629ae4b17
+    md5: 32ddb97f897740641d8d46a829ce1704
+    sha256: c30970e5e6515c662d00bb74e7c1b09ebe0c8c92c772b952a41a5725e2dcc936
   category: main
   optional: false
 - name: libarrow
-  version: 15.0.2
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
-    aws-sdk-cpp: '>=1.11.267,<1.11.268.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    aws-crt-cpp: '>=0.28.3,<0.28.4.0a0'
+    aws-sdk-cpp: '>=1.11.407,<1.11.408.0a0'
+    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
+    azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
+    azure-storage-blobs-cpp: '>=12.12.0,<12.12.1.0a0'
+    azure-storage-files-datalake-cpp: '>=12.11.0,<12.11.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.7.0,<0.8.0a0'
-    libabseil: '>=20240116.1,<20240117.0a0'
+    gflags: '>=2.2.2,<2.3.0a0'
+    glog: '>=0.7.1,<0.8.0a0'
+    libabseil: '>=20240116.2,<20240117.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libgcc-ng: '>=12'
-    libgoogle-cloud: '>=2.22.0,<2.23.0a0'
-    libgoogle-cloud-storage: '>=2.22.0,<2.23.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libstdcxx-ng: '>=12'
+    libgcc: '>=13'
+    libgoogle-cloud: '>=2.29.0,<2.30.0a0'
+    libgoogle-cloud-storage: '>=2.29.0,<2.30.0a0'
+    libre2-11: '>=2023.9.1'
+    libstdcxx: '>=13'
     libutf8proc: '>=2.8.0,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.0,<2.0.1.0a0'
+    orc: '>=2.0.2,<2.0.3.0a0'
     re2: ''
-    snappy: '>=1.1.10,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-15.0.2-hb86450c_1_cpu.conda
+    snappy: '>=1.2.1,<1.3.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-16.1.0-had3b6fe_29_cpu.conda
   hash:
-    md5: b68f648f3e2f60755adaa5bfb93287d0
-    sha256: f99e523a0dea433fcc79caf18057ef83621fd28da6f1b3e42096c4deaa485416
+    md5: 10aaea548b6f3460d407c6f84c16568d
+    sha256: b254c7c02771eaa5f85d2f40353ce77a6181e9908dea2cd75a1de80d80906ba1
   category: main
   optional: false
 - name: libarrow-acero
-  version: 15.0.2
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.2
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-15.0.2-h59595ed_1_cpu.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libarrow: 16.1.0
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-16.1.0-h5888daf_29_cpu.conda
   hash:
-    md5: b9423f0ec36b99f729aa890b6fb3c98d
-    sha256: 6bf96851b6451f5d3ede688d454a23e40e53bbceb1e56e6d30a538be451d126d
+    md5: a394dfa5772ed993426baf95eb535bcc
+    sha256: f39aa8f5d529652cd44f402482eb1b3c4be526e0faffd7f2b6c0d993eaf62b06
   category: main
   optional: false
 - name: libarrow-dataset
-  version: 15.0.2
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.2
-    libarrow-acero: 15.0.2
-    libgcc-ng: '>=12'
-    libparquet: 15.0.2
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-15.0.2-h59595ed_1_cpu.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libarrow: 16.1.0
+    libarrow-acero: 16.1.0
+    libgcc: '>=13'
+    libparquet: 16.1.0
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-16.1.0-h5888daf_29_cpu.conda
   hash:
-    md5: a921e87ad731a7cde36a016233c1b80b
-    sha256: 41610da5423d6f167791b9dcf670151d53dbe545092e95efafd68dbf4437e6b1
-  category: main
-  optional: false
-- name: libarrow-flight
-  version: 15.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libarrow: 15.0.2
-    libgcc-ng: '>=12'
-    libgrpc: '>=1.62.1,<1.63.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-    ucx: '>=1.15.0,<1.16.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-15.0.2-hc6145d9_1_cpu.conda
-  hash:
-    md5: a8166c3e9ff1222307cdd86af0234dbe
-    sha256: 0524b7b92b6d3ab5b043f5e3ea57291aec8fe69813191819bfd9e74bdcedfa1d
-  category: main
-  optional: false
-- name: libarrow-flight-sql
-  version: 15.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libarrow: 15.0.2
-    libarrow-flight: 15.0.2
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-15.0.2-h757c851_1_cpu.conda
-  hash:
-    md5: b59b90d6c8d2e072890f5d289f9ba36f
-    sha256: 5d2910012453c698657a2129c9d3337d4569d79a23cf93b40ada013777a04798
-  category: main
-  optional: false
-- name: libarrow-gandiva
-  version: 15.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libarrow: 15.0.2
-    libgcc-ng: '>=12'
-    libllvm16: '>=16.0.6,<16.1.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libstdcxx-ng: '>=12'
-    libutf8proc: '>=2.8.0,<3.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-15.0.2-hb016d2e_1_cpu.conda
-  hash:
-    md5: c595407620b1688599908bdc1c17fd74
-    sha256: 1e528b63285fd1918495e9b2ba83ece291ef0d53060b9120bb2af3591b53ffdd
+    md5: d9a344c5277c71d7cf875ace13fb0bca
+    sha256: 64209a090c15e83ec928ace2e34f4836d381ee929f1c9739aedf60dd5123a2fb
   category: main
   optional: false
 - name: libarrow-substrait
-  version: 15.0.2
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.2
-    libarrow-acero: 15.0.2
-    libarrow-dataset: 15.0.2
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libabseil: '>=20240116.2,<20240117.0a0'
+    libarrow: 16.1.0
+    libarrow-acero: 16.1.0
+    libarrow-dataset: 16.1.0
+    libgcc: '>=13'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-15.0.2-h757c851_1_cpu.conda
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-16.1.0-hf54134d_29_cpu.conda
   hash:
-    md5: 802e115e2c489e1c76c0fe809e766ccd
-    sha256: c4d7e0e2753eb193144b18ca78699d92da2a76011c3441952393ee672d1b9e32
+    md5: 2ca2bab8b89c7f5e2f61b2202f1e744c
+    sha256: c2006aa62e7e41bc6085941b8cf9e7fa9a063df4ddd2add58893fcce01add1ed
   category: main
   optional: false
 - name: libass
-  version: 0.17.1
+  version: 0.17.3
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     fontconfig: '>=2.14.2,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=8.1.1,<9.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
+    harfbuzz: '>=9.0.0,<10.0a0'
+    libexpat: '>=2.6.2,<3.0a0'
     libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
   hash:
-    md5: c306fd9cc90c0585171167d09135a827
-    sha256: 1bc3e44239a11613627488b7a9b6c021ec6b52c5925abd666832db0cb2a59f05
+    md5: 2a66267ba586dadd110cc991063cfff7
+    sha256: 52afd5e79681185ea33da0e7548aa3721be7e9a153a90f004c5adc33d61f7a14
   category: main
   optional: false
 - name: libavif16
-  version: 1.0.4
+  version: 1.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    aom: '>=3.8.1,<3.9.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    aom: '>=3.9.1,<3.10.0a0'
     dav1d: '>=1.2.1,<1.2.2.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     rav1e: '>=0.6.6,<1.0a0'
-    svt-av1: '>=1.8.0,<1.8.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.0.4-h1dcd450_1.conda
+    svt-av1: '>=2.3.0,<2.3.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-h1909e37_2.conda
   hash:
-    md5: be1c6d64adce7e3217fa24bdf2097263
-    sha256: 735a5737975a9872e270ac333c85d59d7336819f6540006d93123433617dbaec
+    md5: 21e468ed3786ebcb2124b123aa2484b7
+    sha256: e06da844b007a64a9ac35d4e3dc4dbc66583f79b57d08166cf58f2f08723a6e8
   category: main
   optional: false
 - name: libblas
@@ -5449,22 +5760,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.26,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_openblas.conda
+    libopenblas: '>=0.3.28,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
   hash:
-    md5: 0ac9f44fc096772b0aa092119b00c3ca
-    sha256: ebd5c91f029f779fb88a1fcbd1e499559a9c258e3674ff58a2fbb4e375ae56d9
-  category: main
-  optional: false
-- name: libboost-headers
-  version: 1.84.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_2.conda
-  hash:
-    md5: 85d30a3fcc0f1cfc252776208af546a1
-    sha256: 5a7843db33422d043256af27f288836f51530b058653bdb074704eb72282f601
+    md5: 8ea26d42ca88ec5258802715fe1ee10b
+    sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
   category: main
   optional: false
 - name: libbrotlicommon
@@ -5472,11 +5772,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
   hash:
-    md5: aec6c91c7371c26392a06708a73c70e5
-    sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
+    md5: 41b599ed2b02abcfdd84302bff174b23
+    sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
   category: main
   optional: false
 - name: libbrotlidec
@@ -5484,12 +5785,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libbrotlicommon: 1.1.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
   hash:
-    md5: f07002e225d7a60a694d42a7bf5ff53f
-    sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
+    md5: 9566f0bd264fbd463002e759b8a82401
+    sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
   category: main
   optional: false
 - name: libbrotlienc
@@ -5497,12 +5799,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libbrotlicommon: 1.1.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
   hash:
-    md5: 5fc11c6020d421960607d821310fcd4d
-    sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
+    md5: 06f70867945ea6a84d35836af780f1de
+    sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
   category: main
   optional: false
 - name: libcblas
@@ -5511,10 +5814,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
   hash:
-    md5: 4a3816d06451c4946e2db26b86472cb6
-    sha256: 467bbfbfe1a1aeb8b1f9f6485eedd8ed1b6318941bf3702da72336ccf4dc25a6
+    md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
+    sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
   category: main
   optional: false
 - name: libcrc32c
@@ -5531,46 +5834,49 @@ package:
   category: main
   optional: false
 - name: libcurl
-  version: 8.7.1
+  version: 8.10.1
   manager: conda
   platform: linux-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    krb5: '>=1.21.3,<1.22.0a0'
+    libgcc: '>=13'
     libnghttp2: '>=1.58.0,<2.0a0'
     libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.7.1-hca28451_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
   hash:
-    md5: 755c7f876815003337d2c61ff5d047e5
-    sha256: 82a75e9a5d9ee5b2f487d850ec5d4edc18a56eb9527608a95a916c40baae3843
+    md5: 6e801c50a40301f6978c53976917b277
+    sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
   category: main
   optional: false
 - name: libdeflate
-  version: '1.20'
+  version: '1.22'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
   hash:
-    md5: 8e88f9389f1165d7c0936fe40d9a9a79
-    sha256: f8e0f25c382b1d0b87a9b03887a34dbd91485453f1ea991fef726dba57373612
+    md5: b422943d5d772b7cc858b36ad2a92db5
+    sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
   category: main
   optional: false
 - name: libdrm
-  version: 2.4.120
+  version: 2.4.123
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=13'
     libpciaccess: '>=0.18,<0.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.120-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
   hash:
-    md5: 7c3071bdf1d28b331a06bda6e85ab607
-    sha256: 8622f52e517418ae7234081fac14a3caa8aec5d1ee5f881ca1f3b194d81c3150
+    md5: ee605e794bdc14e2b7f84c4faa0d8c2c
+    sha256: 5f274243fc7480b721a4ed6623c72d07b86a508a1363a85f0f16451ab655ace8
   category: main
   optional: false
 - name: libedit
@@ -5584,6 +5890,19 @@ package:
   hash:
     md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
     sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  category: main
+  optional: false
+- name: libegl
+  version: 1.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libglvnd: 1.7.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_1.conda
+  hash:
+    md5: 38a5cd3be5fb620b48069e27285f1a44
+    sha256: e64388e983cf14354b70fe908ca3943f2481ea63df8a4de5e4d418dc2addd38e
   category: main
   optional: false
 - name: libev
@@ -5612,15 +5931,16 @@ package:
   category: main
   optional: false
 - name: libexpat
-  version: 2.6.2
+  version: 2.6.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
   hash:
-    md5: e7ba12deb7020dd080c6c70e7b6f6a3d
-    sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
+    md5: 59f4c43bb1b5ef1c71946ff2cbf59524
+    sha256: 4bb47bb2cd09898737a5211e2992d63c555d63715a07ba56eae0aff31fb89c22
   category: main
   optional: false
 - name: libffi
@@ -5635,28 +5955,41 @@ package:
     sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
   category: main
   optional: false
-- name: libgcc-devel_linux-64
-  version: 12.3.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-12.3.0-h8bca6fd_105.conda
-  hash:
-    md5: e12ce6b051085b8f27e239f5e5f5bce5
-    sha256: ed2dfc6d959dc27e7668439e1ad31b127b43e99f9a7e77a2d34b958fa797316b
-  category: main
-  optional: false
-- name: libgcc-ng
-  version: 13.2.0
+- name: libgcc
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
     _libgcc_mutex: '0.1'
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
   hash:
-    md5: d4ff227c46917d3b4565302a2bbb276b
-    sha256: d32f78bfaac282cfe5205f46d558704ad737b8dbf71f9227788a5ca80facaba4
+    md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+    sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  category: main
+  optional: false
+- name: libgcc-devel_linux-64
+  version: 13.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-h84ea5a7_101.conda
+  hash:
+    md5: 0ce69d40c142915ac9734bc6134e514a
+    sha256: 027cfb011328a108bc44f512a2dec6d954db85709e0b79b748c3392f85de0c64
+  category: main
+  optional: false
+- name: libgcc-ng
+  version: 14.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc: 14.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  hash:
+    md5: e39480b9ca41323497b05492a63bc35b
+    sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
   category: main
   optional: false
 - name: libgd
@@ -5664,118 +5997,368 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    expat: ''
+    __glibc: '>=2.17,<3.0.a0'
     fontconfig: '>=2.14.2,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
+    icu: '>=75.1,<76.0a0'
+    libexpat: '>=2.6.2,<3.0a0'
     libgcc-ng: '>=12'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp: ''
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h119a65a_9.conda
+    libpng: '>=1.6.43,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-hd3e95f3_10.conda
   hash:
-    md5: cfebc557e54905dadc355c0e9f003004
-    sha256: b74f95a6e1f3b31a74741b39cba83ed99fc82d17243c0fd3b5ab16ddd48ab89d
+    md5: 30ee3a29c84cf7b842a8c5828c4b7c13
+    sha256: b0fa27d4d09fb24750c04e89dbd0aee898dc028bde99e62621065a9bde43efe8
   category: main
   optional: false
 - name: libgdal
-  version: 3.8.4
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgdal-core: 3.9.2.*
+    libgdal-fits: 3.9.2.*
+    libgdal-grib: 3.9.2.*
+    libgdal-hdf4: 3.9.2.*
+    libgdal-hdf5: 3.9.2.*
+    libgdal-jp2openjpeg: 3.9.2.*
+    libgdal-kea: 3.9.2.*
+    libgdal-netcdf: 3.9.2.*
+    libgdal-pdf: 3.9.2.*
+    libgdal-pg: 3.9.2.*
+    libgdal-postgisraster: 3.9.2.*
+    libgdal-tiledb: 3.9.2.*
+    libgdal-xls: 3.9.2.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.2-ha770c72_7.conda
+  hash:
+    md5: 63779711c7afd4fcf9cea67538baa67a
+    sha256: 33ae5aed64c19e3e7e50f0d1bbbd7abfe814687b2a350444c4b2867f81fca9b4
+  category: main
+  optional: false
+- name: libgdal-core
+  version: 3.9.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    blosc: '>=1.21.5,<2.0a0'
-    cfitsio: '>=4.4.0,<4.4.1.0a0'
-    freexl: '>=2.0.0,<3.0a0'
-    geos: '>=3.12.1,<3.12.2.0a0'
-    geotiff: '>=1.7.1,<1.8.0a0'
-    giflib: '>=5.2.1,<5.3.0a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    json-c: '>=0.17,<0.18.0a0'
-    kealib: '>=1.5.3,<1.6.0a0'
+    blosc: '>=1.21.6,<2.0a0'
+    geos: '>=3.13.0,<3.13.1.0a0'
+    geotiff: '>=1.7.3,<1.8.0a0'
+    giflib: '>=5.2.2,<5.3.0a0'
+    json-c: '>=0.18,<0.19.0a0'
     lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.3,<2.0a0'
-    libarchive: '>=3.7.2,<3.8.0a0'
-    libcurl: '>=8.6.0,<9.0a0'
-    libdeflate: '>=1.20,<1.21.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
-    libgcc-ng: '>=12'
+    libarchive: '>=3.7.4,<3.8.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libdeflate: '>=1.22,<1.23.0a0'
+    libexpat: '>=2.6.3,<3.0a0'
+    libgcc: '>=13'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
-    libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libpq: '>=16.2,<17.0a0'
+    libpng: '>=1.6.44,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.45.2,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libsqlite: '>=3.46.1,<4.0a0'
+    libstdcxx: '>=13'
+    libtiff: '>=4.7.0,<4.8.0a0'
     libuuid: '>=2.38.1,<3.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libxml2: '>=2.12.6,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libxml2: '>=2.12.7,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    pcre2: '>=10.43,<10.44.0a0'
-    poppler: '>=24.3.0,<24.4.0a0'
-    postgresql: ''
-    proj: '>=9.3.1,<9.3.2.0a0'
-    tiledb: '>=2.21.1,<2.22.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+    proj: '>=9.5.0,<9.6.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
     xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.8.4-h7c88fdf_5.conda
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.2-hd5b9bfb_7.conda
   hash:
-    md5: 750bfb344a8690e7089c8c2b303f252a
-    sha256: caad3fbd31a1572a5688d27bcf863acc36866eeaf73c4af67e5e40480e87772e
+    md5: a23eb349d023a8543752566be00b6d88
+    sha256: afff658dece6c8f4dbff2fc459bc834f8491e7ed1a491397e23280cf0917aa19
+  category: main
+  optional: false
+- name: libgdal-fits
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cfitsio: '>=4.4.1,<4.4.2.0a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.2-h2db6552_7.conda
+  hash:
+    md5: 524e64f1aa0ebc87230109e684f392f4
+    sha256: 156ae6b968301cc0ce51c96b60df594569a6df0caab0ac936d2532d09619e2fc
+  category: main
+  optional: false
+- name: libgdal-grib
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libaec: '>=1.1.3,<2.0a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.2-hc3b29a1_7.conda
+  hash:
+    md5: 56a7436a66a1a4636001ce4b621a3a33
+    sha256: 54937f8f0b85b941321324f350a9e1895b772153b70be64539689466899dd9b1
+  category: main
+  optional: false
+- name: libgdal-hdf4
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    hdf4: '>=4.2.15,<4.2.16.0a0'
+    libaec: '>=1.1.3,<2.0a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.2-hd5ecb85_7.conda
+  hash:
+    md5: 9c8431dc0b83d5fe9c12a2c0b6861a72
+    sha256: 0b8b77e609b72a51e9548e63c4423222515cd833ab5321eb7f283cf250bb00b5
+  category: main
+  optional: false
+- name: libgdal-hdf5
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.2-h6283f77_7.conda
+  hash:
+    md5: c8c82df3aece4e23804d178a8a8b308a
+    sha256: 0998f51e51086a56871538c803eb4e87eb404862a38ab0109e1dc78705491db2
+  category: main
+  optional: false
+- name: libgdal-jp2openjpeg
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libstdcxx: '>=13'
+    openjpeg: '>=2.5.2,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.2-h1b2c38e_7.conda
+  hash:
+    md5: f0f86f8cb8835bb91acb8c7fa2c350b0
+    sha256: 27068921e22565c71cca415211f0185154db3f1d070680790f5c3cc59bb376c7
+  category: main
+  optional: false
+- name: libgdal-kea
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    kealib: '>=1.5.3,<1.6.0a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libgdal-hdf5: 3.9.2.*
+    libkml: '>=1.3.0,<1.4.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.2-h1df15e4_7.conda
+  hash:
+    md5: c693e703649051ee9db0fabd4fcd0483
+    sha256: 252d6f9cc3bb2fa2788e73ce5c8a4587f653f9b1f1dc34ecc022ef4aa1b53bf0
+  category: main
+  optional: false
+- name: libgdal-netcdf
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    hdf4: '>=4.2.15,<4.2.16.0a0'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libgdal-hdf4: 3.9.2.*
+    libgdal-hdf5: 3.9.2.*
+    libkml: '>=1.3.0,<1.4.0a0'
+    libnetcdf: '>=4.9.2,<4.9.3.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.2-hf2d2f32_7.conda
+  hash:
+    md5: 4015ef020928219acc0b5c9edbce8d30
+    sha256: 58155b0df43b090ed55341c9b24e07047db9b4bd8889309a02180e99c4e69558
+  category: main
+  optional: false
+- name: libgdal-pdf
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libstdcxx: '>=13'
+    poppler: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.2-h600f43f_7.conda
+  hash:
+    md5: 567066db0820f4983a6741e429c651d1
+    sha256: 10ebe0047d4300152185c095a74a3159fcc3b3d2b0e0bb111381dc7d018cbf65
+  category: main
+  optional: false
+- name: libgdal-pg
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libpq: '>=17.0,<18.0a0'
+    libstdcxx: '>=13'
+    postgresql: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.2-h5e77dd0_7.conda
+  hash:
+    md5: e86b26f53ae868565e95fde5b10753d3
+    sha256: 24bebc7b479dc2373739655a4e8e4142d47d64b37dd5529fdf87dfc2e7586cc4
+  category: main
+  optional: false
+- name: libgdal-postgisraster
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libpq: '>=17.0,<18.0a0'
+    libstdcxx: '>=13'
+    postgresql: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.2-h5e77dd0_7.conda
+  hash:
+    md5: 3392965ffc4e8b7c66a532750ce0e91f
+    sha256: cfa1968d15e1e4ab94c74a426c55795bd2b702bd9e99767cb74633dfba77afbc
+  category: main
+  optional: false
+- name: libgdal-tiledb
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libstdcxx: '>=13'
+    tiledb: '>=2.26.1,<2.27.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.2-h4a3bace_5.conda
+  hash:
+    md5: 4361660d9babee02d729bff61eb50cbe
+    sha256: 87cd6b33baf87a46096d8c03edeb4e93d742a1367c7bfb361198bcf87b627ee8
+  category: main
+  optional: false
+- name: libgdal-xls
+  version: 3.9.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    freexl: '>=2.0.0,<3.0a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9'
+    libkml: '>=1.3.0,<1.4.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.2-h03c987c_7.conda
+  hash:
+    md5: 165f12373452e8d17889e9c877431acf
+    sha256: 363f00ff7b5295a65e918c5f96bcd8fd3daba09fd8d6563de7b7d266144f86e5
+  category: main
+  optional: false
+- name: libgfortran
+  version: 14.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgfortran5: 14.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  hash:
+    md5: f1fd30127802683586f768875127a987
+    sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
   category: main
   optional: false
 - name: libgfortran-ng
-  version: 13.2.0
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgfortran5: 13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
+    libgfortran: 14.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
   hash:
-    md5: e73e9cfd1191783392131e6238bdb3e9
-    sha256: 238c16c84124d58307376715839aa152bd4a1bf5a043052938ad6c3137d30245
+    md5: 0a7f4cd238267c88e5d69f7826a407eb
+    sha256: 423f1e2403f0c665748e42d335e421e53fd03c08d457cfb6f360d329d9459851
   category: main
   optional: false
 - name: libgfortran5
-  version: 13.2.0
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=13.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
+    libgcc: '>=14.2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
   hash:
-    md5: 7a6bd7a12a4bd359e2afe6c0fa1acace
-    sha256: ba8d94e8493222ce155bb264d9de4200e41498a458e866fedf444de809bde8b6
+    md5: 9822b874ea29af082e5d36098d25427d
+    sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+  category: main
+  optional: false
+- name: libgl
+  version: 1.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libglvnd: 1.7.0
+    libglx: 1.7.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_1.conda
+  hash:
+    md5: 204892bce2e44252b5cf272712f10bdd
+    sha256: 2de573a2231d0ffa13242e274d33b7bae88fb0a178392fd4a03cf803a47e4051
   category: main
   optional: false
 - name: libglib
-  version: 2.80.0
+  version: 2.82.2
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    pcre2: '>=10.43,<10.44.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.0-hf2295e7_1.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
   hash:
-    md5: 0725f6081030c29b109088639824ff90
-    sha256: 636d984568a1e5d915098a5020712f82bb3988635015765c3caf70f1a91340c5
+    md5: 13e8e54035ddd2b91875ba399f0f7c04
+    sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
   category: main
   optional: false
 - name: libglu
@@ -5785,97 +6368,126 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    xorg-libx11: '>=1.8.6,<2.0a0'
+    libxcb: '>=1.16,<2.0.0a0'
+    xorg-libx11: '>=1.8.9,<2.0a0'
     xorg-libxext: '>=1.3.4,<2.0a0'
     xorg-xextproto: '>=7.3.0,<8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
   hash:
-    md5: 50c389a09b6b7babaef531eb7cb5e0ca
-    sha256: 8368435c41105dc3e1c02896a02ecaa21b77d0b0d67fc8b06a16ba885c86f917
+    md5: df069bea331c8486ac21814969301c1f
+    sha256: c4a14878c2be8c18b7e89a19917f0f6c964dd962c91a079fe5e0c6e8b8b1bbd4
+  category: main
+  optional: false
+- name: libglvnd
+  version: 1.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_1.conda
+  hash:
+    md5: 1ece2ccb1dc8c68639712b05e0fae070
+    sha256: 67942c2b6e4ddb705640b5db962e678f17d8305df5c1633e939cef1158a95058
+  category: main
+  optional: false
+- name: libglx
+  version: 1.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libglvnd: 1.7.0
+    xorg-libx11: '>=1.8.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_1.conda
+  hash:
+    md5: 80a57756c545ad11f9847835aa21e6b2
+    sha256: facc239145719034f7b8815d9630032e701d26534dae28303cdbae8b19590a82
   category: main
   optional: false
 - name: libgomp
-  version: 13.2.0
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
     _libgcc_mutex: '0.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
   hash:
-    md5: d211c42b9ce49aee3734fdc828731689
-    sha256: 0d3d4b1b0134283ea02d58e8eb5accf3655464cf7159abf098cc694002f8d34e
+    md5: cc3573974587f12dda90d96e3e55a702
+    sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.22.0
+  version: 2.29.0
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libgrpc: '>=1.62.0,<1.63.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libabseil: '>=20240116.2,<20240117.0a0'
+    libcurl: '>=8.9.1,<9.0a0'
+    libgcc: '>=13'
+    libgrpc: '>=1.62.2,<1.63.0a0'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.22.0-h9be4e54_1.conda
+    libstdcxx: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.29.0-h435de7b_0.conda
   hash:
-    md5: 4b4e36a91e7dabf7345b82d85767a7c3
-    sha256: b9980209438b22113f4352df2b260bf43b2eb63a7b6325192ec5ae3a562872ed
+    md5: 5d95d9040c4319997644f68e9aefbe70
+    sha256: c8ee42a4acce5227d220ec6500f6872d52d82e478c76648b9ff57dd2d86429bd
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 2.22.0
+  version: 2.29.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libabseil: ''
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
-    libgcc-ng: '>=12'
-    libgoogle-cloud: 2.22.0
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libgcc: '>=13'
+    libgoogle-cloud: 2.29.0
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.22.0-hc7a4891_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.29.0-h0121fbd_0.conda
   hash:
-    md5: 7811f043944e010e54640918ea82cecd
-    sha256: 0e00e1ca2a981db1c96071edf266bc29fd6f13ac484225de1736fc4dac5c64a8
+    md5: 06dfd5208170b56eee943d9ac674a533
+    sha256: 2847c9e940b742275a7068e0a742bdabf211bf0b2bbb1453592d6afb47c7e17e
   category: main
   optional: false
 - name: libgrpc
-  version: 1.62.1
+  version: 1.62.2
   manager: conda
   platform: linux-64
   dependencies:
-    c-ares: '>=1.27.0,<2.0a0'
+    c-ares: '>=1.28.1,<2.0a0'
     libabseil: '>=20240116.1,<20240117.0a0'
     libgcc-ng: '>=12'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
+    libre2-11: '>=2023.9.1'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
     openssl: '>=3.2.1,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.1-h15f2491_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.2-h15f2491_0.conda
   hash:
-    md5: 564517a8cbd095cff75eb996d33d2b7e
-    sha256: 1d4ece94dfef73d904dcba0fd9d56098796f5fdc62ea5f9edff60c71be7a3d63
+    md5: 8dabe607748cb3d7002ad73cd06f1325
+    sha256: 28241ed89335871db33cb6010e9ccb2d9e9b6bb444ddf6884f02f0857363c06a
   category: main
   optional: false
 - name: libhwloc
-  version: 2.9.3
+  version: 2.11.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.11.5,<3.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libxml2: '>=2.12.7,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_he43201b_1000.conda
   hash:
-    md5: f36ddc11ca46958197a45effdd286e45
-    sha256: 6950fee24766d03406e0f6f965262a5d98829c71eed8d1004f313892423b559b
+    md5: 36247217c4e1018085bd9db41eb3526a
+    sha256: 75be8732e6f94ff2faa129f44ec4970275e1d977559b0c2fb75b7baa5347e16b
   category: main
   optional: false
 - name: libhwy
@@ -5903,20 +6515,6 @@ package:
     sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
   category: main
   optional: false
-- name: libidn2
-  version: 2.3.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    libgcc-ng: '>=12'
-    libunistring: '>=0,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
-  hash:
-    md5: 2b7b0d827c6447cc1d85dc06d5b5de46
-    sha256: 253f9be445c58bf07b39d8f67ac08bccc5010c75a8c2070cddfb6c20e1ca4f4f
-  category: main
-  optional: false
 - name: libjpeg-turbo
   version: 3.0.0
   manager: conda
@@ -5930,19 +6528,20 @@ package:
   category: main
   optional: false
 - name: libjxl
-  version: 0.10.1
+  version: 0.11.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     libhwy: '>=1.1.0,<1.2.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.10.1-hcae5a98_1.conda
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.0-hdb8da77_2.conda
   hash:
-    md5: ca9532696d031f78d1dc245c413823d4
-    sha256: da25dc6ac688fbd90ba36dbf44c8b02be582fdaaf0cd66f9ea64bb7dce5c40d8
+    md5: 9c4554fafc94db681543804037e65de2
+    sha256: ea50bc2d3cb87c667decdde55100faca6a9b7c59bd6792690c53950660bbce57
   category: main
   optional: false
 - name: libkml
@@ -5950,16 +6549,16 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libboost-headers: ''
-    libexpat: '>=2.5.0,<3.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    uriparser: '>=0.9.7,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-h01aab08_1018.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libexpat: '>=2.6.2,<3.0a0'
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    uriparser: '>=0.9.8,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
   hash:
-    md5: 3eb5f16bcc8a02892199aa63555c731f
-    sha256: f67fc0be886c7eac14dbce858bfcffbc90a55b598e897e513f0979dd2caad750
+    md5: e8c7620cc49de0c6a2349b6dd6e39beb
+    sha256: 721c3916d41e052ffd8b60e77f2da6ee47ff0d18babfca48ccf93606f1e0656a
   category: main
   optional: false
 - name: liblapack
@@ -5968,10 +6567,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
   hash:
-    md5: 1a42f305615c3867684e049e85927531
-    sha256: 64b5c35dce00dd6f9f53178b2fe87116282e00967970bd6551a5a42923806ded
+    md5: 4dc03a53fc69371a6158d0ed37214cd3
+    sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
   category: main
   optional: false
 - name: libllvm14
@@ -5981,27 +6580,11 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
   hash:
     md5: 73301c133ded2bf71906aa2104edae8b
     sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
-  category: main
-  optional: false
-- name: libllvm16
-  version: 16.0.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.1,<3.0.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm16-16.0.6-hb3ce162_3.conda
-  hash:
-    md5: a4d48c40dd5c60edbab7fd69c9a88967
-    sha256: 624fa4012397bc5a8c9269247bf9baa7d907eb59079aefc6f6fa6a40f10fd0ba
   category: main
   optional: false
 - name: libnetcdf
@@ -6013,51 +6596,38 @@ package:
     bzip2: '>=1.0.8,<2.0a0'
     hdf4: '>=4.2.15,<4.2.16.0a0'
     hdf5: '>=1.14.3,<1.14.4.0a0'
-    libaec: '>=1.1.2,<2.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
+    libaec: '>=1.1.3,<2.0a0'
+    libcurl: '>=8.8.0,<9.0a0'
     libgcc-ng: '>=12'
-    libpnetcdf: '>=1.12.3,<1.12.4.0a0'
     libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.2,<3.0.0a0'
+    libxml2: '>=2.12.7,<3.0a0'
     libzip: '>=1.10.1,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    mpich: '>=4.1.2,<5.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    libzlib: '>=1.2.13,<2.0a0'
+    openssl: '>=3.3.1,<4.0a0'
     zlib: ''
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-mpi_mpich_h60ccfc9_13.conda
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h135f659_114.conda
   hash:
-    md5: faabb8b346434d9aebdc3f96ee223a6b
-    sha256: 9bc17adcacb3dfab580f17001c4f336ba974b94f85704eae82e2bd79c4a9d204
+    md5: a908e463c710bd6b10a9eaa89fdf003c
+    sha256: 055572a4c8a1c3f9ac60071ee678f5ea49cfd7ac60a636d817988a6f9d6de6ae
   category: main
   optional: false
 - name: libnghttp2
-  version: 1.58.0
+  version: 1.64.0
   manager: conda
   platform: linux-64
   dependencies:
-    c-ares: '>=1.23.0,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    c-ares: '>=1.32.3,<2.0a0'
     libev: '>=4.33,<5.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
   hash:
-    md5: 700ac6ea6d53d5510591c4344d5c989a
-    sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
-  category: main
-  optional: false
-- name: libnl
-  version: 3.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.9.0-hd590300_0.conda
-  hash:
-    md5: d27c451db4f1d3c983c78167d2fdabc2
-    sha256: aae03117811e704c3f3666e8374dd2e632f1d78bef0c27330e7298b24004819e
+    md5: 19e57602824042dfd0446292ef90488b
+    sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
   category: main
   optional: false
 - name: libnsl
@@ -6072,201 +6642,243 @@ package:
     sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   category: main
   optional: false
-- name: libopenblas
-  version: 0.3.26
+- name: libntlm
+  version: '1.4'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
+    libgcc-ng: '>=9.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.4-h7f98852_1002.tar.bz2
   hash:
-    md5: 760ae35415f5ba8b15d09df5afe8b23a
-    sha256: b626954b5a1113dafec8df89fa8bf18ce9b4701464d9f084ddd7fc9fac404bbd
+    md5: e728e874159b042d92b90238a3cb0dc2
+    sha256: 63244b73156033ea3b7c2a1581526e79b4670349d64b15f645dcdb12de441d1a
+  category: main
+  optional: false
+- name: libopenblas
+  version: 0.3.28
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=14'
+    libgfortran-ng: ''
+    libgfortran5: '>=14.1.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_0.conda
+  hash:
+    md5: 9ebc9aedafaa2515ab247ff6bb509458
+    sha256: 1e41a6d63e07be996238a1e840a426f86068956a45e0c0bb24e49a8dad9874c1
   category: main
   optional: false
 - name: libopenvino
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.11.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.0.0-h2e90f83_4.conda
+    tbb: '>=2021.13.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_0.conda
   hash:
-    md5: 126a2a61d276c4268f71adeef25bfc33
-    sha256: 901d6a974cf86c96f5ec29e7ef0e3a3bcf128ad9f48ee65d244d796512c2c8f5
+    md5: a9048b1af0374fe0b5fa4c25bb8d22ca
+    sha256: 34579cc1ce59efe1560d17e6ec86fe07936b10858d2883f3a66f2bb496163a1b
   category: main
   optional: false
 - name: libopenvino-auto-batch-plugin
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
-    libstdcxx-ng: '>=12'
-    tbb: '>=2021.11.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.0.0-hd5fc58b_4.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
+    libstdcxx: '>=13'
+    tbb: '>=2021.13.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_0.conda
   hash:
-    md5: de9c380fea8634540db5fc8422888df1
-    sha256: 7997f2e1e24d79dbecbc7a275a0aef495cdb25018b19ab982b23147cfe80f659
+    md5: 52c847d170f613afb0841c5ec1f87b78
+    sha256: 976a5e703d2d3f94daa3aa9c00a8f47c28b038d20f421bf21114abfd8e0cbf58
   category: main
   optional: false
 - name: libopenvino-auto-plugin
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
-    libstdcxx-ng: '>=12'
-    tbb: '>=2021.11.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.0.0-hd5fc58b_4.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
+    libstdcxx: '>=13'
+    tbb: '>=2021.13.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_0.conda
   hash:
-    md5: de1cbf145ecdc1d29af18e14eb267bca
-    sha256: 1ec1dc0cf9aa4e1879145f0d8645d6132d19e7f8ea0a678b500ee96a110527e7
+    md5: f6335f9d947ba550ada90cf101b6232c
+    sha256: 605faab60844c8e044005dc80a4e18e3d6ca98c905d4e6065606a34220bcce0c
   category: main
   optional: false
 - name: libopenvino-hetero-plugin
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
+    libstdcxx: '>=13'
     pugixml: '>=1.14,<1.15.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.0.0-h3ecfda7_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_0.conda
   hash:
-    md5: 016b763e4776b4c2c536420a7e6a2349
-    sha256: 6b530d036bf3a608c6cae2de4ab8f7e9471b53603c63b10d0a04c211e3325b1f
+    md5: cc7f76fdcc00ecb9aab668b8c956cc8d
+    sha256: af9c55da6c25f921973c9001c8893d643ddad399c8da81342ff2033a297055be
   category: main
   optional: false
 - name: libopenvino-intel-cpu-plugin
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
+    libstdcxx: '>=13'
     pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.11.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.0.0-h2e90f83_4.conda
+    tbb: '>=2021.13.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_0.conda
   hash:
-    md5: d866cc8dc37f101505e65a4372794631
-    sha256: 2daa2f6fc584674adee84b036a9a267a6bcae731c912326efda155f2328586d8
+    md5: 9b47c0e151ce7e2b6169ab8e3d18f9d8
+    sha256: c8676331577475bd2602a898fed2d4855695723fbb602fa554b34873b694a7ed
   category: main
   optional: false
 - name: libopenvino-intel-gpu-plugin
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
+    libstdcxx: '>=13'
     ocl-icd: '>=2.3.2,<3.0a0'
     pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.11.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.0.0-h2e90f83_4.conda
+    tbb: '>=2021.13.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_0.conda
   hash:
-    md5: 6ebefdc74cb700ec82cd6702125cc422
-    sha256: 15f0ad9ea10829d8964253b08667af015dfa4befa0afd2e6f3a44110f6efcb96
+    md5: 5b85313c114e1e681b5878c4fbf640b3
+    sha256: d37210cbcb345b95ffd246c9b04669beaa31740c57bf1e9ff131588dec2bbafa
+  category: main
+  optional: false
+- name: libopenvino-intel-npu-plugin
+  version: 2024.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
+    libstdcxx: '>=13'
+    pugixml: '>=1.14,<1.15.0a0'
+    tbb: '>=2021.13.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_0.conda
+  hash:
+    md5: 2f4a881f43dd916fe71be85848440584
+    sha256: bf74978afa331b27079f0973081c2a1cd3e12ebcee0cc1545b7e400770130879
   category: main
   optional: false
 - name: libopenvino-ir-frontend
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
+    libstdcxx: '>=13'
     pugixml: '>=1.14,<1.15.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.0.0-h3ecfda7_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_0.conda
   hash:
-    md5: 6397395a4677d59bbd32c4f05bb8fa63
-    sha256: 09c91b8701764154b41a2c82d0412939e5625c712edfe965496930cdad6c822e
+    md5: e58bb393b3e13eae8c472a962748750f
+    sha256: 4e3391075bb992d6ac686ec276952677b0d176b2ed07a583042eff64dd2976a3
   category: main
   optional: false
 - name: libopenvino-onnx-frontend
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.0.0-h757c851_4.conda
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h56242b0_0.conda
   hash:
-    md5: 24c9cf1dd8f6d6189102a136a731758c
-    sha256: c29f5bead57bfb14cca7bd89e20f13eb18ec9a4624dcff1d56834454deb3be9c
+    md5: bc2d0913d22b2f30e441036542dfc5e9
+    sha256: a119277dff41843d9967c77756d1fcba7e17f7fa65977762d6c32d71214da917
   category: main
   optional: false
 - name: libopenvino-paddle-frontend
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.0.0-h757c851_4.conda
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h56242b0_0.conda
   hash:
-    md5: 259bd0c788f447fe78aab69895365528
-    sha256: cc16cf9103d57d14a4f65b0148ae6197ced75063bebb07533744a1f0675ef294
+    md5: 9b97741337ad0c7df240498c5bc3e69f
+    sha256: 3c984a74c06720f9eed0cb4e7c4370470f635c8c5e148aac1517cb51b074ac54
   category: main
   optional: false
 - name: libopenvino-pytorch-frontend
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.0.0-h59595ed_4.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_0.conda
   hash:
-    md5: ec121a4195acadad086f84719cc91430
-    sha256: 2f032e4cec7d24f80ea932c99b0fea896fbf1e4a202453b71b50bc6980d0cfae
+    md5: 4188f0bb601163c25ed8cd515324358c
+    sha256: 314b476ded8c7de2e42911ad6a5a0957e0ceb8b4d99a99caf552f18e69973dde
   category: main
   optional: false
 - name: libopenvino-tensorflow-frontend
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
+    __glibc: '>=2.17,<3.0.a0'
+    libabseil: '>=20240116.2,<20240117.0a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-    snappy: '>=1.1.10,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.0.0-hca94c1a_4.conda
+    libstdcxx: '>=13'
+    snappy: '>=1.2.1,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h358ae18_0.conda
   hash:
-    md5: bdbf11f760f1a3b35d766e03cebd9c42
-    sha256: 3037418cbf5e14964e4c4909ac4f15729db29e990b57d3b2d0b7cf6b0186a3d7
+    md5: 5fbd3f499da9d147ed5417a6f7e24d83
+    sha256: f348f0d569dfba6c8e7b9bfff16f244da1f26b1f7ce1001245e1fb8b0af1dc6b
   category: main
   optional: false
 - name: libopenvino-tensorflow-lite-frontend
-  version: 2024.0.0
+  version: 2024.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: 2024.0.0
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.0.0-h59595ed_4.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libopenvino: 2024.4.0
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_0.conda
   hash:
-    md5: 4354ea9f30a8c5111403fa4b24a2ad66
-    sha256: 792f3a7de81b92a85339082008281dc03359c64ab10d9a93c71856fbefac8333
+    md5: bffe380c0f0d813bdf7e35445cf11f2a
+    sha256: 6990ea69c92e0f48f3628b753f42919d6201ca1d53c2434750d46b0f7af7b3dd
   category: main
   optional: false
 - name: libopus
@@ -6282,19 +6894,20 @@ package:
   category: main
   optional: false
 - name: libparquet
-  version: 15.0.2
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.2
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libthrift: '>=0.19.0,<0.19.1.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-15.0.2-h352af49_1_cpu.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libarrow: 16.1.0
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libthrift: '>=0.20.0,<0.20.1.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-16.1.0-h39682fd_29_cpu.conda
   hash:
-    md5: 9c9171bf3a477a585d08a7979f84c3b8
-    sha256: 3561887d5cecd273ca4a40c7263b0b81b9fcb7d14c54fe83c1f691b86c1c6b6f
+    md5: 3fc2cb985cf9b5c3931e907f65bd8926
+    sha256: b02f94949b47df47f1521384ca999a77b94dcfaefbabb8ee63615923b00cdde7
   category: main
   optional: false
 - name: libpciaccess
@@ -6309,47 +6922,57 @@ package:
     sha256: c0a30ac74eba66ea76a4f0a39acc7833f5ed783a632ca3bb6665b2d81aabd2fb
   category: main
   optional: false
-- name: libpnetcdf
-  version: 1.12.3
+- name: libpdal-core
+  version: 2.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-    libstdcxx-ng: '>=12'
-    mpich: '>=4.1.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpnetcdf-1.12.3-mpi_mpich_h4ac58e2_101.conda
+    __glibc: '>=2.17,<3.0.a0'
+    geotiff: '>=1.7.3,<1.8.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9.2,<3.10.0a0'
+    libstdcxx: '>=13'
+    libxml2: '>=2.12.7,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+    proj: '>=9.5.0,<9.6.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpdal-core-2.8.0-h8f62525_3.conda
   hash:
-    md5: c5383c05b6ad083e3dae1bc1cecf014a
-    sha256: de6ebf584c20f32d2b9ddaa87fbe0c6016e047373a9afd97eb667d2dccd7be21
+    md5: a9b58e36eee9eda99300339ecfc157d2
+    sha256: d87228b0a5f1de21d15a2e27e2ddcf0ab710d431470784d827c3659732f55200
   category: main
   optional: false
 - name: libpng
-  version: 1.6.43
+  version: 1.6.44
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
   hash:
-    md5: 009981dd9cfcaa4dbfa25ffaed86bcae
-    sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
+    md5: f4cc49d7aa68316213e4b12be35308d1
+    sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
   category: main
   optional: false
 - name: libpq
-  version: '16.2'
+  version: '17.0'
   manager: conda
   platform: linux-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=75.1,<76.0a0'
+    krb5: '>=1.21.3,<1.22.0a0'
+    libgcc: '>=13'
+    openldap: '>=2.6.8,<2.7.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.0-h04577a9_4.conda
   hash:
-    md5: 9e49ec2a61d02623b379dc332eb6889d
-    sha256: e03a8439b79e013840c44c957d37dbce10316888b2b5dc7dcfcfc0cfe3a3b128
+    md5: 392cae2a58fbcb9db8c2147c6d6d1620
+    sha256: 2f7e72e32f495cfb0492b8091d97dbe1c0700428fe167f3a781bb46e88dee4e5
   category: main
   optional: false
 - name: libprotobuf
@@ -6357,14 +6980,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libabseil: '>=20240116.2,<20240117.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-hd5b35b9_1.conda
   hash:
-    md5: 6945825cebd2aeb16af4c69d97c32c13
-    sha256: 70e0eef046033af2e8d21251a785563ad738ed5281c74e21c31c457780845dcd
+    md5: 06def97690ef90781a91b786cb48a0a9
+    sha256: 8b5e4e31ed93bf36fd14e9cf10cd3af78bb9184d0f1f87878b8d28c0374aa4dc
   category: main
   optional: false
 - name: libre2-11
@@ -6382,21 +7006,24 @@ package:
   category: main
   optional: false
 - name: librsvg
-  version: 2.56.3
+  version: 2.58.4
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.0,<2.0a0'
-    gdk-pixbuf: '>=2.42.10,<3.0a0'
-    gettext: '>=0.21.1,<1.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.1,<3.0a0'
-    libxml2: '>=2.12.1,<3.0.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.56.3-he3f83f7_1.conda
+    freetype: '>=2.12.1,<3.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    harfbuzz: '>=9.0.0,<10.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.80.3,<3.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libxml2: '>=2.12.7,<3.0a0'
+    pango: '>=1.54.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
   hash:
-    md5: 03bd1ddcc942867a19528877143b9852
-    sha256: b82d0c60376da88a2bf15d35d17c176aa923917ad7de4bc62ddef6d02f3518fb
+    md5: 83f045969988f5c7a65f3950b95a8b35
+    sha256: fda3197ffb24512e719d55defa02f9f70286038e56cad8c1d580ed6460f417fa
   category: main
   optional: false
 - name: librttopo
@@ -6404,50 +7031,39 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    geos: '>=3.12.1,<3.12.2.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h8917695_15.conda
+    __glibc: '>=2.17,<3.0.a0'
+    geos: '>=3.13.0,<3.13.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
   hash:
-    md5: 20c3c14bc491f30daecaa6f73e2223ae
-    sha256: 03e248787162a1804683c614c0681c2488fa6d9f353cb32e2f8c1158157165ea
+    md5: e16e9b1333385c502bf915195f421934
+    sha256: 1fb8a71bdbc236b8e74f0475887786735d5fa6f5d76d9a4135021279c7ff54b8
   category: main
   optional: false
 - name: libsanitizer
-  version: 12.3.0
+  version: 13.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_5.conda
+    libgcc: '>=13.3.0'
+    libstdcxx: '>=13.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-heb74ff8_1.conda
   hash:
-    md5: 11d1ceacff40054d5a74b12975d76f20
-    sha256: 70329cb8b0604273521cdae63520cb364a8d5477e156e65cdbd810984caeabee
+    md5: c4cb22f270f501f5c59a122dc2adf20a
+    sha256: c86d130f0a3099e46ff51aa7ffaab73cb44fc420d27a96076aab3b9a326fc137
   category: main
   optional: false
 - name: libsodium
-  version: 1.0.18
+  version: 1.0.20
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
   hash:
-    md5: c3788462a6fbddafdb413a9f9053e58d
-    sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
-  category: main
-  optional: false
-- name: libspatialindex
-  version: 1.9.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-    libstdcxx-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialindex-1.9.3-h9c3ff4c_4.tar.bz2
-  hash:
-    md5: d87fbe9c0ff589e802ff13872980bfd9
-    sha256: 588fbd0c11bc44e354365d5f836183216a4ed17d680b565ff416a93b839f1a8b
+    md5: a587892d3c13b6621a6091be690dbca2
+    sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
   category: main
   optional: false
 - name: libspatialite
@@ -6455,34 +7071,36 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     freexl: '>=2.0.0,<3.0a0'
-    geos: '>=3.12.1,<3.12.2.0a0'
-    libgcc-ng: '>=12'
+    geos: '>=3.13.0,<3.13.1.0a0'
+    libgcc: '>=13'
     librttopo: '>=1.1.0,<1.2.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.2,<3.0.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    proj: '>=9.3.1,<9.3.2.0a0'
+    libsqlite: '>=3.46.1,<4.0a0'
+    libstdcxx: '>=13'
+    libxml2: '>=2.12.7,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    proj: '>=9.5.0,<9.6.0a0'
     sqlite: ''
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h7bd4643_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
   hash:
-    md5: 127d36f9ee392fa81b45e81867ce30ab
-    sha256: 2d07badb81296f42dd0c59b02dbf7d64ca2c78c086226327c1e11e11f71effbd
+    md5: 43a7f3df7d100e8fc280e6636680a870
+    sha256: 11d8537d472c5fc25176fda7af6b9aa47f37ba98d0467b77cb713be18ed847ea
   category: main
   optional: false
 - name: libsqlite
-  version: 3.45.2
+  version: 3.47.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
   hash:
-    md5: 866983a220e27a80cb75e85cb30466a1
-    sha256: 8cdbeb7902729e319510a82d7c642402981818702b58812af265ef55d1315473
+    md5: b6f02b52a174e612e89548f4663ce56a
+    sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
   category: main
   optional: false
 - name: libssh2
@@ -6491,7 +7109,7 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
     openssl: '>=3.1.1,<4.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
   hash:
@@ -6499,75 +7117,66 @@ package:
     sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
   category: main
   optional: false
-- name: libstdcxx-ng
-  version: 13.2.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
-  hash:
-    md5: f6f6600d18a4047b54f803cf708b868a
-    sha256: a56c5b11f1e73a86e120e6141a42d9e935a99a2098491ac9e15347a1476ce777
-  category: main
-  optional: false
-- name: libtasn1
-  version: 4.19.0
+- name: libstdcxx
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
+    libgcc: 14.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
   hash:
-    md5: 93840744a8552e9ebf6bb1a5dffc125a
-    sha256: 5bfeada0e1c6ec2574afe2d17cdbc39994d693a41431338a6cb9dfa7c4d7bfc8
+    md5: 234a5554c53625688d51062645337328
+    sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+  category: main
+  optional: false
+- name: libstdcxx-ng
+  version: 14.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libstdcxx: 14.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  hash:
+    md5: 8371ac6457591af2cf6159439c1fd051
+    sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
   category: main
   optional: false
 - name: libthrift
-  version: 0.19.0
+  version: 0.20.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libevent: '>=2.1.12,<2.1.13.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.20.0-h0e7cc3e_1.conda
   hash:
-    md5: 8cdb7d41faa0260875ba92414c487e2d
-    sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
+    md5: d0ed81c4591775b70384f4cc78e05cd1
+    sha256: 3e70dfda31a3ce28310c86cc0001f20abb78c917502e12c94285a1337fe5b9f0
   category: main
   optional: false
 - name: libtiff
-  version: 4.6.0
+  version: 4.7.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.20,<1.21.0a0'
-    libgcc-ng: '>=12'
+    libdeflate: '>=1.22,<1.23.0a0'
+    libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libstdcxx: '>=13'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
   hash:
-    md5: 66f03896ffbe1a110ffda05c7a856504
-    sha256: fc3b210f9584a92793c07396cb93e72265ff3f1fa7ca629128bf0a50d5cb15e4
-  category: main
-  optional: false
-- name: libunistring
-  version: 0.9.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
-  hash:
-    md5: 7245a044b4a1980ed83196176b78b73a
-    sha256: e88c45505921db29c08df3439ddb7f771bbff35f95e7d3103bf365d5d6ce2a6d
+    md5: 63872517c98aa305da58a757c443698e
+    sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
   category: main
   optional: false
 - name: libutf8proc
@@ -6595,75 +7204,67 @@ package:
   category: main
   optional: false
 - name: libva
-  version: 2.21.0
+  version: 2.22.0
   manager: conda
   platform: linux-64
   dependencies:
-    libdrm: '>=2.4.120,<2.5.0a0'
-    xorg-libx11: '>=1.8.7,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libdrm: '>=2.4.123,<2.5.0a0'
+    libegl: '>=1.7.0,<2.0a0'
+    libgcc: '>=13'
+    libgl: '>=1.7.0,<2.0a0'
+    libglx: '>=1.7.0,<2.0a0'
+    libxcb: '>=1.16,<2.0.0a0'
+    wayland: '>=1.23.1,<2.0a0'
+    wayland-protocols: ''
+    xorg-libx11: '>=1.8.9,<2.0a0'
     xorg-libxext: '>=1.3.4,<2.0a0'
     xorg-libxfixes: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.21.0-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
   hash:
-    md5: e50a2609159a3e336fe4092738c00687
-    sha256: b4e3a3fa523a5ddd1eca7981c9d6a9b831a182950116cc5bda18c94a040b63bc
+    md5: 139262125a3eac8ff6eef898598745a3
+    sha256: 0bd81019e02cce8d9d4077c96b82ca03c9b0ece67831c7437f977ca1f5a924a3
   category: main
   optional: false
 - name: libvpx
-  version: 1.14.0
+  version: 1.14.1
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.0-h59595ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
   hash:
-    md5: 01c76c6d71097a0f3bd8683a8f255123
-    sha256: b0e0500fc92f626baaa2cf926dece5ce7571c42a2db2d993a250d4c5da4d68ca
-  category: main
-  optional: false
-- name: libwebp
-  version: 1.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    giflib: '>=5.2.1,<5.3.0a0'
-    libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-1.3.2-h658648e_1.conda
-  hash:
-    md5: 0ebb65e8d86843865796c7c95a941f34
-    sha256: cc5e55531d8067ea379b145861aea8c749a545912bc016372f5e3c69cc925efd
+    md5: cde393f461e0c169d9ffb2fc70f81c33
+    sha256: e7d2daf409c807be48310fcc8924e481b62988143f582eb3a58c5523a6763b13
   category: main
   optional: false
 - name: libwebp-base
-  version: 1.3.2
+  version: 1.4.0
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
   hash:
-    md5: 30de3fd9b3b602f7473f30e684eeea8c
-    sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
+    md5: b26e8aa824079e1be0294e7152ca4559
+    sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
   category: main
   optional: false
 - name: libxcb
-  version: '1.15'
+  version: 1.17.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     pthread-stubs: ''
-    xorg-libxau: ''
+    xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
   hash:
-    md5: 33277193f5b92bad9fdd230eb700929c
-    sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
+    md5: 92ed62436b625154323d40d5f2f11dd7
+    sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
   category: main
   optional: false
 - name: libxcrypt
@@ -6679,46 +7280,62 @@ package:
   category: main
   optional: false
 - name: libxml2
-  version: 2.12.6
+  version: 2.13.4
   manager: conda
   platform: linux-64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=75.1,<76.0a0'
+    libgcc: '>=13'
     libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.6-h232c23b_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.4-hb346dea_2.conda
   hash:
-    md5: 6853448e9ca1cfd5f15382afd2a6d123
-    sha256: c0bd693bb1a7e5aba388a0c79be16ff92e2411e03aaa920f94b4b33bf099e254
+    md5: 69b90b70c434b916abf5a1d5ee5d55fb
+    sha256: a111cb7f2deb6e20ebb475e8426ce5291451476f55f0dec6c220aa51e5a5784f
+  category: main
+  optional: false
+- name: libxslt
+  version: 1.1.39
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libxml2: '>=2.12.1,<3.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
+  hash:
+    md5: e71f31f8cfb0a91439f2086fc8aa0461
+    sha256: 684e9b67ef7b9ca0ca993762eeb39705ec58e2e7f958555c758da7ef416db9f3
   category: main
   optional: false
 - name: libzip
-  version: 1.10.1
+  version: 1.11.2
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
+    libgcc: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
   hash:
-    md5: ac79812548e7e8cf61f7b0abdef01d3b
-    sha256: 84e93f189072dcfcbe77744f19c7e4171523fbecfaba7352e5a23bbe014574c7
+    md5: a7b27c075c9b7f459f1c022090697cba
+    sha256: 991e7348b0f650d495fb6d8aa9f8c727bdf52dabf5853c0cc671439b160dce48
   category: main
   optional: false
 - name: libzlib
-  version: 1.2.13
+  version: 1.3.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   hash:
-    md5: f36c115f1ee199da648e0597ec2047ad
-    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+    md5: edb0dca6bc32e4f4789199455a1dbeb8
+    sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   category: main
   optional: false
 - name: libzopfli
@@ -6748,20 +7365,21 @@ package:
   category: main
   optional: false
 - name: llvmlite
-  version: 0.42.0
+  version: 0.43.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     libllvm14: '>=14.0.6,<14.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.42.0-py310h1b8f574_1.conda
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py311h9c9ff8c_1.conda
   hash:
-    md5: e2a5e9f92629c8e4c8611883a35745b4
-    sha256: 2b25157b0724cbfc84b58e83a466d84afb8a5f09889a224c821d86adb4541ba1
+    md5: 9ab40f5700784bf16ff7cf8012a646e8
+    sha256: fb8b3eeea19f1160343d2c84f3b3e888f8c45db563375660905e1e73a793fc74
   category: main
   optional: false
 - name: locket
@@ -6790,19 +7408,38 @@ package:
     sha256: 163564614a24807504dc33a9ddeb470d511f900f62aa84e323d651ef6d26086d
   category: main
   optional: false
+- name: lxml
+  version: 5.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libxml2: '>=2.12.7,<3.0a0'
+    libxslt: '>=1.1.39,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/lxml-5.3.0-py311hcfaa980_2.conda
+  hash:
+    md5: e8782d6eed47d773c2bd8cb36230f841
+    sha256: a688a22eeb432b87d7d118bfb4a536ced4b332cfccc5fcd4bff3f3ceb5921cec
+  category: main
+  optional: false
 - name: lz4
   version: 4.3.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py310h350c4a5_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h2cbdf9a_1.conda
   hash:
-    md5: 943866d33b651ae9a3287e84383f6ddc
-    sha256: 119189a08204d97b1866e97d127d85574980547bc3b4aedc59ac6bb0b521a5c7
+    md5: 867a4aa23ae6c0e9c84cf9aa4f2df0fe
+    sha256: 83f560beb20f61bb8c6e43a0656f1e744934d41a48b8a19408e6596cf8ce99a8
   category: main
   optional: false
 - name: lz4-c
@@ -6823,29 +7460,29 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h516909a_1000.tar.bz2
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
   hash:
-    md5: bb14fcb13341b81d5eb386423b9d2bac
-    sha256: 25d16e6aaa3d0b450e61d0c4fadd7c9fd17f16e2fef09b34507209342d63c9f6
+    md5: ec7398d21e2651e0dcb0044d03b9a339
+    sha256: 88433b98a9dd9da315400e7fb9cd5f70804cb17dca8b1c85163a64f90f584126
   category: main
   optional: false
 - name: mako
-  version: 1.3.2
+  version: 1.3.5
   manager: conda
   platform: linux-64
   dependencies:
     importlib-metadata: ''
     markupsafe: '>=0.9.2'
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.5-pyhd8ed1ab_0.conda
   hash:
-    md5: a6b5f0124bc6d061350edd6d7f96dd05
-    sha256: 5f21876a83bcc040196d7f3950d576eb492bf0f6293eacd55e48e2c58a069bce
+    md5: 29fddbfa0e2361636a98de4f46ead2ac
+    sha256: f0b982e18e31ad373dd8f22ef5ffa0ae112fc13c573a5eb614814b4081c3ddcb
   category: main
   optional: false
 - name: mapclassify
-  version: 2.6.1
+  version: 2.8.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -6855,10 +7492,10 @@ package:
     python: '>=3.9'
     scikit-learn: '>=1.0'
     scipy: '>=1.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 6aceae1ad4f16cf7b73ee04189947f98
-    sha256: 204ab8b242229d422b33cfec07ea61cefa8bd22375a16658afbabaafce031d64
+    md5: e75920f936efb86f64517d144d610107
+    sha256: ce49505ac5c1d2d0bab6543b057c7cf698b0135ef92cd0eb151a41ea09d24c8c
   category: main
   optional: false
 - name: markdown
@@ -6888,83 +7525,86 @@ package:
   category: main
   optional: false
 - name: markupsafe
-  version: 2.1.5
+  version: 3.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py310h2372a71_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py311h2dc5d0c_0.conda
   hash:
-    md5: f6703fa0214a00bf49d1bef6dc7672d0
-    sha256: 3c18347adf1d091ee9248612308a6bef79038f80b626ef67f58cd0e8d25c65b8
+    md5: 15e4dadd59e93baad7275249f10b9472
+    sha256: 364a0d55abc4c60bc575c81a4acc9e98ea27565147d4d4dc672bad4b2d069710
   category: main
   optional: false
 - name: mashumaro
-  version: '3.12'
+  version: '3.14'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/mashumaro-3.12-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    typing_extensions: '>=4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/mashumaro-3.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 1a8457271699e24f59dbaadc92e7330f
-    sha256: c0b2c8b745a5492aabe9cbece7be6dcbd1458166333c7f96c11741640ed348da
+    md5: 5693c50446050456fca1e960182ad531
+    sha256: 25831c3b7a48fde53726980300101214d6a0384dc894ca21c3f855b248036ca9
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.8.3
+  version: 3.9.2
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     certifi: '>=2020.06.20'
     contourpy: '>=1.0.1'
     cycler: '>=0.10'
     fonttools: '>=4.22.0'
     freetype: '>=2.12.1,<3.0a0'
     kiwisolver: '>=1.3.1'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    numpy: '>=1.23'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
-    python: '>=3.10,<3.11.0a0'
+    python: '>=3.11,<3.12.0a0'
     python-dateutil: '>=2.7'
-    python_abi: 3.10.*
+    python_abi: 3.11.*
+    qhull: '>=2020.2,<2020.3.0a0'
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.3-py310h62c0568_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py311h2b939e6_1.conda
   hash:
-    md5: 4a7296c0273eb01dfbed728dd6a6725a
-    sha256: f3179a086a10a0d7561b5935cfa5986ed9d1fd15b86f5a68de813455cd58f98f
+    md5: db431da3476c884ef08d9f42a32913b6
+    sha256: c9ed6981f9e549d296f40d5534dee1c77b71727bc363a0eb47f57e29c9d46932
   category: main
   optional: false
 - name: matplotlib-inline
-  version: 0.1.6
+  version: 0.1.7
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
   hash:
-    md5: b21613793fcc81d944c76c9f2864a7de
-    sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+    md5: 779345c95648be40d22aaa89de7d4254
+    sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
   category: main
   optional: false
 - name: mdit-py-plugins
-  version: 0.4.0
+  version: 0.4.2
   manager: conda
   platform: linux-64
   dependencies:
     markdown-it-py: '>=1.0.0,<4.0.0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 6c5358a10873a15398b6f15f60cb5e1f
-    sha256: 1ddac8d2be448cd1fbe49d2ca09df7e10d99679d53146a917f8bb4899f76d0ca
+    md5: 5387f2cfa28f8a3afa3368bb4ba201e8
+    sha256: 5cedc99412278b37e9596f1f991d49f5a1663fe79767cf814a288134a1400ba9
   category: main
   optional: false
 - name: mdurl
@@ -6993,24 +7633,12 @@ package:
     sha256: 372275c3b0b0e5028cd25a87a23b23311b3412e556f8ee1768473e7634fb94ea
   category: main
   optional: false
-- name: metis
-  version: 5.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-h59595ed_1007.conda
-  hash:
-    md5: 40ccb8318df2500f83bd868dd8fcd201
-    sha256: 446bf794497284e2ffa28ab9191d70c38d372c51e3fd073f0d8b35efb51e7e02
-  category: main
-  optional: false
 - name: metpy
-  version: 1.6.1
+  version: 1.6.3
   manager: conda
   platform: linux-64
   dependencies:
-    cartopy: '>=0.17.0'
+    cartopy: '>=0.21.0'
     matplotlib-base: '>=3.5.0'
     numpy: '>=1.20'
     pandas: '>=1.4.0'
@@ -7021,14 +7649,14 @@ package:
     scipy: '>=1.8.0'
     traitlets: '>=5.0.5'
     xarray: '>=0.21.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/metpy-1.6.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/metpy-1.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: fdfc73cf6c37e3af737b8169418699db
-    sha256: f805285d3a468bd40844be7fc2b28642e120818fdc09372adc737db9d4531a79
+    md5: b529da163f23310ceb4e7a9fb5c4d41a
+    sha256: eaaa89d93c1e0d1f18377b0be73141f8edace3fafd1a6ce1a0b466aa45839abf
   category: main
   optional: false
 - name: minizip
-  version: 4.0.5
+  version: 4.0.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -7036,14 +7664,14 @@ package:
     libgcc-ng: '>=12'
     libiconv: '>=1.17,<2.0a0'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.1,<4.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.1,<4.0a0'
     xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.5-h0ab5242_0.conda
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
   hash:
-    md5: 557396140c71eba588e96d597e0c61aa
-    sha256: 1a56549751f4c4a7998e0a8bcff367c3992cb832c0b211d775cfd644e1ef5e6b
+    md5: 4474532a312b2245c5c77f1176989b46
+    sha256: 6315ea87d094418e744deb79a22331718b36a0e6e107cd7fc3c52c7922bc8133
   category: main
   optional: false
 - name: mistune
@@ -7059,7 +7687,7 @@ package:
   category: main
   optional: false
 - name: morecantile
-  version: 5.3.0
+  version: 5.4.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -7068,65 +7696,25 @@ package:
     pyproj: '>=3.1,<4.dev0'
     python: '>=3.8'
     rasterio: '>=1.2.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/morecantile-5.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/morecantile-5.4.2-pyhd8ed1ab_0.conda
   hash:
-    md5: b2ef9881dd9d6bf6afdd1f852eb000d2
-    sha256: c79eb1f1919652de84372eed67ea2305853e090841473d03684c0209dc4367c7
-  category: main
-  optional: false
-- name: mpfr
-  version: 4.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gmp: '>=6.2.1,<7.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h9458935_0.conda
-  hash:
-    md5: 4c28f3210b30250037a4a627eeee9e0f
-    sha256: 008230a53ff15cf61966476b44f7ba2c779826825b9ca639a0a2b44d8f7aa6cb
-  category: main
-  optional: false
-- name: mpi
-  version: '1.0'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpi-1.0-mpich.tar.bz2
-  hash:
-    md5: c1fcff3417b5a22bbc4cf6e8c23648cf
-    sha256: cbe8f3bff576ce067141dc34811a6c5c9b56d0da50f28b3cdcc1d6d9661d484c
-  category: main
-  optional: false
-- name: mpich
-  version: 4.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-    libstdcxx-ng: '>=12'
-    mpi: '1.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpich-4.2.0-h846660c_100.conda
-  hash:
-    md5: 9c9c0749155aff3aa3b26b9fd5474806
-    sha256: d7384f8d35b540e6353aff65969be18ddfbd66aa5b7354dfdda97b45ce4c9fb6
+    md5: f82cc3bfe46ec4fc363541d849d1ab67
+    sha256: f42c7d68e22ab04a9c24c354252e8d33fd10df3b3c1736013e54b3a9c92c9c91
   category: main
   optional: false
 - name: msal
-  version: 1.28.0
+  version: 1.31.0
   manager: conda
   platform: linux-64
   dependencies:
-    cryptography: <45,>=0.6
+    cryptography: <46,>=2.5
     pyjwt: <3,>=1.0.0
     python: '>=3.6'
     requests: <3,>=2.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/msal-1.28.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/msal-1.31.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6f11e244d25bd0f23fd2f8f7e3c21c9e
-    sha256: ce36a188f4148810b12d298d0fc369ce46ad16efef2acc6fc03fb9aa4a68cdcc
+    md5: 29423703af5f8e9f7b5da824d83ec510
+    sha256: dcac9d2936aa21b2cc8b1985ee1fe13f2d34ebb4d6985712546526d7fc04abcb
   category: main
   optional: false
 - name: msal_extensions
@@ -7144,18 +7732,19 @@ package:
   category: main
   optional: false
 - name: msgpack-python
-  version: 1.0.7
+  version: 1.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.7-py310hd41b1e2_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
   hash:
-    md5: dc5263dcaa1347e5a456ead3537be27d
-    sha256: a5c7612029e3871b0af0bd69e8ee1545d3deb93b5bec29cf1bf72522375fda31
+    md5: 682f76920687f7d9283039eb542fdacf
+    sha256: 9033fa7084cbfd10e1b7ed3b74cee17169a0731ec98244d05c372fc4a935d5c9
   category: main
   optional: false
 - name: msrest
@@ -7191,17 +7780,18 @@ package:
   category: main
   optional: false
 - name: multidict
-  version: 6.0.5
+  version: 6.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.5-py310h2372a71_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.1.0-py311h2dc5d0c_1.conda
   hash:
-    md5: d4c91d19e4f2f18b64753ac660edad79
-    sha256: 31258f8daee4e0e95cd6911a472f73f47f6d724676719a6a0a812ca144cab475
+    md5: 5384f857bd8b0fc3a62ce1ece858c89f
+    sha256: a7216675325306e3efe30d7036c53379eb391517792d051d738027bc3740aad5
   category: main
   optional: false
 - name: multipledispatch
@@ -7209,12 +7799,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
+    python: '>=3.6'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-py_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 1073dc92c8f247d94ac14dd79ca0bbec
-    sha256: 6d5839f75780475ad4dffe018026d493e26076f95862550a48424b4d7f6689d8
+    md5: 121a57fce7fff0857ec70fa03200962f
+    sha256: c6216a21154373b340c64f321f22fec51db4ee6156c2e642fa58368103ac5d09
   category: main
   optional: false
 - name: munkres
@@ -7242,50 +7832,53 @@ package:
   category: main
   optional: false
 - name: nb_conda_kernels
-  version: 2.3.1
+  version: 2.5.1
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
     jupyter_client: '>=4.2'
-    python: '>=3.8,<3.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/nb_conda_kernels-2.3.1-pyh707e725_4.conda
+    notebook: ''
+    psutil: ''
+    python: '>=3.8'
+    requests: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/nb_conda_kernels-2.5.1-pyh707e725_2.conda
   hash:
-    md5: 62f7c1b9d1954c99f0a0e3b074557324
-    sha256: 9f7b9a89042dd4349022c3293f24e7a9a5ecb42e4c6a8442611a376dc0f8e62d
+    md5: 076e6d822442987779a6622092a8fb6a
+    sha256: 2aaf48824b2bba5af5fe6c36c3d2a8314fee52b3b86e9f84c6009817ba19309c
   category: main
   optional: false
 - name: nbclient
-  version: 0.7.4
+  version: 0.10.0
   manager: conda
   platform: linux-64
   dependencies:
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
     nbformat: '>=5.1'
-    python: '>=3.7'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    traitlets: '>=5.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f7aa15f77d29b11caa1df1eb15383c59
-    sha256: f26afcbbdd4bd1245db514c6ebc6ef18cc12067145dcab229b6f88653575d44c
+    md5: 15b51397e0fe8ea7d7da60d83eb76ebc
+    sha256: 589d72d36d61a23b39d6fff2c488f93e29e20de4fc6f5d315b5f2c16e81028bf
   category: main
   optional: false
 - name: nbconvert
-  version: 7.16.3
+  version: 7.16.4
   manager: conda
   platform: linux-64
   dependencies:
-    nbconvert-core: 7.16.3
-    nbconvert-pandoc: 7.16.3
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.3-hd8ed1ab_0.conda
+    nbconvert-core: 7.16.4
+    nbconvert-pandoc: 7.16.4
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.4-hd8ed1ab_1.conda
   hash:
-    md5: b0c9bbbe54a11a6db3bec51eb0ef0281
-    sha256: c9bb08085ba1508607cd1ba839a31f1164e3ed15f4e499a490b71721d1df7ec5
+    md5: ab83e3b9ca2b111d8f332e9dc8b2170f
+    sha256: e014e8a583ca2f2fc751bf9093ee95bfd203bd189bafe0f512c0262fece69bce
   category: main
   optional: false
 - name: nbconvert-core
-  version: 7.16.3
+  version: 7.16.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -7306,27 +7899,27 @@ package:
     python: '>=3.8'
     tinycss2: ''
     traitlets: '>=5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 0cab42b4917e71df9dc2224b9940ef19
-    sha256: 522d28206fbafa634763da1ae9119a9edd141d8c516ed13878f77b67921e1bb5
+    md5: e2d2abb421c13456a9a9f80272fdf543
+    sha256: 074d858c5808e0a832acc0da37cd70de1565e8d6e17a62d5a11b3902b5e78319
   category: main
   optional: false
 - name: nbconvert-pandoc
-  version: 7.16.3
+  version: 7.16.4
   manager: conda
   platform: linux-64
   dependencies:
-    nbconvert-core: 7.16.3
+    nbconvert-core: 7.16.4
     pandoc: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.3-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.4-hd8ed1ab_1.conda
   hash:
-    md5: 1344bbd74e8bcd1acdd8ec0824e9840c
-    sha256: d22ef91db4ca9592860168499b4d6e5443eca0176190431321ee78ef9cc977df
+    md5: 37cec2cf68f4c09563d8bc833791096b
+    sha256: 31df882e97b227e7e57a328a36840e65ea3247023ac2ce502fd5d4b621da8dbe
   category: main
   optional: false
 - name: nbdime
-  version: 4.0.1
+  version: 4.0.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -7340,30 +7933,30 @@ package:
     python: '>=3.6'
     requests: ''
     tornado: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nbdime-4.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbdime-4.0.2-pyhd8ed1ab_0.conda
   hash:
-    md5: dd76d44a144499f8ff3254fd20cdb7a2
-    sha256: de2dc2281e914d7483b9affdb435fac292b4fd1f736bfe27c3f90b8c23f9244d
+    md5: c85813ae6abbeeddecf9ecf544f052bc
+    sha256: 9d63129f787ddf1deb8b37f328d3293a5ebfc18e9b7ed80c538fecf07f820d65
   category: main
   optional: false
 - name: nbformat
-  version: 5.10.3
+  version: 5.10.4
   manager: conda
   platform: linux-64
   dependencies:
     jsonschema: '>=2.6'
-    jupyter_core: ''
+    jupyter_core: '>=4.12,!=5.0.*'
     python: '>=3.8'
-    python-fastjsonschema: ''
+    python-fastjsonschema: '>=2.15'
     traitlets: '>=5.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
   hash:
-    md5: ca3d437c0ef2e87f63d085822c74c49a
-    sha256: 774ba7f0f175851723d9e1524ca5246b431eca1b1e22387b58a80ad0dcd7acd8
+    md5: 0b57b5368ab7fc7cdc9e3511fa867214
+    sha256: 36fe73da4d37bc7ac2d1540526ecd294fbd09acda04e096181ab8f1ccd2b464c
   category: main
   optional: false
 - name: nbgitpuller
-  version: 1.2.0
+  version: 1.2.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -7371,10 +7964,10 @@ package:
     notebook: '>=5.5.0'
     python: '>=3'
     tornado: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nbgitpuller-1.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbgitpuller-1.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: e74db5ccfcf794e3d67ec7c9c125a39a
-    sha256: 27a0f9b12f411b8e182877b26a0b83afadc68e99a3fd4370e0472f4abccd9fe7
+    md5: 73abf90c19790f8d6c600b0aa152c932
+    sha256: c499912bcbfd47487bb070658a9a3cf374828a3a0e6a2b435117ff6c215ab67d
   category: main
   optional: false
 - name: nbstripout
@@ -7406,15 +7999,16 @@ package:
   category: main
   optional: false
 - name: ncurses
-  version: 6.4.20240210
+  version: '6.5'
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
   hash:
-    md5: 97da8860a0da5413c7c98a3b3838a645
-    sha256: aa0f005b6727aac6507317ed490f0904430584fa8ca722657e7f0fb94741de81
+    md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
+    sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
   category: main
   optional: false
 - name: nest-asyncio
@@ -7434,88 +8028,50 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    hdf5: '>=1.14.2,<1.14.4.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
+    __glibc: '>=2.17,<3.0.a0'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    libgcc: '>=13'
+    libgfortran: ''
+    libgfortran5: '>=13.3.0'
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    mpich: '>=4.1.2,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.1-mpi_mpich_hdf31df6_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.1-nompi_h22f9119_106.conda
   hash:
-    md5: f45b6b4f354ab994a508f959ca894d30
-    sha256: 277e8f292f35a58f8bd3fd6c5cb557c643b2163334c3dcd0c80b6f861c64b96c
+    md5: 5b911bfe75855326bae6857451268e59
+    sha256: 4b64d3ca275be7a791b0de65459d230a8651813f2834127962da630ed3f11cdd
   category: main
   optional: false
 - name: netcdf4
-  version: 1.6.5
+  version: 1.7.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     certifi: ''
     cftime: ''
-    hdf5: '>=1.14.2,<1.14.4.0a0'
-    libgcc-ng: '>=12'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
+    libgcc: '>=13'
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    libzlib: '>=1.3.1,<2.0a0'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.6.5-nompi_py310hba70d50_100.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.1-nompi_py311hae66bec_102.conda
   hash:
-    md5: e19392760c7e4da3b9cb0ee5bf61bc4b
-    sha256: b86677ca301a24ca4ff97fd617851dd2b96aa8e36db8fd493d4dd55703e829f8
-  category: main
-  optional: false
-- name: nettle
-  version: 3.9.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
-  hash:
-    md5: 2bf1915cc107738811368afcb0993a59
-    sha256: 1ef1b7efa69c7fb4e2a36a88316f307c115713698d1c12e19f55ae57c0482995
+    md5: 87b59caea7db5b79766e0776953d8c66
+    sha256: 9574be736103349a3c12f14c19e8f777fcc909dc0b9160cde96042e285035d9d
   category: main
   optional: false
 - name: networkx
-  version: 3.2.1
+  version: 3.4.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.2.1-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.4.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 425fce3b531bed6ec3c74fab3e5f0a1c
-    sha256: 7629aa4f9f8cdff45ea7a4701fe58dccce5bf2faa01c26eb44cbb27b7e15ca9d
-  category: main
-  optional: false
-- name: nitro
-  version: 2.7.dev8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nitro-2.7.dev8-h59595ed_0.conda
-  hash:
-    md5: 5fad8a0083974b2f9e6ff64b8ca426a0
-    sha256: 80b125f82b1553ed00550a642dcaefb5f046d69f6d1eefa9ee3ac8d5b273e029
-  category: main
-  optional: false
-- name: noise
-  version: 1.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/noise-1.2.2-py310h2372a71_1005.conda
-  hash:
-    md5: ff2b91f80f04962be48a4cb401ae4d6e
-    sha256: fe3d215d968ca1ba3bc681df96c3ee66b131f2f6fe1123482de803cb47ca1003
+    md5: 1d4c088869f206413c59acdd309908b7
+    sha256: ad3ac7c22d4f68a5a50ae584ae259af91fbf96f688bf2955750bbdb61bb88fc1
   category: main
   optional: false
 - name: nomkl
@@ -7530,7 +8086,7 @@ package:
   category: main
   optional: false
 - name: notebook
-  version: 7.1.2
+  version: 7.1.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -7540,10 +8096,10 @@ package:
     notebook-shim: '>=0.2,<0.3'
     python: '>=3.8'
     tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.3-pyhd8ed1ab_0.conda
   hash:
-    md5: fa781da51f05c9211b75b5e7bcff8136
-    sha256: ed5987efcf3a394c4ab12288b4fe7d858784aabc591cebf3dabcd1cdbc7b7347
+    md5: a4b1e12d54210fa80f3eb3fc270f2480
+    sha256: 8ae08577df126ee1d583dcde59708928cca04ae405b1f38610a4bd44287f0e8e
   category: main
   optional: false
 - name: notebook-shim
@@ -7560,89 +8116,92 @@ package:
   category: main
   optional: false
 - name: nspr
-  version: '4.35'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
-  hash:
-    md5: da0ec11a6454ae19bff5b02ed881a2b1
-    sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
-  category: main
-  optional: false
-- name: nss
-  version: '3.98'
+  version: '4.36'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libsqlite: '>=3.45.1,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    nspr: '>=4.35,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.98-h1d7d5a4_0.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
   hash:
-    md5: 54b56c2fdf973656b748e0378900ec13
-    sha256: a9bc94d03df48014011cf6caaf447f2ef86a5edf7c70d70002ec4b59f5a4e198
+    md5: de9cd5bca9e4918527b9b72b6e2e1409
+    sha256: a87471d9265a7c02a98c20debac8b13afd80963968ed7b1c1c2ac7b80955ce31
+  category: main
+  optional: false
+- name: nss
+  version: '3.106'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libsqlite: '>=3.47.0,<4.0a0'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    nspr: '>=4.36,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.106-hdf54f9c_0.conda
+  hash:
+    md5: efe735c7dc47dddbb14b3433d11c6feb
+    sha256: e5dd3e57498decdef87ff641fa6b7bd5484fce3f2783811ee5ec278bc9e71281
   category: main
   optional: false
 - name: numba
-  version: 0.59.1
+  version: 0.60.0
   manager: conda
   platform: linux-64
   dependencies:
     _openmp_mutex: '>=4.5'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    llvmlite: '>=0.42.0,<0.43.0a0'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.59.1-py310h7dc5dd1_0.conda
+    llvmlite: '>=0.43.0,<0.44.0a0'
+    numpy: '>=1.22.3,<2.1'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
   hash:
-    md5: b757b5ecfa1cad38328fa73e236b6563
-    sha256: d2c631345a40f0ffbe18d312ef665e1ae1a4942ecff46334df2de49b8277bf81
+    md5: e32a210e9caf97383c35685fd2343512
+    sha256: b48178613ba637b647c5738772d3efabfca502ea579b5ec10784a33d5acb0789
   category: main
   optional: false
 - name: numcodecs
-  version: 0.12.1
+  version: 0.13.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     msgpack-python: ''
     numpy: '>=1.7'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.12.1-py310hc6cd4ac_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.13.1-py311h7db5c69_0.conda
   hash:
-    md5: ec9394896c7ae67726c4716578fc2032
-    sha256: 2adddad7a1bbaffe551e0f124943adfc757078c4faec58c56f3d00569b55b974
+    md5: de2eb968f98cef90a1937fc19e673756
+    sha256: 907a23484a7a25cbd6ceb285432427b790dfb31c39b33bd3a16baf39f64818be
   category: main
   optional: false
 - name: numexpr
-  version: 2.9.0
+  version: 2.10.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     nomkl: ''
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.9.0-py310hc2d3c2e_100.conda
+    numpy: '>=1.23.0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.1-py311h38b10cd_103.conda
   hash:
-    md5: 436667a5556cbb372fceb3126acfbb7b
-    sha256: 15aaf91bb17f1b5e40676ef221bfb7b4b87eb276acbebd6eec459e0618c49fb3
+    md5: 397a061dbf4b3819ad9ad61666e32bc1
+    sha256: b6267b5a363250d007fe0c2b4ca11b8bcaa85bc68732c31af38a58a97e7fbb14
   category: main
   optional: false
 - name: numpy
-  version: 1.23.4
+  version: 1.26.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -7651,25 +8210,25 @@ package:
     libgcc-ng: '>=12'
     liblapack: '>=3.9.0,<4.0a0'
     libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.23.4-py310h53a5b5f_1.tar.bz2
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
   hash:
-    md5: 0b7d4c8253f7191030adf34e2768c412
-    sha256: b0c38316fe6fcfb504f1399a8d71b731aa3d2334e96c2288385a3184e93f68f3
+    md5: a502d7aad449a1206efb366d6a12c52d
+    sha256: 3f4365e11b28e244c95ba8579942b0802761ba7bb31c026f50d1a9ea9c728149
   category: main
   optional: false
 - name: numpy_groupies
-  version: 0.10.2
+  version: 0.11.2
   manager: conda
   platform: linux-64
   dependencies:
     numpy: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/numpy_groupies-0.10.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/numpy_groupies-0.11.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 61881cb4fbdc59ed4f5af6199c66399f
-    sha256: 05140b476f3341c0fd3fd4edec10ddc4d1a1d88c4bed12c4a01f00f7d2823c90
+    md5: f089393c03e9f3a28ac4f77eb775e17e
+    sha256: b042997131c5df079c904aee84d124ee7ede799f9bdbf720eda6d7d0a43a399a
   category: main
   optional: false
 - name: oauthlib
@@ -7685,6 +8244,18 @@ package:
   hash:
     md5: 8f882b197fd9c4941a787926baea4868
     sha256: 0cfd5146a91d3974f4abfc2a45de890371d510a77238fe553e036ec8c031dc5b
+  category: main
+  optional: false
+- name: objsize
+  version: 0.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/objsize-0.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1db3bf71afb94cb0f37dd4a5b8d99d35
+    sha256: 5472c5b47dbe7f70f4f37f3e9c0ac3bf82cffc26c6cce0edd9c9b49e9c7f8a9b
   category: main
   optional: false
 - name: ocl-icd
@@ -7723,7 +8294,7 @@ package:
   category: main
   optional: false
 - name: odc-geo
-  version: 0.4.3
+  version: 0.4.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -7734,31 +8305,31 @@ package:
     python: '>=3.8'
     shapely: ''
     xarray: '>=0.19'
-  url: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.8-pyhd8ed1ab_0.conda
   hash:
-    md5: 3d821615c2a9ed2b3a8778917bb0d56b
-    sha256: 1b50f96543040c38b00fc348fe3904379590062f13bfd63489d06b39960f0f45
+    md5: abb44a416828ea4c77f53c512cbf46b1
+    sha256: 3d3c46618815efb7bd8bf73b974f300296ff260158b1f203069785474723818c
   category: main
   optional: false
 - name: odc-stac
-  version: 0.3.9
+  version: 0.3.10
   manager: conda
   platform: linux-64
   dependencies:
     affine: ''
     dask-core: ''
     numpy: '>=1.20.0'
-    odc-geo: '>=0.3.0'
+    odc-geo: '>=0.4.7'
     pandas: ''
     pystac: '>=1.0.0,<2'
     python: '>=3.8'
     rasterio: '>=1.0.0,!=1.3.0,!=1.3.1'
     toolz: ''
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/odc-stac-0.3.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/odc-stac-0.3.10-pyhd8ed1ab_1.conda
   hash:
-    md5: 8844c795ac155e61d60f6d8103fb4a77
-    sha256: 95f192595cc2b575db659955a1574c4dcf5916e27d3261a106c0e03cc6353de2
+    md5: a24c95f14971ce95b6acdea9f9e4be12
+    sha256: 0bd8010e1010bfaeb34dd94f122b66b3455c47193f217c1c05e221177bdc7c48
   category: main
   optional: false
 - name: openh264
@@ -7782,55 +8353,77 @@ package:
     libgcc-ng: '>=12'
     libpng: '>=1.6.43,<1.7.0a0'
     libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
   hash:
     md5: 7f2e286780f072ed750df46dc2631138
     sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
   category: main
   optional: false
-- name: openssl
-  version: 3.2.1
+- name: openldap
+  version: 2.6.8
   manager: conda
   platform: linux-64
   dependencies:
-    ca-certificates: ''
+    cyrus-sasl: '>=2.1.27,<3.0a0'
+    krb5: '>=1.21.2,<1.22.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
+    libstdcxx-ng: '>=12'
+    openssl: '>=3.3.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.8-hedd0468_0.conda
   hash:
-    md5: 9d731343cff6ee2e5a25c4a091bf8e2a
-    sha256: 2c689444ed19a603be457284cf2115ee728a3fafb7527326e96054dee7cdc1a7
+    md5: dcd0ed5147d8876b0848a552b416ce76
+    sha256: 902652f7a106caa6ea9db2c44118078e23a499bf091ce8ea01d8498c156e8219
+  category: main
+  optional: false
+- name: openssl
+  version: 3.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    ca-certificates: ''
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+  hash:
+    md5: 4d638782050ab6faa27275bed57e9b4e
+    sha256: cee91036686419f6dd6086902acf7142b4916e1c4ba042e9ca23e151da012b6d
   category: main
   optional: false
 - name: orc
-  version: 2.0.0
+  version: 2.0.2
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=12'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.1.10,<2.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.0-h1e5e2c1_0.conda
+    snappy: '>=1.2.1,<1.3.0a0'
+    tzdata: ''
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-h669347b_0.conda
   hash:
-    md5: 53e8f030579d34e1a36a735d527c021f
-    sha256: ed8cfe1f35e8ef703e540e7731e77fade1410bba406e17727a10dee08c37d5b4
+    md5: 1e6c10f7d749a490612404efeb179eb8
+    sha256: 8a126e0be7f87c499f0a9b5229efa4321e60fc4ae46abdec9b13240631cb1746
   category: main
   optional: false
 - name: orjson
-  version: 3.9.15
+  version: 3.10.11
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/orjson-3.9.15-py310hcb5633a_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/orjson-3.10.11-py311h9e33e62_0.conda
   hash:
-    md5: da1b180ccf1dce5d87d145ad2fc14e5a
-    sha256: 3ee3ea151b7328349abc73b7a4bcc1c16cf98992a5c0525e692046cd13662f61
+    md5: 6c3658d42aeb1c3b0be757ebed14a309
+    sha256: 40a7c70c31ad912feebb2785276ff49e0c7969021cd39366e6a2505276c05979
   category: main
   optional: false
 - name: overrides
@@ -7846,72 +8439,59 @@ package:
     sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
   category: main
   optional: false
-- name: p11-kit
-  version: 0.24.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libffi: '>=3.4.2,<3.5.0a0'
-    libgcc-ng: '>=12'
-    libtasn1: '>=4.18.0,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
-  hash:
-    md5: 56ee94e34b71742bbdfa832c974e47a8
-    sha256: aa8d3887b36557ad0c839e4876c0496e0d670afe843bf5bba4a87764b868196d
-  category: main
-  optional: false
 - name: packaging
-  version: '24.0'
+  version: '24.1'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 248f521b64ce055e7feae3105e7abeb8
-    sha256: a390182d74c31dfd713c16db888c92c277feeb6d1fe96ff9d9c105f9564be48a
+    md5: cbe1bb1f21567018ce595d9c2be0f0db
+    sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
   category: main
   optional: false
 - name: pamela
-  version: 1.1.0
+  version: 1.2.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pamela-1.1.0-pyh1a96a4e_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pamela-1.2.0-pyhff2d567_0.conda
   hash:
-    md5: dce93ccf07159017c69c6d9cea2d5d61
-    sha256: 63f90d7e8517dae2eb859a48210536bb05d119e915df0fb706d76b2a3012a430
+    md5: adb3a4c7f269923b7f2ccff0ef071102
+    sha256: 060b28a4b003681cc0b96d8edb0b1608ede432b2331659c87a5f94dd4e61bbcc
   category: main
   optional: false
 - name: pandas
-  version: 2.2.1
+  version: 2.2.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    numpy: '>=1.22.4'
+    python: '>=3.11,<3.12.0a0'
     python-dateutil: '>=2.8.1'
     python-tzdata: '>=2022a'
-    python_abi: 3.10.*
-    pytz: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.1-py310hcc13569_0.conda
+    python_abi: 3.11.*
+    pytz: '>=2020.1,<2024.2'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_1.conda
   hash:
-    md5: cf5d315e3601a6a2931f63aa9a84dc40
-    sha256: 275bfe1485072153687b121b435864d97105928c674428348448d79ad85565aa
+    md5: 643f8cb35133eb1be4919fb953f0a25f
+    sha256: dce121d3838996b77b810ca9097cc17068552075c761408a9b2eb788cf8fd1b0
   category: main
   optional: false
 - name: pandoc
-  version: 3.1.12.3
+  version: '3.5'
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.1.12.3-ha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.5-ha770c72_0.conda
   hash:
-    md5: cdea66892b19a454f939487318b6c517
-    sha256: 26bfcda675fbddd059a8861dc75b9e497980ec6c679ec2a27e7d74042c4b295b
+    md5: 2889e6b9c666c3a564ab90cedc5832fd
+    sha256: 56df96c2707a5ac71b2e5d3b32e38521c0bac91006d0b8948c1d347dd5c12609
   category: main
   optional: false
 - name: pandocfilters
@@ -7927,27 +8507,28 @@ package:
   category: main
   optional: false
 - name: panel
-  version: 1.4.0
+  version: 1.5.3
   manager: conda
   platform: linux-64
   dependencies:
     bleach: ''
-    bokeh: '>=3.4.0,<3.5'
+    bokeh: '>=3.5.0,<3.7.0'
     linkify-it-py: ''
     markdown: ''
     markdown-it-py: ''
     mdit-py-plugins: ''
     packaging: ''
-    param: '>=2.0.0,<3'
-    python: '>=3.9'
-    pyviz_comms: '>=0.7.4'
+    pandas: '>=1.2'
+    param: '>=2.1.0,<3.0'
+    python: '>=3.10'
+    pyviz_comms: '>=2.0.0'
     requests: ''
-    tqdm: '>=4.48.0'
+    tqdm: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/panel-1.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 72a1705b2033e07bab7b9c105252a23f
-    sha256: aa890340a78ba72e274ffcc3ab7b1f2adc0302a102dff70581bffef7dacf56a2
+    md5: 058794444fc8aafcb0385788ce58e979
+    sha256: 1613bb56fb5b93094b64f0bc95476de7ceb42f4dacbf04f90bc25519b00f9878
   category: main
   optional: false
 - name: pangeo-dask
@@ -7965,36 +8546,33 @@ package:
   category: main
   optional: false
 - name: pangeo-forge-recipes
-  version: 0.9.4
+  version: 0.10.7
   manager: conda
   platform: linux-64
   dependencies:
-    aiohttp: ''
-    dask: ''
-    distributed: ''
-    fsspec: '>=2021.6.0'
+    apache-beam: ''
+    cftime: ''
+    dask: '>=2021.11.2'
+    dask-core: '>=2021.11.2'
+    fastparquet: ''
+    fsspec: '>=2023.4.0'
     h5netcdf: ''
     h5py: '>=3.3.0'
-    intake: ''
-    intake-xarray: ''
     kerchunk: '>=0.0.7'
-    mypy_extensions: '>=0.4.2'
     netcdf4: ''
     numcodecs: '>=0.9.0'
     python: '>=3.8'
-    rechunker: '>=0.4.2'
-    requests: ''
-    setuptools: ''
+    ujson: ''
     xarray: '>=0.18.0'
-    zarr: '>=2.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pangeo-forge-recipes-0.9.4-pyh1a96a4e_0.conda
+    zarr: '>=2.12.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pangeo-forge-recipes-0.10.7-pyhca7485f_0.conda
   hash:
-    md5: 2e4cb0b8414d2023f95124725e7910b4
-    sha256: 288df92e82d93cfa1109e7e7bf283cab444fff4b6bcbc9eef4a2fbe90f547328
+    md5: c776055c0efa22d1724e5a24f4b02e25
+    sha256: 2585e9ddf2dab2fa7e061bdde1965cc781b37d80719bd540808d2d455767f1c7
   category: main
   optional: false
 - name: pango
-  version: 1.52.1
+  version: 1.54.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -8003,69 +8581,52 @@ package:
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=8.3.0,<9.0a0'
+    harfbuzz: '>=9.0.0,<10.0a0'
     libgcc-ng: '>=12'
-    libglib: '>=2.78.4,<3.0a0'
+    libglib: '>=2.80.2,<3.0a0'
     libpng: '>=1.6.43,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.52.1-ha41ecd1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
   hash:
-    md5: 5c0cc002bf4eaa56448b0729efd6e96c
-    sha256: 53d3442fb39eb9f0ac36646769469f2f825afaeda984719002460efd7c3d354f
+    md5: 7df02e445367703cd87a574046e3a6f0
+    sha256: d362237be82d5a0d532fe66ec8d68018c3b2a9705bad6d73c2b63dae2970da02
   category: main
   optional: false
 - name: papermill
-  version: 2.5.0
+  version: 2.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    ansiwrap: ''
-    black: ''
+    aiohttp: '>=3.9,<3.10'
+    ansicolors: ''
     click: ''
     entrypoints: ''
     nbclient: '>=0.2.0'
-    nbformat: '>=5.1.2'
+    nbformat: '>=5.2.0'
     python: '>=3.7'
     pyyaml: ''
     requests: ''
-    tenacity: ''
+    tenacity: '>=5.0.2'
     tqdm: '>=4.32.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/papermill-2.5.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/papermill-2.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e6e69b90afd3d0597da8f1f74cc4bd58
-    sha256: c9896ec2358bf9da079ce34b986d8843ecf75f840d2d719f430b665cfa674a59
-  category: main
-  optional: false
-- name: parallelio
-  version: 2.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-    libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpnetcdf: '>=1.12.3,<1.12.4.0a0'
-    mpich: '>=4.1.2,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/parallelio-2.6.2-mpi_mpich_h79a22d0_100.conda
-  hash:
-    md5: 7af3aaea9ff542e3630526e858889158
-    sha256: 76d726d4827a88e239b003cf17da988e1f3ce4b736b62392710d6d8cc888afd3
+    md5: 7e2150bca46f713bb6e290ac1b26ed1d
+    sha256: 64e05023f00762bc3f4cd9ed9bedfb6b2af03f645e9a98ff2904ed690686f566
   category: main
   optional: false
 - name: param
-  version: 2.1.0
+  version: 2.1.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/param-2.1.0-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
   hash:
-    md5: 79d0ed2d7cb5b62bf90b3dbaf1782a23
-    sha256: efcc10c5e5f6007144908a84f4ca79edcd8ec6bb3f339bc422c8c9a1331f78ff
+    md5: bd991333d5bc659bb82bfb5a5d4c1576
+    sha256: db644c81c1f47e1fa8134d5de935ec4269d765fbef8d44bd454eb187c7524472
   category: main
   optional: false
 - name: paramiko
-  version: 3.4.0
+  version: 3.5.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -8073,14 +8634,14 @@ package:
     cryptography: '>=3.3'
     pynacl: '>=1.5'
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a5e792523b028b06d7ce6e65a6cd4a33
-    sha256: 2e66359261954a79b66858c30e69ea6dd4380bf8bd733940527386b25e31dd13
+    md5: 3a359c35a1f9ec2859fbddcabcfd4c4d
+    sha256: f2c3ac882c1123a71479c15ecec0c632aa004bc8a8c10daf25d69461ea1da38a
   category: main
   optional: false
 - name: parcels
-  version: 3.0.2
+  version: 3.1.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -8096,42 +8657,42 @@ package:
     psutil: ''
     pymbolic: ''
     pytest: ''
-    python: '>=3.8'
+    python: '>=3.10'
     scipy: '>=0.16.0'
     tqdm: ''
     trajan: ''
     xarray: '>=0.10.8'
-    zarr: '>=2.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/parcels-3.0.2-pyh779afd3_0.conda
+    zarr: '>=2.11.0,!=2.18.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/parcels-3.1.0-pyh6fe113f_1.conda
   hash:
-    md5: f58776ea34fd258e830e343f37d51114
-    sha256: 8d47de3f14fb0cd053d3e4d39fd5841c513f92b3db84aaf6d44ec6e8520b9e9b
+    md5: b4152da63d30f914628df40c07f7f04f
+    sha256: 129a54c3e11120add97cff680aefc2c012697dae5e04fd8dba87c926e2f14f3c
   category: main
   optional: false
 - name: parso
-  version: 0.8.3
+  version: 0.8.4
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 17a565a0c3899244e938cdf417e7b094
-    sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+    md5: 81534b420deb77da8833f2289b8d47ac
+    sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
   category: main
   optional: false
 - name: partd
-  version: 1.4.1
+  version: 1.4.2
   manager: conda
   platform: linux-64
   dependencies:
     locket: ''
-    python: '>=3.7'
+    python: '>=3.9'
     toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
   hash:
-    md5: acf4b7c0bcd5fa3b0e05801c4d2accd6
-    sha256: b248238da2bb9dfe98e680af911dc7013af86095e3ec8baf08905555632d34c7
+    md5: 0badf9c54e24cecfb0ad2f99d680c163
+    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
   category: main
   optional: false
 - name: pathspec
@@ -8161,45 +8722,18 @@ package:
   category: main
   optional: false
 - name: pcre2
-  version: '10.43'
+  version: '10.44'
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
     libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
   hash:
-    md5: 8292dea9e022d9610a11fce5e0896ed8
-    sha256: 766dd986a7ed6197676c14699000bba2625fd26c8a890fcb7a810e5cf56155bc
-  category: main
-  optional: false
-- name: pdal
-  version: 2.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ceres-solver: '>=2.2.0,<2.3.0a0'
-    curl: ''
-    draco: ''
-    eigen: '>=3.4.0,<3.4.1.0a0'
-    geotiff: '>=1.7.1,<1.8.0a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc-ng: '>=12'
-    libgdal: '>=3.8.4,<3.9.0a0'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libpq: '>=16.2,<17.0a0'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.6,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    nitro: ''
-    tiledb: '>=2.21.1,<2.22.0a0'
-    zlib: ''
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pdal-2.7.1-h8cae3e1_1.conda
-  hash:
-    md5: cee810e92c608469e415fe7d14baa1d1
-    sha256: 40cae56904cc86cebb6c2d93cfb7b403d24a1c6a449aad20948f9b79fe4d77fd
+    md5: df359c09c41cd186fffb93a2d87aa6f5
+    sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
   category: main
   optional: false
 - name: pendulum
@@ -8208,14 +8742,14 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
+    python: '>=3.11,<3.12.0a0'
     python-dateutil: '>=2.6,<3.0'
-    python_abi: 3.10.*
+    python_abi: 3.11.*
     pytzdata: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pendulum-2.1.2-py310h2372a71_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pendulum-2.1.2-py311h459d7ec_6.conda
   hash:
-    md5: 1942f8904121c1a88bb94777a1cbde3b
-    sha256: f7bffc1bb9bcc9cec514ea0ec84e94aa4a29d2ce11574e7ddfc439b8329e81fd
+    md5: 7ada98068961b6a6f1f620dcbfedd1ec
+    sha256: 59a97ea22e5bbc42981af7625b780b29eee6680bd91c52695b4e388ce786e65b
   category: main
   optional: false
 - name: pexpect
@@ -8244,61 +8778,67 @@ package:
   category: main
   optional: false
 - name: pillow
-  version: 10.2.0
+  version: 10.4.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     freetype: '>=2.12.1,<3.0a0'
     lcms2: '>=2.16,<3.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    libtiff: '>=4.6.0,<4.8.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libxcb: '>=1.16,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.2.0-py310h01dd4db_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py311h4aec55e_1.conda
   hash:
-    md5: 9ec32d0d90f7670eb29bbba18299cf29
-    sha256: ddb300d69329606a9933717127880c2062e9d6539d8824b21a43ed63eb7dab4f
+    md5: 4484d021b3bf4938b8c75fe418bfd27b
+    sha256: 22d2da0c005231fc264984d2886c2ee66300744408657c380c38fe3e6388fdad
   category: main
   optional: false
 - name: pims
-  version: 0.6.1
+  version: '0.7'
   manager: conda
   platform: linux-64
   dependencies:
     imageio: ''
     jinja2: ''
-    numpy: '>=1.17'
+    numpy: '>=1.19'
+    packaging: ''
     pillow: ''
     python: '>=3.7'
     slicerator: '>=1.1.0'
     tifffile: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pims-0.6.1-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pims-0.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 541b167643218ddb6604f22da934f75c
-    sha256: 951ccc507283d9632ffdfa92468a028e33450a8ac9e3d20b079ca3a5df384208
+    md5: b0acc7e1a2514298728307d560f04235
+    sha256: 40135209a3be74257df4fb340d25230a20d8ccdbfca8c5f4695b6ed8bd426bee
   category: main
   optional: false
 - name: pint
-  version: '0.23'
+  version: 0.24.3
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
+    appdirs: '>=1.4.4'
+    flexcache: '>=0.3'
+    flexparser: '>=0.3'
+    python: '>=3.9,<3.13.0a0'
+    typing-extensions: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pint-0.23-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.3-pyhd8ed1ab_0.conda
   hash:
-    md5: d47f9170e3933e53368e0d447c16856f
-    sha256: c26dfa2094949782db6ddbce2b6e03aff1e9e64c808fef68f66cfea72be18e1d
+    md5: ca12b329038e1a3b73f5f5d73ba99475
+    sha256: b6f2dd095747551ff2ec73b86c7d741720037c31facec845e402e21d35d4a450
   category: main
   optional: false
 - name: pint-xarray
-  version: '0.3'
+  version: '0.4'
   manager: conda
   platform: linux-64
   dependencies:
@@ -8306,24 +8846,24 @@ package:
     pint: '>=0.16'
     python: '>=3.8'
     xarray: '>=0.16.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pint-xarray-0.3-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pint-xarray-0.4-pyhd8ed1ab_0.conda
   hash:
-    md5: d748055363d88b1e90b5ba316982e165
-    sha256: fd57837d595737c3d44e6e12bf33cbfb65958c5c31af6e9a5e2d21b6aef5f5d5
+    md5: 54398492a68901ff0ec45fea86ce83cc
+    sha256: e033d6782e601bff993eef6883d2f016215b5da37ad593088f514d2822ed7845
   category: main
   optional: false
 - name: pip
-  version: '24.0'
+  version: 24.3.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8,<3.13.0a0'
     setuptools: ''
     wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
   hash:
-    md5: f586ac1e56c8638b64f9c8122a7b8a67
-    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+    md5: 5dd546fe99b44fda83963d15f84263b7
+    sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
   category: main
   optional: false
 - name: pixman
@@ -8372,41 +8912,41 @@ package:
   category: main
   optional: false
 - name: platformdirs
-  version: 4.2.0
+  version: 4.3.6
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
   hash:
-    md5: a0bc3eec34b0fab84be6b2da94e98e20
-    sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
+    md5: fd8f2b18b65bbf62e8f653100690c8d2
+    sha256: c81bdeadc4adcda216b2c7b373f0335f5c78cc480d1d55d10f21823590d7e46f
   category: main
   optional: false
 - name: plotly
-  version: 5.19.0
+  version: 5.24.1
   manager: conda
   platform: linux-64
   dependencies:
     packaging: ''
     python: '>=3.6'
     tenacity: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotly-5.19.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotly-5.24.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 669cd7065794633b9e64e6a9612ec700
-    sha256: fa9ae81e1f304f1480378ea25d559748e061c5b8d55b3ade433c3bc483dbae9e
+    md5: 81bb643d6c3ab4cbeaf724e9d68d0a6a
+    sha256: 39cef6d3056211840709054b90badfa4efd6f61ea37935a89ab0b549a54cc83f
   category: main
   optional: false
 - name: pluggy
-  version: 1.4.0
+  version: 1.5.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 139e9feb65187e916162917bb2484976
-    sha256: 6edfd2c41938ea772096c674809bfcf2ebb9bef7e82de6c7ea0b966b86bfb4d0
+    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
+    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
   category: main
   optional: false
 - name: ply
@@ -8414,15 +8954,27 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-py_1.tar.bz2
+    python: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_2.conda
   hash:
-    md5: 7205635cd71531943440fbfe3b6b5727
-    sha256: 2cd6fae8f9cbc806b7f828f006ae4a83c23fac917cacfd73c37ce322d4324e53
+    md5: 18c6deb6f9602e32446398203c8f0e91
+    sha256: d8faaf4dcc13caed560fa32956523b35928a70499a2d08c51320947d637e3a41
+  category: main
+  optional: false
+- name: pmtiles
+  version: 3.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pmtiles-3.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 05b92d0fce8fcb37d66f16212720ced8
+    sha256: 538be144eebdb338fb2fec1400ce559c3af6af4f16efcae514a3fcc2d3271cb3
   category: main
   optional: false
 - name: pooch
-  version: 1.8.1
+  version: 1.8.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -8430,39 +8982,40 @@ package:
     platformdirs: '>=2.5.0'
     python: '>=3.7'
     requests: '>=2.19.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_0.conda
   hash:
-    md5: d15917f33140f8d2ac9ca44db7ec8a25
-    sha256: 63f95e626754f5e05e74f39c0f4866aa8bd40b933eef336077978d365d66ca7b
+    md5: 8dab97d8a9616e07d779782995710aed
+    sha256: f2ee98740ac62ff46700c3cae8a18c78bdb3d6dd80832c6e691e789b844830d8
   category: main
   optional: false
 - name: poppler
-  version: 24.03.0
+  version: 24.08.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.0,<2.0a0'
     fontconfig: '>=2.14.2,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     lcms2: '>=2.16,<3.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.4,<3.0a0'
+    libcurl: '>=8.9.1,<9.0a0'
+    libgcc-ng: '>=13'
+    libglib: '>=2.80.3,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libpng: '>=1.6.43,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libstdcxx-ng: '>=13'
+    libtiff: '>=4.6.0,<4.8.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     nspr: '>=4.35,<5.0a0'
-    nss: '>=3.98,<4.0a0'
+    nss: '>=3.103,<4.0a0'
     openjpeg: '>=2.5.2,<3.0a0'
     poppler-data: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.03.0-h590f24d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.08.0-h47131b8_1.conda
   hash:
-    md5: c688853df9dcfed47200d0e28e5dfe11
-    sha256: 0ea3e63ae3ba07bcae8cc541647c647c68aeec32dfbe3bbaeecc845833b27a6f
+    md5: 0854b9ff0cc10a1f6f67b0f352b8e75a
+    sha256: b32fe787525236908e21885fef8d77e8ebdbbe6694b2fb89ed799444ebda3178
   category: main
   optional: false
 - name: poppler-data
@@ -8489,60 +9042,71 @@ package:
   category: main
   optional: false
 - name: postgresql
-  version: '16.2'
+  version: '17.0'
   manager: conda
   platform: linux-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    libpq: '16.2'
-    libxml2: '>=2.12.6,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.1,<4.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=75.1,<76.0a0'
+    krb5: '>=1.21.3,<1.22.0a0'
+    libgcc: '>=13'
+    libpq: '17.0'
+    libxml2: '>=2.12.7,<3.0a0'
+    libxslt: '>=1.1.39,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    openldap: '>=2.6.8,<2.7.0a0'
+    openssl: '>=3.3.2,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tzcode: ''
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.2-h82ecc9d_1.conda
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-17.0-h1122569_4.conda
   hash:
-    md5: 7a5806219d0f77ce8393375d040df065
-    sha256: 7fc52e69478973f173f055ade6c4087564362be9172c294b493a79671fef9a7e
+    md5: 028ea131f116f13bb2a4a382b5863a04
+    sha256: 83565b4966d86d39b8628f9137d0918fac8ae2f3241a48da145be444426ed057
   category: main
   optional: false
 - name: prefect
-  version: 2.16.8
+  version: 2.20.4
   manager: conda
   platform: linux-64
   dependencies:
-    aiosqlite: '>=0.17.0'
+    aiosqlite: '>=0.17.0,<1.0.0'
     alembic: '>=1.7.5,<2.0.0'
-    anyio: '>=3.7.1,<4.0.0'
+    anyio: '>=4.4.0,<5.0.0'
     apprise: '>=1.1.0,<2.0.0'
     asgi-lifespan: '>=1.0,<3.0'
-    asyncpg: '>=0.23'
+    asyncpg: '>=0.23,<1.0.0'
     click: '>=8.0,<8.2'
     cloudpickle: '>=2.0,<3.0'
     coolname: '>=1.0.4,<3.0.0'
     croniter: '>=1.0.12,<2.0.0'
     cryptography: '>=36.0.1'
     dateparser: '>=1.1.1,<2.0.0'
-    docker-py: '>=4.0,<7.0'
+    docker-py: '>=4.0,<8.0'
+    exceptiongroup: '>=1.2.1'
     fsspec: '>=2022.5.0'
-    griffe: '>=0.20.0'
+    griffe: '>=0.49.0,<2.0.0'
     httpcore: '>=0.15.0,<2.0.0'
     httpx: '>=0.23,!=0.23.2'
     importlib_metadata: '>=4.4'
+    importlib_resources: '>=6.1.3,<6.5.0'
     jinja2: '>=3.0.0,<4.0.0'
+    jinja2-humanize-extension: '>=0.4.0'
     jsonpatch: '>=1.32,<2.0'
     jsonschema: '>=3.2.0,<5.0.0'
     orjson: '>=3.7,<4.0'
     packaging: '>=21.3,<24.3'
     pathspec: '>=0.8.0'
     pendulum: '>=2.1.2,<3.0.0'
-    pydantic: '>=1.10.0,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0'
+    pydantic: '>=1.10.0,!=1.10.14,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0'
+    pydantic-core: '>=2.17.0,<3.0.0'
     python: '>=3.7'
     python-dateutil: '>=2.8.2,<3.0.0'
     python-graphviz: '>=0.20.1'
     python-kubernetes: '>=24.2.0,<29.0.0'
+    python-multipart: '>=0.0.7'
     python-slugify: '>=5.0,<9.0'
     pytz: '>=2021.1,<2024'
     pyyaml: '>=5.4.1,<7.0.0'
@@ -8553,70 +9117,98 @@ package:
     sqlalchemy: '>=1.4.22,!=1.4.33,<3.0.0'
     starlette: '>=0.27.0,<0.28.0'
     toml: '>=0.10.0'
-    typer: '>=0.4.2'
+    typer: '>=0.12.0,!=0.12.2,<0.13.0'
     typing_extensions: '>=4.5.0,<5.0.0'
     ujson: '>=5.8.0,<6.0.0'
-    uvicorn: '>=0.14.0'
-    websockets: '>=10.4,<12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/prefect-2.16.8-pyhd8ed1ab_0.conda
+    uvicorn: '>=0.14.0,!=0.29.0'
+    websockets: '>=10.4,<14.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/prefect-2.20.4-pyhd8ed1ab_0.conda
   hash:
-    md5: dcc0f5d8ab6948be4b1cc71d1bcdf511
-    sha256: c3fcd2aea920af6b0604b4531ac58547360c7f0b47c58488c82c2ae483ecfb8e
+    md5: 1b747f1b2f6a91d46807a3f5ac594d61
+    sha256: 12948ecf0cb4b1f21d079c2567fdccc0dcd83cc368ed1ea5dd1c4b565512f698
   category: main
   optional: false
 - name: proj
-  version: 9.3.1
+  version: 9.5.0
   manager: conda
   platform: linux-64
   dependencies:
-    libcurl: '>=8.4.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libsqlite: '>=3.44.2,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libcurl: '>=8.10.0,<9.0a0'
+    libgcc: '>=13'
+    libsqlite: '>=3.46.1,<4.0a0'
+    libstdcxx: '>=13'
+    libtiff: '>=4.6.0,<4.8.0a0'
     sqlite: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.3.1-h1d62c97_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
   hash:
-    md5: 44ec51d0857d9be26158bb85caa74fdb
-    sha256: 234f8f7b255dc9036812ec30d097c0725047f3fc7e8e0bc7944e4e17d242ab99
+    md5: 8c29983ebe50cc7e0998c34bc7614222
+    sha256: 936de8754054d97223e87cc87b72641d2c7582d536ee9eee4b0443fa66e2733f
   category: main
   optional: false
 - name: prometheus_client
-  version: 0.20.0
+  version: 0.21.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 9a19b94034dd3abb2b348c8b93388035
-    sha256: 757cd91d01c2e0b64fadf6bc9a11f558cf7638d897dfbaf7415ddf324d5405c9
+    md5: 07e9550ddff45150bfc7da146268e165
+    sha256: 01f0c3dd00081637ed920a922b17bcc8ed49608404ee466ced806856e671f6b9
   category: main
   optional: false
 - name: prompt-toolkit
-  version: 3.0.42
+  version: 3.0.38
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
   hash:
-    md5: 0bf64bf10eee21f46ac83c161917fa86
-    sha256: 58525b2a9305fb154b2b0d43a48b9a6495441b80e4fbea44f2a34a597d2cef16
+    md5: 59ba1bf8ea558751a0d391249a248765
+    sha256: 78c2f3c6195ec350d7d6e5fa3e43274ca8191c181c97a867e2920faaeec0e9bc
   category: main
   optional: false
-- name: proto-plus
-  version: 1.23.0
+- name: prompt_toolkit
+  version: 3.0.38
   manager: conda
   platform: linux-64
   dependencies:
-    protobuf: '>=3.19.0,<5.0.0dev'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/proto-plus-1.23.0-pyhd8ed1ab_0.conda
+    prompt-toolkit: '>=3.0.38,<3.0.39.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
   hash:
-    md5: 26c043ffe1c027eaed894d70ea04a18d
-    sha256: 2c9ca8233672032fb372792b1e4c2a556205e631dc375c2c606eab478f32349d
+    md5: 45b74f64d8808eda7e6f6e6b1d641fd2
+    sha256: c0f24a75d27918eb33f86902aa6024783d128a89eb3a169bcb22f24163a422b3
+  category: main
+  optional: false
+- name: propcache
+  version: 0.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.2.0-py311h9ecbd09_2.conda
+  hash:
+    md5: 85a56dd3b692fb5435de1e901354b5b8
+    sha256: bc2fbbc3f494884b62f288db2f6d53f57a9a1129cc95138780abdb783c487bc4
+  category: main
+  optional: false
+- name: proto-plus
+  version: 1.25.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    protobuf: '>=3.19.0,<6.0.0dev'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/proto-plus-1.25.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 36147996294573f1e8f9fea08e5938de
+    sha256: ec841b8e78ac65ac9ec86daf2d7e5d5f8d632818d9e03487dd1462779704d61d
   category: main
   optional: false
 - name: protobuf
@@ -8624,17 +9216,18 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libabseil: '>=20240116.2,<20240117.0a0'
+    libgcc: '>=13'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.25.3-py310ha8c1f0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.25.3-py311hbffca5d_1.conda
   hash:
-    md5: 0cee4d21cd822c598cf894d1df1657d4
-    sha256: 2da5aa342456c2f6a80ebfef9a2a8c57723e8f6c9b00a874660e49a937e8ed9b
+    md5: 27089f71e28d01bcc070460d822d5acb
+    sha256: 3e06dcdd3ec2e73fb456d5c2fdf9c8829d7f70c15d724f9920a24276a0a1d6b5
   category: main
   optional: false
 - name: pscript
@@ -8655,12 +9248,12 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py310h2372a71_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py311h459d7ec_0.conda
   hash:
-    md5: bd19b3096442ea342c4a5208379660b1
-    sha256: f1866425aa67f3fe1e3f6e07562a4bc986fd487e01146a91eb1bdbe5ec16a836
+    md5: 9bc62d25dcf64eec484974a3123c9d57
+    sha256: 467788418a2c71fb3df9ac0a6282ae693d1070a6cb47cb59bdb529b53acaee1c
   category: main
   optional: false
 - name: psycopg2
@@ -8668,14 +9261,29 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libpq: '>=16.1,<17.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.9-py310h275853b_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libpq: '>=17.0,<18.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.9-py311h83e8966_2.conda
   hash:
-    md5: ab5ef89b98dad51f23d49a44f114905f
-    sha256: 583aa8fef12988a26e24a94f7a3b3045412dce3860884b47e28318196cccab70
+    md5: 0bcd749cdae1d94cb4c48d9a95707125
+    sha256: 6b170fd60c6c213cf78983099376e1087ea17f1e40ab1e4d9419e29d43fce3f5
+  category: main
+  optional: false
+- name: psygnal
+  version: 0.11.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    typing_extensions: ''
+    wrapt: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/psygnal-0.11.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: b49c6ca5e5661b5473f91ac01782e487
+    sha256: fc12b32c36c522d263bf24dbced4c755925198fa153bbddd7181b68e3443a468
   category: main
   optional: false
 - name: pthread-stubs
@@ -8683,11 +9291,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   hash:
-    md5: 22dad4df6e8630e8dff2428f6f6a7036
-    sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+    md5: b3c17d95b5a10c6e64a21fa17573e70e
+    sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   category: main
   optional: false
 - name: ptyprocess
@@ -8716,39 +9325,53 @@ package:
   category: main
   optional: false
 - name: pure_eval
-  version: 0.2.2
+  version: 0.2.3
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+    md5: 0f051f09d992e0d08941706ad519ee0e
+    sha256: dcfcb3cee1ae0a89729601582cc3edea20ba13c9493967a03a693c67567af0c8
   category: main
   optional: false
 - name: pyarrow
-  version: 15.0.2
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.2
-    libarrow-acero: 15.0.2
-    libarrow-dataset: 15.0.2
-    libarrow-flight: 15.0.2
-    libarrow-flight-sql: 15.0.2
-    libarrow-gandiva: 15.0.2
-    libarrow-substrait: 15.0.2
-    libgcc-ng: '>=12'
-    libparquet: 15.0.2
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-15.0.2-py310hf9e7431_1_cpu.conda
+    libarrow-acero: 16.1.0.*
+    libarrow-dataset: 16.1.0.*
+    libarrow-substrait: 16.1.0.*
+    libparquet: 16.1.0.*
+    numpy: '>=1.19,<3'
+    pyarrow-core: 16.1.0
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-16.1.0-py311hbd00459_6.conda
   hash:
-    md5: 7828e1661a5168ca7089b4be96fbf02c
-    sha256: 94c4f9598354c8cf3be3d7da0a0d8d5cc3f9784979d7d2bd0791951c0eb2558b
+    md5: 1ab36200f108cfa8fcbdb30f27a2895f
+    sha256: a7161f1246ba983804cab45e0f17020140b144ad2c30e9d42aec01e80d8d30b5
+  category: main
+  optional: false
+- name: pyarrow-core
+  version: 16.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libarrow: 16.1.0.*
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-16.1.0-py311h4854187_6_cpu.conda
+  hash:
+    md5: 2d6aed24bd8ce29610da4663573e2a56
+    sha256: 9666a763783111d0aa07d78823cff9e89446ba8c928ca16abe876ebe9b1f9c3b
   category: main
   optional: false
 - name: pyarrow-hotfix
@@ -8765,28 +9388,28 @@ package:
   category: main
   optional: false
 - name: pyasn1
-  version: 0.5.1
+  version: 0.6.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.5.1-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_1.conda
   hash:
-    md5: fb1a800972b072aa4d16450983c81418
-    sha256: 8b116da9acbb471e107203c11acaffcb259aca2367aa7e83e796e43ed5d381b3
+    md5: 960ae8a1852b4e0fbeafe439fa7f4eab
+    sha256: 7f8d61f80e548ed29e452bb51742f0370614f210156cd8355b89803c3f3999d5
   category: main
   optional: false
 - name: pyasn1-modules
-  version: 0.3.0
+  version: 0.4.1
   manager: conda
   platform: linux-64
   dependencies:
-    pyasn1: '>=0.4.6,<0.6.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.3.0-pyhd8ed1ab_0.conda
+    pyasn1: '>=0.4.6,<0.7.0'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.4.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 26db749166cdca55e5ef1ffdc7767d0e
-    sha256: 7867ba43b6ef1e66054ca6b70f59bbef4cdb0cc761f0be3b66d79d15bd43143b
+    md5: f781c31cdff5c086909f8037ed0b0472
+    sha256: 2dd9d70e055cdc51b5b2dcf3f0e9c0c44599b6155928033886f4efebfdda03f3
   category: main
   optional: false
 - name: pycamhd
@@ -8829,80 +9452,86 @@ package:
   category: main
   optional: false
 - name: pyct
-  version: 0.4.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    pyct-core: 0.4.6.*
-    python: ''
-    pyyaml: ''
-    requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pyct-0.4.6-py_0.tar.bz2
-  hash:
-    md5: 42d91c89bc3993ec88681cffd3c0e326
-    sha256: 50af51619db6a35c36e65e8f50c83c722c3358f1f4b5527e87799b8f9935ace0
-  category: main
-  optional: false
-- name: pyct-core
-  version: 0.4.6
+  version: 0.5.0
   manager: conda
   platform: linux-64
   dependencies:
     param: '>=1.7.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pyct-core-0.4.6-py_0.tar.bz2
+    python: '>=3.7'
+    pyyaml: ''
+    requests: ''
+    setuptools: '>=61.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 55ec526f95e0959de3f68bc6289a20da
-    sha256: 8abc24dcf2782feca867974ba2aa0c9aaeae0966dad3f54507b39da30123d481
+    md5: 24c245c82396be3297c0aa26b69e18d8
+    sha256: 0e1e17a37d53be84c33b88218f10afb5f8137f19a727fdc56e45ae0b8b439a57
   category: main
   optional: false
 - name: pydantic
-  version: 2.6.4
+  version: 2.9.2
   manager: conda
   platform: linux-64
   dependencies:
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.16.3
+    annotated-types: '>=0.6.0'
+    pydantic-core: 2.23.4
     python: '>=3.7'
     typing-extensions: '>=4.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 2e8e9f16431085f4b5a218b31fe557a3
-    sha256: 9747044e91a607c175bbce67fdb5865de5373151098bbb4a2cd79bc05666a299
+    md5: 1eb533bb8eb2199e3fef3e4aa147319f
+    sha256: 1b7b0dc9f6af4da156bf22b0263be70829364a08145c696d3670facff2f6441a
   category: main
   optional: false
 - name: pydantic-core
-  version: 2.16.3
+  version: 2.23.4
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.16.3-py310hcb5633a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.23.4-py311h9e33e62_0.conda
   hash:
-    md5: 3f7aa5bfda188d57c4741de6fcc15330
-    sha256: 0048a136343af983b6f6ee9fc6a65259d231eb3e90c57b2f9adaef725b64b17e
+    md5: 5e24fd648b7926bec16e535efda533c2
+    sha256: 3cdbe29c2b4aec34aabcf03cf2b34a6284563c03bdb43b63d204e6d9f6f0dbfc
   category: main
   optional: false
 - name: pydap
-  version: 3.4.0
+  version: '3.5'
   manager: conda
   platform: linux-64
   dependencies:
     beautifulsoup4: ''
-    docopt: ''
+    docopt-ng: ''
+    importlib-metadata: ''
+    importlib-resources: ''
     jinja2: ''
+    lxml: ''
     numpy: ''
-    python: '>=3.7'
+    python: '>=3.9'
     requests: ''
-    six: '>=1.4.0'
     webob: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pydap-3.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydap-3.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 14fd0d740838aec5356d42a04c4e40e8
-    sha256: 2ba09aeebf92f3f3eba944d805c6106a638bc2c4cef6744d4b387a3f4f53afd5
+    md5: 308214e9f1c2183363b6c49ecf757422
+    sha256: f431b034fa889526b31f6d8ad04e3e0f7b3f88a4eaf45fa6c21e8e404276939d
+  category: main
+  optional: false
+- name: pydot
+  version: 1.4.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    graphviz: ''
+    pyparsing: '>=2.1.4'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydot-1.4.2-py311h38be061_4.conda
+  hash:
+    md5: 5c223cb0d9c05552bf9d1586a92720b2
+    sha256: 63318c69bcdacd4789652141025087e8c56306428e34d32fe62ffd08005862b1
   category: main
   optional: false
 - name: pyepsg
@@ -8919,18 +9548,19 @@ package:
   category: main
   optional: false
 - name: pyerfa
-  version: 2.0.1.1
+  version: 2.0.1.4
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyerfa-2.0.1.1-py310h1f7b6fc_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyerfa-2.0.1.4-py311h9f3472d_2.conda
   hash:
-    md5: 3e94f020268f6bd6c4a8a52b81aeee84
-    sha256: a31812c6f9cf621459fa8991d53b7e887483a57ace65e47fb4336cd638a20328
+    md5: e44bbd13d3c44d5870cb05aa7e802f39
+    sha256: 982d0727102f55e65b2647f11a68cedd7d8b5f781db140ad6d4652e04cd26816
   category: main
   optional: false
 - name: pygls
@@ -8948,42 +9578,59 @@ package:
   category: main
   optional: false
 - name: pygments
-  version: 2.17.2
+  version: 2.18.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 140a7f159396547e9799aa98f9f0742e
-    sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
+    md5: b7f5c092b8f9800150d998a71b76d5a1
+    sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
   category: main
   optional: false
 - name: pyjwt
-  version: 2.8.0
+  version: 2.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_1.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.9.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 74f76d4868dbba5870f2cf1d9b12d8f3
-    sha256: d7cb7fbafd767e938db10820c76a9c16d91faf5a081842159cc185787879eb07
+    md5: 5ba575830ec18d5c51c59f403310e2c7
+    sha256: b6f47cd0737cb1f5aca10be771641466ec1a3be585382d44877140eb2cb2dd46
   category: main
   optional: false
 - name: pykdtree
-  version: 1.3.11
+  version: 1.3.13
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pykdtree-1.3.11-py310h1f7b6fc_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pykdtree-1.3.13-py311h9f3472d_1.conda
   hash:
-    md5: 25ede13c92af9a12712dc33fdc3adc11
-    sha256: 54b1f7aab4087a3e21fbedc5839121e05fd53214548f7a73578156e8b0cb5192
+    md5: 87b04d34d110ea5ff945f1949b7436be
+    sha256: 7f8dcafb729ccdc36d458790e743321259ce6767933cbe1d98fd8bbe5eccc0ee
+  category: main
+  optional: false
+- name: pykrb5
+  version: 0.5.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cryptography: '>=1.3'
+    krb5: '>=1.21.2,<1.22.0a0'
+    libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pykrb5-0.5.1-py311h0820609_1.conda
+  hash:
+    md5: 26ee2e5df547f4545c0e3a9ef98fdcb7
+    sha256: 07f0619523166973a4d8129bc1d71d47185452cb48d7f6537ecdb24a2790d376
   category: main
   optional: false
 - name: pykube-ng
@@ -9017,100 +9664,138 @@ package:
     sha256: eac07e515393f891e0d4031d14db4d3609febc30a4e3536172cec412480c249b
   category: main
   optional: false
+- name: pymongo
+  version: 4.10.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    dnspython: <3.0.0,>=1.16.0
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pymongo-4.10.1-py311hfdbb021_0.conda
+  hash:
+    md5: 55b0b73f9cf7b2be9cd96e3e4b7e62b9
+    sha256: 4b5521971a8d22d42ea3d4b926b7f91b580a9c7374ba104bb4b687d6d31391bb
+  category: main
+  optional: false
 - name: pynacl
   version: 1.5.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cffi: '>=1.4.1'
-    libgcc-ng: '>=12'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    libgcc: '>=13'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     six: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.5.0-py310h2372a71_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.5.0-py311h9ecbd09_4.conda
   hash:
-    md5: a29a0825809cd3a780097472be176618
-    sha256: f47cc2039e555a03187defab05cf77cc28f56df1a820d789efad39a930994192
+    md5: 522059f3c55e201aa5f189fe5276f83f
+    sha256: ce8ba3a3448b6d55a4740b5e826839752976435f0121739565aae5796bcf6dc1
   category: main
   optional: false
-- name: pyopenssl
-  version: 24.0.0
+- name: pyogrio
+  version: 0.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    cryptography: '>=41.0.5,<43'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.9.2,<3.10.0a0'
+    libstdcxx: '>=13'
+    numpy: ''
+    packaging: ''
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.10.0-py311h5fbebbf_0.conda
   hash:
-    md5: b50aec2c744a5c493c09cce9e2e7533e
-    sha256: bacd1d38585f447e2809e7621283661da7c97cfa20f545edb0ac5838356ed87b
+    md5: 9d7fdfd10f69e238be48da8bf7219633
+    sha256: 7e15af8cd9014c59122b3c2c2eacec325c2ee144cbbdef58406fd8f65c263502
+  category: main
+  optional: false
+- name: pyopenssl
+  version: 24.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cryptography: '>=41.0.5,<44'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.2.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: 85fa2fdd26d5a38792eb57bc72463f07
+    sha256: 6618aaa9780b723abfda95f3575900df99dd137d96c80421ad843a5cbcc70e6e
   category: main
   optional: false
 - name: pyorbital
-  version: 1.8.2
+  version: 1.8.3
   manager: conda
   platform: linux-64
   dependencies:
     numpy: '>=1.6.0,!=1.14.0'
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyorbital-1.8.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyorbital-1.8.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 7a2e5cfd77fcb5f1eb3f8b50345e444e
-    sha256: a4e15ef69cf3cc56d80bff37cf7a6e7122337552124aa4fe2a14a0c86e497081
+    md5: b8800b68eed43d48c43531de338c92af
+    sha256: e19a1dc431c908d5f4337d8b517a60a3cb1b18f956b0a1b9c94063ac0a62435a
   category: main
   optional: false
 - name: pyparsing
-  version: 3.1.2
+  version: 3.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: b9a4dacf97241704529131a0dfc0494f
-    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
+    md5: 035c17fbf099f50ff60bf2eb303b0a83
+    sha256: b846e3965cd106438cf0b9dc0de8d519670ac065f822a7d66862e9423e0229cb
   category: main
   optional: false
 - name: pyproj
-  version: 3.6.1
+  version: 3.7.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     certifi: ''
-    libgcc-ng: '>=12'
-    proj: '>=9.3.1,<9.3.2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py310hd5c30f3_5.conda
+    libgcc: '>=13'
+    proj: '>=9.5.0,<9.6.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py311h0f98d5a_0.conda
   hash:
-    md5: dc2ee770a2299307f3c127af79160d25
-    sha256: a0085fc194db88e0a82468d27659a4a8cb167670676c88d0431846dc3dbcbd04
+    md5: 22531205a97c116251713008d65dfefd
+    sha256: 194440401fba9fb3903aa921abcf3da468172700b5b5c9b21f98fb7be469a54f
   category: main
   optional: false
 - name: pyresample
-  version: 1.28.2
+  version: 1.31.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     configobj: ''
     donfig: ''
-    importlib-metadata: ''
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    numpy: '>=1.21.0'
     platformdirs: ''
     pykdtree: '>=1.3.1'
     pyproj: '>=3.0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     pyyaml: ''
     setuptools: '>=3.2'
     shapely: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyresample-1.28.2-py310hcc13569_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyresample-1.31.0-py311h7db5c69_0.conda
   hash:
-    md5: 3ccf8deead2905f015422a6f4331ed10
-    sha256: c317a9b3942a92e039de05e1c6402891707ed8efbcce20ffda16213f816544a9
+    md5: df49168de7760db9acede27945fe0528
+    sha256: 3dc9a6a2c0008636e0b63094ae4f4b4235a9d50af2ac9a3af519162f8b90588d
   category: main
   optional: false
 - name: pyshp
@@ -9139,59 +9824,72 @@ package:
   category: main
   optional: false
 - name: pyspectral
-  version: 0.13.0
+  version: 0.13.5
   manager: conda
   platform: linux-64
   dependencies:
-    appdirs: ''
     dask: ''
-    docutils: '>=0.3'
     h5py: '>=2.5'
     numpy: '>=1.5.1'
+    platformdirs: ''
     python: '>=3.10'
     python-geotiepoints: '>=1.1.1'
     pyyaml: ''
     requests: ''
-    scipy: '>=0.14'
+    scipy: '>=1.6.0'
     setuptools: ''
-    six: ''
     tqdm: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pyspectral-0.13.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyspectral-0.13.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 0447dcf800d61907801c635b0332317c
-    sha256: 75329597d0162a5a3b719b181fcc89fd0b04ca7892dfb4d361eaf97960c70809
+    md5: fb231e26b0d64d3bf989a3cc96c3c7d8
+    sha256: 21d19499972990dcc574ea39b7128e837a03b040b3a014b8843786f6af088bcc
+  category: main
+  optional: false
+- name: pyspnego
+  version: 0.11.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cryptography: ''
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    ruamel.yaml: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyspnego-0.11.1-py311h38be061_0.conda
+  hash:
+    md5: 907b17dbe4dd97a0029ba6a9b7cbab3e
+    sha256: 34973f101c6a0ba8022f0b9f7760920861e34b620f66701272ba07b6e77e565a
   category: main
   optional: false
 - name: pystac
-  version: 1.10.0
+  version: 1.11.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     python-dateutil: '>=2.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pystac-1.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-1.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2a8bb0f238965a29f19e69707e803e51
-    sha256: 9b8ef88ed0d23dc4300366baab3be11e96dd8e1f773fa152b05eb61fa4356741
+    md5: 33c5e6aa8842a539826bd1bcb405001c
+    sha256: 51603c07c4935110872f450d4663a14e5b59e1c8fedd815f60fcd910738ea22c
   category: main
   optional: false
 - name: pystac-client
-  version: 0.7.6
+  version: 0.8.5
   manager: conda
   platform: linux-64
   dependencies:
-    pystac: '>=1.8.2'
-    python: '>=3.8'
+    pystac: '>=1.10.0'
+    python: '>=3.10'
     python-dateutil: '>=2.8.2'
     requests: '>=2.28.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.7.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.8.5-pyhd8ed1ab_0.conda
   hash:
-    md5: b036daea0a2114d5dcffaeefff84f6b4
-    sha256: a0917d92a53300f495b55cc4f64df92b47e2fd83c18e3deb499efe7765d63b75
+    md5: 68fb9ba6beefb406896a642bf2a77e79
+    sha256: 37bd343a90605a2705d2dbabe4a588d57d75d909e77f0560b312a0f24772c0ca
   category: main
   optional: false
 - name: pytest
-  version: 8.1.1
+  version: 8.3.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -9199,72 +9897,76 @@ package:
     exceptiongroup: '>=1.0.0rc8'
     iniconfig: ''
     packaging: ''
-    pluggy: <2.0,>=1.4
+    pluggy: <2,>=1.5
     python: '>=3.8'
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 94ff09cdedcb7b17e9cd5097ee2cfcff
-    sha256: 3c481d6b54af1a33c32a3f3eaa3e0971955431e7023db55808740cd062271c73
+    md5: c03d61f31f38fdb9facf70c29958bf7a
+    sha256: e99376d0068455712109d233f5790458ff861aeceb458bfda74e353338e4d815
   category: main
   optional: false
 - name: python
-  version: 3.10.14
+  version: 3.11.10
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
     ld_impl_linux-64: '>=2.36.1'
+    libexpat: '>=2.6.3,<3.0a0'
     libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     libnsl: '>=2.0.1,<2.1.0a0'
-    libsqlite: '>=3.45.2,<4.0a0'
+    libsqlite: '>=3.46.1,<4.0a0'
     libuuid: '>=2.38.1,<3.0a0'
     libxcrypt: '>=4.4.36'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4.20240210,<7.0a0'
-    openssl: '>=3.2.1,<4.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    ncurses: '>=6.5,<7.0a0'
+    openssl: '>=3.3.2,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.14-hd12c33a_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_3_cpython.conda
   hash:
-    md5: 2b4ba962994e8bd4be9ff5b64b75aff2
-    sha256: 76a5d12e73542678b70a94570f7b0f7763f9a938f77f0e75d9ea615ef22aa84c
+    md5: 9e1ad55c87368e662177661a998feed5
+    sha256: b7fa3bd48e3a3d30f65608e07759cefd27885c6388b3f612af85ce40282e6936
   category: main
   optional: false
 - name: python-blosc
-  version: 1.10.6
+  version: 1.11.2
   manager: conda
   platform: linux-64
   dependencies:
-    blosc: '>=1.21.1,<2.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-blosc-1.10.6-py310h769672d_1.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    blosc: '>=1.21.6,<2.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-blosc-1.11.2-py311h6dcdc2f_1.conda
   hash:
-    md5: 6cc3fc6a2f2ec1e1ee5caf13a699fb86
-    sha256: 189c7c203ade06ce35a4b2da6c03b71a91b27e20b7ee1bf4fd28de94151bd411
+    md5: d99c861be5994e16fb6e4a6c88ee6d6e
+    sha256: 8ddb8848095a0868ea606be255e3f61bf28c8072c11d9cf838ef44ccc64b53d7
   category: main
   optional: false
 - name: python-box
-  version: 7.1.1
+  version: 7.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     pip: ''
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     ruamel.yaml: ''
     toml: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-box-7.1.1-py310h2372a71_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-box-7.2.0-py311h9ecbd09_1.conda
   hash:
-    md5: edca7c2aab51ede5a557148931a80c2c
-    sha256: 9e76ae12b9f8938eec86c3c17cbe56b2ae7339be6ad4a3382471420b93dda917
+    md5: 019115b94fbd5e389afe4a18e253e1fb
+    sha256: 901e86ca6b8085283d2046ef4a6bafb4b8ffa4330a3daa309e8378967fb1b3b2
   category: main
   optional: false
 - name: python-dateutil
@@ -9293,66 +9995,69 @@ package:
   category: main
   optional: false
 - name: python-duckdb
-  version: 0.10.1
+  version: 1.1.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-0.10.1-py310hc6cd4ac_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.1.2-py311hfdbb021_1.conda
   hash:
-    md5: 08dd2f9a01eea47cf3be7ed47d3086b3
-    sha256: 6d72e2840b8112e89fe7c0275dfb8a433f1ed0b10916f0867951eaf06d494d9c
+    md5: a489c660bed1df2a040066161c7bf26e
+    sha256: 68e8494cea1e9c921941d62c15b6bf7d1e476af0cd05498e877e5a5257c9d71a
   category: main
   optional: false
 - name: python-eccodes
-  version: 1.7.0
+  version: 2.37.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     attrs: ''
     cffi: ''
-    eccodes: '>=2.31.0'
+    eccodes: '>=2.37.0'
     findlibs: ''
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-eccodes-1.7.0-py310h1f7b6fc_1.conda
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-eccodes-2.37.0-py311h9f3472d_0.conda
   hash:
-    md5: f020ac07b7df9c4b0bd0ece3055b5bd2
-    sha256: 020555df1fbfb8b30312af75ef81040be31ab02a0fbf8dee6b3646f007471054
+    md5: 648bccc358ec5b19dec01a5685f3aeb9
+    sha256: 2993b79577de22cc949f13cea70d74b6d31c98aef12bdc7616c82787d5fc7dd8
   category: main
   optional: false
 - name: python-fastjsonschema
-  version: 2.19.1
+  version: 2.20.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 4d3ceee3af4b0f9a1f48f57176bf8625
-    sha256: 38b2db169d65cc5595e3ce63294c4fdb6a242ecf71f70b3ad8cad3bd4230d82f
+    md5: b98d2018c01ce9980c03ee2850690fab
+    sha256: 7d8c931b89c9980434986b4deb22c2917b58d9936c3974139b9c10ae86fdfe60
   category: main
   optional: false
 - name: python-geotiepoints
-  version: 1.7.2
+  version: 1.7.5
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
     pandas: ''
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-geotiepoints-1.7.2-py310h1f7b6fc_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-geotiepoints-1.7.5-py311h9f3472d_1.conda
   hash:
-    md5: 695af89d9954245c8496e0f3682010cf
-    sha256: 9eb47c6efb0fd6606a51f2433f6cfc5c189f4f7bf877eda6dd8012fd7ae67025
+    md5: bb4d327577092a558d02eb0c31ba9010
+    sha256: c3543be1c02ba82bcc1736169ed97d065b72fa1cd11f59bf5c0ee1d99bab9eb9
   category: main
   optional: false
 - name: python-gist
@@ -9387,11 +10092,46 @@ package:
   platform: linux-64
   dependencies:
     graphviz: '>=2.46.1'
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyh717bed2_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyhe28f650_1.conda
   hash:
-    md5: 031c005eb6d4513013d99ed163dd5f59
-    sha256: 71365b1f6b7eca79af010bfc184fa00ad05bb86eec3c20aec4ae98b411e056ab
+    md5: 881be78ca9f3f2f5f6aa45d9b38a799f
+    sha256: 0eca3595a52dd7ad83ebca1ee738af50bf21dbd70d623583b0185d84074e21af
+  category: main
+  optional: false
+- name: python-gssapi
+  version: 1.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    decorator: ''
+    krb5: '>=1.21.3,<1.22.0a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-gssapi-1.9.0-py311h9db375c_0.conda
+  hash:
+    md5: 7c1331954f398c3be464734b8fac4edf
+    sha256: bfe937975dabdff2ee8eb4f9cb5e9f699b94632c7b8e6601edd97b63da37ada2
+  category: main
+  optional: false
+- name: python-hdfs
+  version: 2.7.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    docopt: ''
+    fastavro: '>=0.21.19'
+    pandas: '>=0.14.1'
+    python: '>=3.7'
+    requests: '>=2.7.0'
+    requests-kerberos: '>=0.7.0'
+    six: '>=1.9.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.7.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: c43e50d900680f7bfbb0237317b9983f
+    sha256: 09eb22ebcbd42fe4ee517cfed707ceb92cc8a4ca3102ed8fa1d44d5bc3e914eb
   category: main
   optional: false
 - name: python-json-logger
@@ -9407,54 +10147,67 @@ package:
   category: main
   optional: false
 - name: python-jsonpath
-  version: 1.1.1
+  version: 1.2.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-jsonpath-1.1.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-jsonpath-1.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 953e2b70918e22ab25fc9e56bac20ea1
-    sha256: 30712837411e51f50b6f80df052c015603175ca7a4fce137edcfda3c2ea14514
+    md5: 14e19678b15886c27dd7bae60d5254f6
+    sha256: fda8967d652fa124a1288b24b4cdefaee607a2a3e7eda9cfc74f82affe6514d2
   category: main
   optional: false
 - name: python-kubernetes
-  version: 27.2.0
+  version: 28.1.0
   manager: conda
   platform: linux-64
   dependencies:
     certifi: '>=14.05.14'
     google-auth: '>=1.0.1'
+    oauthlib: '>=3.2.2'
     python: '>=3.6'
     python-dateutil: '>=2.5.3'
     pyyaml: '>=5.4.1'
     requests: ''
     requests-oauthlib: ''
-    setuptools: '>=21.0.0'
     six: '>=1.9.0'
-    urllib3: '>=1.24.2'
+    urllib3: '>=1.24.2,<2.0'
     websocket-client: '>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-kubernetes-27.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-kubernetes-28.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6978e0543a3e71fc22db5763371e460b
-    sha256: b6fe4941559b7cb334e850729da9a56cabd528b3822e1fe075c55715735a7c7f
+    md5: 19e0767d01e052487650c0341c186219
+    sha256: 559098188048ea52739815b2311b06bf381bf4c7a7924baaf2e99de0c01b2113
   category: main
   optional: false
-- name: python-pdal
-  version: 3.3.0
+- name: python-multipart
+  version: 0.0.17
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    pdal: '>=2.7.1,<2.7.2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-pdal-3.3.0-py310he6b3783_7.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.17-pyhff2d567_0.conda
   hash:
-    md5: 96c5f378606b2d369afa53fcd5dc64f9
-    sha256: a15b4a5fa711403441b3277a3fe039c0a5a3c577cbb8d7f50da7d4f548803d48
+    md5: a08ea55eb3ad403b12639cd3a4a8d28f
+    sha256: f351636a91163de28cf602c755abd1b5ad858e4a790c3a30d5a5aa1066c0550c
+  category: main
+  optional: false
+- name: python-pdal
+  version: 3.4.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libpdal-core: '>=2.8.0,<2.9.0a0'
+    libstdcxx: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-pdal-3.4.5-py311h870b839_12.conda
+  hash:
+    md5: e7d14277a7e49e437f056f171d9041c4
+    sha256: aa19a6d4eb44aca304a2e8ba80475e6b6f4e24b79546c5b9f02a45a466b4f728
   category: main
   optional: false
 - name: python-slugify
@@ -9471,40 +10224,42 @@ package:
   category: main
   optional: false
 - name: python-tzdata
-  version: '2024.1'
+  version: '2024.2'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 98206ea9954216ee7540f0c773f2104d
-    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
+    md5: 986287f89929b2d629bd6ef6497dc307
+    sha256: fe3f62ce2bc714bdaa222ab3f0344a2815ad9e853c6df38d15c9f25de8a3a6d4
   category: main
   optional: false
 - name: python_abi
-  version: '3.10'
+  version: '3.11'
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
   hash:
-    md5: 26322ec5d7712c3ded99dd656142b8ce
-    sha256: 456bec815bfc2b364763084d08b412fdc4c17eb9ccc66a36cb775fa7ac3cbaec
+    md5: 139a8d40c8a2f430df31048949e450de
+    sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
   category: main
   optional: false
 - name: pytools
-  version: 2024.1.1
+  version: 2024.1.14
   manager: conda
   platform: linux-64
   dependencies:
-    platformdirs: '>=2.2.0'
+    platformdirs: '>=2.2'
     python: '>=3.8'
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pytools-2024.1.1-pyhd8ed1ab_0.conda
+    siphash24: '>=1.6'
+    typing-extensions: '>=4'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytools-2024.1.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 61d348388af32b6d95250a342afd5a0b
-    sha256: 686e2e9b22543699e26a7eee14cfc90c45427054bb76d4c829553102704b38c0
+    md5: 8d9d51e98099390c35e72f5b8b1747f1
+    sha256: 427dc2ad1ec0afc51aa00e2b28c09dd7bb0d4efecad11088caf0adc7f947468a
   category: main
   optional: false
 - name: pytz
@@ -9545,31 +10300,32 @@ package:
   category: main
   optional: false
 - name: pyviz_comms
-  version: 3.0.1
+  version: 3.0.3
   manager: conda
   platform: linux-64
   dependencies:
     param: ''
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 228d232000920ca651f5b6212389785c
-    sha256: a3604580a8b4b61dedf982c66a7d2937a64a857eeac73004e353c1d550cb8a05
+    md5: 02b4e3a3014c1ac490ee4a4316f2d229
+    sha256: a7979e8e4936c430f5fe3d04fc2d67b42dab84fb4a502c4961a17dcb2327fec0
   category: main
   optional: false
 - name: pywavelets
-  version: 1.4.1
+  version: 1.7.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.4.1-py310h1f7b6fc_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.23,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.7.0-py311h9f3472d_2.conda
   hash:
-    md5: be6f0382440ccbf9fb01bb19ab1f1fc0
-    sha256: 2aa5da771dd7e4ec8316de51edd7aefcb6f688f7e4d2a2905faac76462826cf7
+    md5: bd9c3ff46028eec017bc78377f9e0fb6
+    sha256: f513c2e6fac16fd90ab5b8af87b704202e49c9e3685ba49884703a9c7d523daa
   category: main
   optional: false
 - name: pywin32-on-windows
@@ -9586,61 +10342,78 @@ package:
   category: main
   optional: false
 - name: pyyaml
-  version: 6.0.1
+  version: 6.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
   hash:
-    md5: bb010e368de4940771368bc3dc4c63e7
-    sha256: aa78ccddb0a75fa722f0f0eb3537c73ee1219c9dd46cea99d6b9eebfdd780f3d
+    md5: abeb54d40f439b86f75ea57045ab8496
+    sha256: e721e5ff389a7b2135917c04b27391be3d3382e261bb60a369b1620655365c3d
   category: main
   optional: false
 - name: pyzmq
-  version: 25.1.2
+  version: 26.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.2-py310h795f18f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_3.conda
   hash:
-    md5: fa09f98f3acfd3f5de30bd2d27d5cb7f
-    sha256: 6ce93fd1e847ce02c2bbfa6022b639b21d4229d61b21ce0ecacb22c380e5680e
+    md5: e0897de1d8979a3bb20ef031ae1f7d28
+    sha256: 3fdef7b3c43474b7225868776a373289a8fd92787ffdf8bed11cf7f39b4ac741
+  category: main
+  optional: false
+- name: qhull
+  version: '2020.2'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  hash:
+    md5: 353823361b1d27eb3960efb076dfcaf6
+    sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
   category: main
   optional: false
 - name: rasterio
-  version: 1.3.9
+  version: 1.4.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     affine: ''
     attrs: ''
     certifi: ''
     click: '>=4'
     click-plugins: ''
     cligj: '>=0.5'
-    libgcc-ng: '>=12'
-    libgdal: '>=3.8.1,<3.9.0a0'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    proj: '>=9.3.1,<9.3.2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    libgcc: '>=13'
+    libgdal-core: '>=3.9.2,<3.10.0a0'
+    libstdcxx: '>=13'
+    numpy: '>=1.21,<3'
+    proj: '>=9.5.0,<9.6.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     setuptools: '>=0.9.8'
     snuggs: '>=1.4.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.3.9-py310hedc89e0_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.1-py311hfbe26e2_0.conda
   hash:
-    md5: 02574ea00576e31d6eddc778bedcce3e
-    sha256: 48bc1daedd4c4dc5c9ea30638fb8337467bb6da362081ed340201f00b2eaf827
+    md5: 638f81ea2b56a2dc5e428d5378287548
+    sha256: 7774c96faa3f5bb66ca5a0d29eea9a3dcce0a1474b25ddc7ab45b1ae010488b2
   category: main
   optional: false
 - name: rav1e
@@ -9653,21 +10426,6 @@ package:
   hash:
     md5: 77d9955b4abddb811cb8ab1aa7d743e4
     sha256: 91b3c1ced90d04ee2eded1f72cf3cbc19ff05a25e41876ef0758266a5bab009f
-  category: main
-  optional: false
-- name: rdma-core
-  version: '51.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libnl: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-51.0-hd3aeb46_0.conda
-  hash:
-    md5: 493598e1f28c01e316fda127715593aa
-    sha256: bcc774b60605b09701cfad41b2d6d9c3f052dd4adfc1f02bf1c929076f48fe30
   category: main
   optional: false
 - name: re2
@@ -9683,15 +10441,15 @@ package:
   category: main
   optional: false
 - name: readchar
-  version: 4.0.5
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/readchar-4.0.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/readchar-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 513334936060e80697bc21079e4f2829
-    sha256: 0426cd7a524c31ab6d52b4d181848daea81d057e200a74200ea6e2896534bc18
+    md5: b578301525c2c0ac7c91809d10d4f768
+    sha256: 6ddd104e484a4aa6ec674f8ed434f8681ef08e3fb84f329441bf127d3f278dc8
   category: main
   optional: false
 - name: readline
@@ -9722,48 +10480,82 @@ package:
     sha256: ece0b0ac0fff93bdc068e169cc394a5f65bb119242f15b84b06dbb1b176b21b2
   category: main
   optional: false
+- name: redis-py
+  version: 5.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    async-timeout: '>=4.0.2'
+    importlib-metadata: '>=1.0'
+    python: '>=3.8'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/redis-py-5.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6500d1982f80aacd0fb41ce74771fbed
+    sha256: c6864b473b8faa1c7a3bba28fafd7b1bdb85062f0c6cbd3472169479e76d77a8
+  category: main
+  optional: false
 - name: referencing
-  version: 0.34.0
+  version: 0.35.1
   manager: conda
   platform: linux-64
   dependencies:
     attrs: '>=22.2.0'
     python: '>=3.8'
     rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.34.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
   hash:
-    md5: e4492c22e314be5c75db3469e3bbf3d9
-    sha256: 2e631e9e1d49280770573f7acc7441b70181b2dc21948bb1be15eaae80550672
+    md5: 0fc8b52192a8898627c3efae1003e9f6
+    sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
   category: main
   optional: false
 - name: regex
-  version: 2023.12.25
+  version: 2024.9.11
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/regex-2023.12.25-py310h2372a71_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/regex-2024.9.11-py311h9ecbd09_0.conda
   hash:
-    md5: 4a9ba4e7af60356e63b38a6d419acad6
-    sha256: b9d2c96a468e4c871df098f6c34c72b160911fb98132e1ffd6ba92670cbeb523
+    md5: 3f88e160ed9b6c987ca37a57c28c6247
+    sha256: 96543775d25b653c9a0939b63c1d2657115a7ecdbfb36fb60ed8979c3bccd2e8
   category: main
   optional: false
 - name: requests
-  version: 2.31.0
+  version: 2.32.3
   manager: conda
   platform: linux-64
   dependencies:
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: '>=3.7'
+    python: '>=3.8'
     urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
-    md5: a30144e4156cdbb236f99ebb49828f8b
-    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+    md5: 5ede4753180c7a550a443c430dc8ab52
+    sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
+  category: main
+  optional: false
+- name: requests-kerberos
+  version: 0.15.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+    cryptography: '>=1.3'
+    pykrb5: '>=0.3.0'
+    pyspnego: ''
+    python: '>=3.8'
+    python-gssapi: '>=1.6.0'
+    requests: '>=1.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-kerberos-0.15.0-pyh707e725_0.conda
+  hash:
+    md5: b56c004b94c38569f79d735f1345c054
+    sha256: f80cfc7e4d8c5a07404c1bf04137cca313a539318199c3b63d2ab914b7ecb7ce
   category: main
   optional: false
 - name: requests-oauthlib
@@ -9806,39 +10598,38 @@ package:
   category: main
   optional: false
 - name: rich
-  version: 13.7.1
+  version: 13.9.4
   manager: conda
   platform: linux-64
   dependencies:
     markdown-it-py: '>=2.2.0'
     pygments: '>=2.13.0,<3.0.0'
-    python: '>=3.7.0'
+    python: '>=3.8'
     typing_extensions: '>=4.0.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_0.conda
   hash:
-    md5: ba445bf767ae6f0d959ff2b40c20912b
-    sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
+    md5: bcf8cc8924b5d20ead3d122130b8320b
+    sha256: c009488fc07fd5557434c9c1ad32ab1dd50241d6a766e4b2b4125cd6498585a8
   category: main
   optional: false
 - name: rio-cogeo
-  version: 5.2.0
+  version: 5.3.6
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=7.0'
     morecantile: '>=5.0,<6.0'
-    numpy: '>=1.15,<2.dev0'
     pydantic: '>=2.0,<3.dev0'
     python: '>=3.8'
     rasterio: '>=1.3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/rio-cogeo-5.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rio-cogeo-5.3.6-pyhd8ed1ab_0.conda
   hash:
-    md5: fba66248ba149dcde45de4c5e79340c8
-    sha256: c3edc68e12458a484a2a5363b9ade99c992a42a96b0e4d39bc0342208760bba3
+    md5: e771b73aeb202e24e532527cd13872b3
+    sha256: dc1c392deabec6ec8ea99e6d05d7ad24652271c27129cf789f044cca2a4f26e2
   category: main
   optional: false
 - name: rio-tiler
-  version: 6.4.3
+  version: 6.7.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -9855,14 +10646,14 @@ package:
     pystac: '>=0.5.4'
     python: '>=3.8'
     rasterio: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rio-tiler-6.4.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rio-tiler-6.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 124a2f24f171026128c282a58e8d27da
-    sha256: cae1b594752aaad10c41861aee09ff9ad907e8e442fb1196a70c43f6263f0167
+    md5: f707113f3b34acc288adc011618d804b
+    sha256: 6b0732970ebb84dbbf39eeea46e84862953e367d27cf7ac75640a193a7b573a8
   category: main
   optional: false
 - name: rioxarray
-  version: 0.15.1
+  version: 0.17.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -9873,82 +10664,71 @@ package:
     rasterio: '>=1.3'
     scipy: ''
     xarray: '>=2022.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1ee15f68451f316e24e76b48f2b98aeb
-    sha256: 534c4792376ca1face1f51e0d386c9d84ac5f511631373276531addc423215cc
+    md5: 160464c6f979eb68e9a9ea31dd6b5aa6
+    sha256: 992ce1a2667dd2beac45157dcb9058775e0522ebf1a70f1563c0fd0608f9480a
   category: main
   optional: false
 - name: roaring-landmask
-  version: 0.7.1
+  version: 0.9.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     xz: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/roaring-landmask-0.7.1-py310h9b4d0d4_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/roaring-landmask-0.9.1-py311ha8c6e60_1.conda
   hash:
-    md5: cc1be127d46a72c43ad0561ebe0adaf4
-    sha256: 68af44dca15591d97a092fa4fbaa731e30bac3e61ad45b987d4a8ab478fefcf5
+    md5: d277ffa8346202ec6d9c1ad134a81989
+    sha256: a92b8cbec7eaac5ea9e50acb2f6045769a63334101fefa2cff139515571f1a05
   category: main
   optional: false
 - name: rpds-py
-  version: 0.18.0
+  version: 0.20.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.18.0-py310hcb5633a_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.20.1-py311h9e33e62_0.conda
   hash:
-    md5: eca3962963d1de0a4d13572ba943b61d
-    sha256: 180f734f14402a3605cc0d0a70dd52539c87ba76337da6eb73ebf603c8405c6b
+    md5: 359aec32fd9f6b881f6f1e2b287608eb
+    sha256: e68466c94743a728f848d152e1088498c2d7d14d8f5034101a1c18c5211b10f2
   category: main
   optional: false
 - name: rsa
-  version: 4.7.2
+  version: '4.9'
   manager: conda
   platform: linux-64
   dependencies:
     pyasn1: '>=0.1.3'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.7.2-pyh44b312d_0.tar.bz2
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
   hash:
-    md5: 3452ab3790dbb1df9508b3fa4ea2f806
-    sha256: 6ea0fcd8f40c7f78e2c6cff344bb91f457682aa352ee48364246371a41410ee8
-  category: main
-  optional: false
-- name: rtree
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libspatialindex: '>=1.9.3,<1.9.4.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/rtree-1.2.0-py310hbdcdc62_0.conda
-  hash:
-    md5: 9d74922cb84c2c63e96cda3407c6372f
-    sha256: e90231d6ef275be2c912d5cc1e0e59edf22fb575d724d497fad399a325b56a26
+    md5: 03bf410858b2cefc267316408a77c436
+    sha256: 23214cdc15a41d14136754857fd9cd46ca3c55a7e751da3b3a48c673f0ee2a57
   category: main
   optional: false
 - name: ruamel.yaml
-  version: 0.18.6
+  version: 0.17.21
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     ruamel.yaml.clib: '>=0.1.2'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.6-py310h2372a71_0.conda
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.21-py311h2582759_3.conda
   hash:
-    md5: 50b7d9b39099cdbabf65bf27df73a793
-    sha256: 37581cbd99eb8855b6d268c85d189d723dd4fa1f9d115b8a633bed6dea4c370e
+    md5: d47e33b1053996205f29896708c91a3d
+    sha256: bbf5aff9519226e7cf98a7df4b4d0b0de97991c64515a6ddcaca91d4c822226e
   category: main
   optional: false
 - name: ruamel.yaml.clib
@@ -9956,54 +10736,56 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py310h2372a71_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py311h9ecbd09_1.conda
   hash:
-    md5: dcf6d2535586c77b31425ed835610c54
-    sha256: cfcb1b4528074684b2e339b6854320f42a03e7545ff1944ef8262e0130e5c6c8
+    md5: e56869fca385961323e43783b89bef66
+    sha256: e38364ad63e29ea0134b2d6661c71d78a384a6f0f0c6248a270c97a73a970de8
   category: main
   optional: false
 - name: s2n
-  version: 1.4.8
+  version: 1.5.5
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.8-h06160fa_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.5-h3931f03_0.conda
   hash:
-    md5: 0240a49dffea6daea27aa388663edcab
-    sha256: 1068495f0f8f8b999dda339429dfaf5a8bd2e7a25bb386b6c39fd33ba01753fd
+    md5: 334dba9982ab9f5d62033c61698a8683
+    sha256: a6fa0afa836f8f26dea0abc180ca2549bb517932d9a88a121e707135d4bcb715
   category: main
   optional: false
 - name: s3fs
-  version: 2024.3.1
+  version: 2024.10.0
   manager: conda
   platform: linux-64
   dependencies:
     aiobotocore: '>=2.5.4,<3.0.0'
     aiohttp: ''
-    fsspec: 2024.3.1
+    fsspec: 2024.10.0
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 09003467a61e115c4652f8b1ffa7ccbb
-    sha256: a893cf822ca952cacb89ffa3daf312a4c367056a94db942ad792dcd672940f42
+    md5: 18cc1c4f5b104400d75be999b56486a1
+    sha256: b5a8e8fb68087166abef44c185dfb8c6ad1e4b54c56e82c03a3e3b306e0ca757
   category: main
   optional: false
 - name: s3transfer
-  version: 0.10.1
+  version: 0.10.3
   manager: conda
   platform: linux-64
   dependencies:
     botocore: '>=1.33.2,<2.0a.0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.3-pyhd8ed1ab_0.conda
   hash:
-    md5: a41cafc1fb653ce0e48b9310226e90fd
-    sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
+    md5: 0878f8e10cb8b4e069d27db48b95c3b5
+    sha256: a8d6061e31cd4e315b26ab1f6a74c618c930d3e14eb3b7c82e4077a11eae2141
   category: main
   optional: false
 - name: sarsen
@@ -10028,17 +10810,17 @@ package:
   category: main
   optional: false
 - name: satpy
-  version: 0.47.0
+  version: 0.52.1
   manager: conda
   platform: linux-64
   dependencies:
-    appdirs: ''
     dask: '>=0.17.1'
     donfig: ''
     h5py: ''
     netcdf4: ''
     numpy: '>=1.21.0'
     pillow: ''
+    platformdirs: ''
     pooch: ''
     pyorbital: ''
     pyproj: ''
@@ -10050,87 +10832,90 @@ package:
     trollsift: ''
     xarray: '>=0.10.1'
     zarr: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/satpy-0.47.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/satpy-0.52.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5d2728c64515a7c7d176c7e65e777aa3
-    sha256: 975b1e9f02f924394aca635fe628eddeb1ef13e0d0f651475908c33fcbb17252
+    md5: 2d692be9f7d970828bb89c2900e398e2
+    sha256: e4bdefc2c147c924f6b9b9a019d8dbd0b995585a500b6abeffb18c1024f213b4
   category: main
   optional: false
 - name: scikit-image
-  version: 0.22.0
+  version: 0.24.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     imageio: '>=2.27'
     lazy_loader: '>=0.2'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     networkx: '>=2.8'
-    numpy: '>=1.22.4,<2.0a0'
+    numpy: '>=1.19,<3'
     packaging: '>=21'
     pillow: '>=9.0.1'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     pywavelets: '>=1.1.1'
     scipy: '>=1.8'
     tifffile: '>=2022.8.12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.22.0-py310hcc13569_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.24.0-py311h7db5c69_3.conda
   hash:
-    md5: 801b47c8f5ecc81eb2cd5083197e5a19
-    sha256: dcb6cc7c27dfa8aa041ff7a9c237898bc82cc116f1e16665ee573d70a84df1f4
+    md5: 80773ebde697ba54dc3313356138936f
+    sha256: a992f0e099b619c9baafdb1245de760840cc105a871e09cf7bb531f0681bd945
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.4.1.post1
+  version: 1.5.2
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
     joblib: '>=1.2.0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     scipy: ''
-    threadpoolctl: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.4.1.post1-py310h1fdf081_0.conda
+    threadpoolctl: '>=3.1.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py311h57cc02b_1.conda
   hash:
-    md5: 2706ad1a5f6cbad8b57d4094889d1e33
-    sha256: ead98c64d92973cfbd82418be8030b848d0de1a865696ea1ddbaee2efbe77c4a
+    md5: d1b6d7a73364d9fe20d2863bd2c43e3a
+    sha256: b6489f65911847d1f9807e254e9af0815548454b911df4d0b5019f9ab16fe530
   category: main
   optional: false
 - name: scipy
-  version: 1.12.0
+  version: 1.14.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
+    libgcc: '>=13'
+    libgfortran: ''
+    libgfortran5: '>=13.3.0'
     liblapack: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.12.0-py310hb13e2d6_2.conda
+    libstdcxx: '>=13'
+    numpy: '>=1.23.5'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he9a78e4_1.conda
   hash:
-    md5: cd3baec470071490bc5ab05da64c52b5
-    sha256: 336c5c1b29441b99033375d084ed24a65bea852a02b3c79954134fc5ada8c6c4
+    md5: 49ba89bf4d8a995efb99517d1c7aeb1e
+    sha256: 59482b974c36c375fdfd0bc3e5a3003ea2d2ae72b64b8f3deaeef5a851dbc91d
   category: main
   optional: false
 - name: scooby
-  version: 0.9.2
+  version: 0.10.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/scooby-0.9.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/scooby-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 66dc03353b88f5f2db8c630854174a3f
-    sha256: 2da33192d89f313fcda87b1c852d4bce9cda32bc3dc06c9348c2415f637d0deb
+    md5: 9e57330f431abbb4c88a5f898a4ba223
+    sha256: e47c80ff6c06898e7f49fbea5b0fd3a97dda0c11348004ada2070071d03b34cf
   category: main
   optional: false
 - name: seaborn
@@ -10140,10 +10925,10 @@ package:
   dependencies:
     seaborn-base: 0.13.2
     statsmodels: '>=0.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_2.conda
   hash:
-    md5: fd31ebf5867914de597f9961c478e482
-    sha256: 60a49c630bf429ae5264ee52f1e6a08df1d8b98c93047ec57f58786ef3094854
+    md5: a79d8797f62715255308d92d3a91ef2e
+    sha256: 79943fbbf1fafbf969257989a7d88638c0c3e7b89a81a75c9347c28768dd6141
   category: main
   optional: false
 - name: seaborn-base
@@ -10156,51 +10941,52 @@ package:
     pandas: '>=1.2'
     python: '>=3.8'
     scipy: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_2.conda
   hash:
-    md5: 0918a9201e824211cdf444dbf8d55752
-    sha256: 0c40edc2f36edbeeb38dd8fb667f63ce7759a2c148d5d5ca2044a791fe9898a1
+    md5: b713b116feaf98acdba93ad4d7f90ca1
+    sha256: 5de8b9e88a0f2daf58b07e3f144da26f894e9a20071304fa37329664eb2a29a7
   category: main
   optional: false
 - name: send2trash
-  version: 1.8.2
+  version: 1.8.3
   manager: conda
   platform: linux-64
   dependencies:
     __linux: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
   hash:
-    md5: ada5a17adcd10be4fc7e37e4166ba0e2
-    sha256: e74d3faf51a6cc429898da0209d95b209270160f3edbf2f6d8b61a99428301cd
+    md5: 778594b20097b5a948c59e50ae42482a
+    sha256: c4401b071e86ddfa0ea4f34b85308db2516b6aeca50053535996864cfdee7b3f
   category: main
   optional: false
 - name: setuptools
-  version: 69.2.0
+  version: 75.3.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: da214ecd521a720a9d521c68047682dc
-    sha256: 78a75c75a5dacda6de5f4056c9c990141bdaf4f64245673a590594d00bc63713
+    md5: 2ce9825396daf72baabaade36cee16da
+    sha256: a36d020b9f32fc3f1a6488a1c4a9c13988c6468faf6895bf30ca69521a61230e
   category: main
   optional: false
 - name: shapely
-  version: 2.0.3
+  version: 2.0.6
   manager: conda
   platform: linux-64
   dependencies:
-    geos: '>=3.12.1,<3.12.2.0a0'
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.3-py310hc3e127f_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    geos: '>=3.13.0,<3.13.1.0a0'
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.6-py311h2fdb869_2.conda
   hash:
-    md5: fbc825d13cbcb2d5d3fbba22c83fd203
-    sha256: 63cbe3c285b7be6fc12e27e296fe2e6e99f856046b21547d7f22d2d5d084d8e3
+    md5: 4c78235905053663d1c9e23df3f11b65
+    sha256: c09f263d503aa59d9bb31425c175bd202917669d1047f830942407b23de231ab
   category: main
   optional: false
 - name: shellingham
@@ -10225,6 +11011,21 @@ package:
   hash:
     md5: 1f6df17b16d6295a484d59e844fef6ee
     sha256: ae06686c9b4a93c07cdbfb04d91d34c2f5e3aa3e8170922cc3b5f1fbf52e566f
+  category: main
+  optional: false
+- name: siphash24
+  version: '1.7'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/siphash24-1.7-py311h9ecbd09_0.conda
+  hash:
+    md5: c00fad5b1628dfc19c48a1a34d1589a5
+    sha256: 1d29986e63c704bc6f6533c5c59722337044c471ad4e20ac207a8889f9e22454
   category: main
   optional: false
 - name: six
@@ -10264,16 +11065,16 @@ package:
   category: main
   optional: false
 - name: snappy
-  version: 1.1.10
+  version: 1.2.1
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
   hash:
-    md5: e6d228cd0bb74a51dd18f5bfce0b4115
-    sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
+    md5: 6b7dcc7349efd123d493d2dbe85a045f
+    sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
   category: main
   optional: false
 - name: sniffio
@@ -10295,11 +11096,11 @@ package:
   dependencies:
     numpy: ''
     pyparsing: '>=2.1.6'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
   hash:
-    md5: cb83a3d6ecf73f50117635192414426a
-    sha256: ebb8f5f9e362f186fb7d732e656f85c969b86309494436eba51cc3b8b96683f7
+    md5: 5abeaa41ec50d4d1421a8bc8fbc93054
+    sha256: 4c2281d61c325f9208ce18e030efc94e44c9a4f0d28a6c5737ff79740e1db2d4
   category: main
   optional: false
 - name: sortedcontainers
@@ -10327,32 +11128,33 @@ package:
   category: main
   optional: false
 - name: sparse
-  version: 0.15.1
+  version: 0.15.4
   manager: conda
   platform: linux-64
   dependencies:
-    numba: '>=0.49'
+    python: ''
     numpy: '>=1.17'
-    python: '>=3.8'
     scipy: '>=0.19'
-  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.15.1-pyhd8ed1ab_1.conda
+    numba: '>=0.49'
+  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.15.4-pyh267e887_1.conda
   hash:
-    md5: 780a42534f1429b802b5d1f51880b619
-    sha256: 32abbbb694a101cb7d5f793e4677be4c050352a11779cdc42e0d836586d35c69
+    md5: 40d80cd9fa4cc759c6dba19ea96642db
+    sha256: d6698bdf9411daf3f79f3745b687b18df47b5201e3d1e486fac62722cbe0bc32
   category: main
   optional: false
 - name: spdlog
-  version: 1.12.0
+  version: 1.14.1
   manager: conda
   platform: linux-64
   dependencies:
-    fmt: '>=10.1.1,<11.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    fmt: '>=11.0.1,<12.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.12.0-hd2e6256_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.14.1-hed91bc2_1.conda
   hash:
-    md5: f37afc6ce10d45b9fae2f55ddc635b9f
-    sha256: 34c2ac3ecafc109ea659087f2a429b8fd7c557eb75d072e723a9954472726e62
+    md5: 909188c8979846bac8e586908cf1ca6a
+    sha256: 0c604fe3f78ddb2b612841722bd9b5db24d0484e30ced89fac78c0a3f524dfd6
   category: main
   optional: false
 - name: sqlalchemy
@@ -10362,45 +11164,52 @@ package:
   dependencies:
     greenlet: '!=0.4.17'
     libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.4.49-py310h2372a71_1.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.4.49-py311h459d7ec_1.conda
   hash:
-    md5: cdeaf46006791202a7597bf2a0e6ad9e
-    sha256: bf3834160c19a080a72f33659d3e3edb74d32e2428413d1fa513f36f3b8e081c
+    md5: 17392bcb4ceac1b2c95db9d54b4ac018
+    sha256: 542dea4823e2e1283936fbd25c9f3fa960ec6df2dd54589b192b4dac68af7295
   category: main
   optional: false
 - name: sqlite
-  version: 3.45.2
+  version: 3.47.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libsqlite: 3.45.2
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libsqlite: 3.47.0
+    libzlib: '>=1.3.1,<2.0a0'
+    ncurses: '>=6.5,<7.0a0'
     readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.45.2-h2c6b66d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
   hash:
-    md5: 1423efca06ed343c1da0fc429bae0779
-    sha256: 22d2692c82b73480c9adc80472bfb241262586edaf1dac1a7504434e47185d3c
+    md5: 53abf1ef70b9ae213b22caa5350f97a9
+    sha256: 8ea1a085fa95d806301aeec0df6985c3ad0852a9a46aa62dd737d228c7862f9f
   category: main
   optional: false
 - name: stac-geoparquet
-  version: 0.4.1
+  version: 0.6.0
   manager: conda
   platform: linux-64
   dependencies:
+    ciso8601: ''
+    deltalake: ''
     geopandas: ''
+    orjson: ''
+    packaging: ''
     pandas: ''
-    pyarrow: ''
+    pyarrow: '>=16'
+    pyproj: ''
     pystac: ''
     python: '>=3.8'
     shapely: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/stac-geoparquet-0.4.1-pyhd8ed1ab_0.conda
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/stac-geoparquet-0.6.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 84de66771ad0c1fa9504dc6abb94d75d
-    sha256: 329726115ea142bc40f9f2ded26d16714e07fc6792f9812de88558f81418ae96
+    md5: 170120ae1851124988bd4d58160f7cd7
+    sha256: 6424216bd7016b41218c9f1fc852cd7a57005d7c79f8057476d9f01390c05833
   category: main
   optional: false
 - name: stac-vrt
@@ -10435,19 +11244,21 @@ package:
   category: main
   optional: false
 - name: stackstac
-  version: 0.5.0
+  version: 0.5.1
   manager: conda
   platform: linux-64
   dependencies:
     dask-core: '>=2022.1.1'
+    numpy: <3,>1.23
+    pandas: <3,>=2
     pyproj: <4.0.0,>=3.0.0
     python: '>=3.8,<4.0'
     rasterio: <2.0.0,>=1.3.0
     xarray: '>=0.18'
-  url: https://conda.anaconda.org/conda-forge/noarch/stackstac-0.5.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/stackstac-0.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a1295d17c40cb4ec767e396293a44d98
-    sha256: 1baf4cb93fd7603176c28521d9d8bde25f3d9029f2a8a170a9b083c47931ca2d
+    md5: af36ec845ee6099742f3e6c46e5c1331
+    sha256: 8774cde4f9314549f1c02d6cd66ba75837f24c9ac5ea60002e2994b68c4d0d39
   category: main
   optional: false
 - name: starlette
@@ -10465,66 +11276,50 @@ package:
   category: main
   optional: false
 - name: statsmodels
-  version: 0.14.1
+  version: 0.14.4
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.19,<3'
     packaging: '>=21.3'
-    pandas: '>=1.0,!=2.1.0'
-    patsy: '>=0.5.4'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    scipy: '>=1.4,!=1.9.2'
-  url: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.1-py310h1f7b6fc_0.conda
+    pandas: '!=2.1.0,>=1.4'
+    patsy: '>=0.5.6'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    scipy: '!=1.9.2,>=1.8'
+  url: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.4-py311h9f3472d_0.conda
   hash:
-    md5: d98c3749dd466513dd921f5818f4b001
-    sha256: 35333b5ed842c3b047a573611f37d4f626de576551d13421d3f489af604d5783
-  category: main
-  optional: false
-- name: suitesparse
-  version: 5.10.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    metis: '>=5.1.0,<5.1.1.0a0'
-    mpfr: '>=4.2.1,<5.0a0'
-    tbb: '>=2021.11.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/suitesparse-5.10.1-h5a4f163_3.conda
-  hash:
-    md5: f363554b9084fb9d5e3366fbbc0d18e0
-    sha256: 235c9321cb76896f3304eea87248a74f52d8c088a38b9cbd98a5366e34756b90
+    md5: 81e81b5b7a744fcb279e98aa6d2e6683
+    sha256: b5925165bdd694f2d22f4d367c31faeb5a43861b0e3fce575e459038a5f42f62
   category: main
   optional: false
 - name: svt-av1
-  version: 1.8.0
+  version: 2.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.8.0-h59595ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
   hash:
-    md5: a9fb862e9d3beb0ebc61c10806056a7d
-    sha256: 6d64facdcdaadc5a3e5e4382ee195b4fde3c84ae3d4156fdd9b78ba7de358ba7
+    md5: 355898d24394b2af353eb96358db9fdd
+    sha256: df30a9be29f1a8b5a2e314dd5b16ccfbcbd1cc6a4f659340e8bc2bd4de37bc6f
   category: main
   optional: false
 - name: sysroot_linux-64
-  version: '2.12'
+  version: '2.17'
   manager: conda
   platform: linux-64
   dependencies:
-    kernel-headers_linux-64: 2.6.32
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_17.conda
+    kernel-headers_linux-64: 3.10.0
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_18.conda
   hash:
-    md5: 595db67e32b276298ff3d94d07d47fbf
-    sha256: b4e4d685e41cb36cfb16f0cb15d2c61f8f94f56fab38987a44eff95d8a673fb5
+    md5: 0ea96f90a10838f58412aa84fdd9df09
+    sha256: 23c7ab371c1b74d01a187e05aa7240e3f5654599e364a9adff7f0b02e26f471f
   category: main
   optional: false
 - name: tabulate
@@ -10540,17 +11335,18 @@ package:
   category: main
   optional: false
 - name: tbb
-  version: 2021.11.0
+  version: 2022.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libhwloc: '>=2.9.3,<2.9.4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.11.0-h00ab1b0_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libhwloc: '>=2.11.2,<2.11.3.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.0.0-hceb3a55_0.conda
   hash:
-    md5: 4531d2927578e7e254ff3bcf6457518c
-    sha256: ded4de0d5a3eb7b47ed829f0ed0e3c61ccd428308bde52d8d22ced228038223b
+    md5: 79f0161f3ca73804315ca980f65d9c60
+    sha256: 2f7931cad1682d8b6bdc90dbb51edf01f6f5c33fc00392c396d63e24437df1e8
   category: main
   optional: false
 - name: tblib
@@ -10566,15 +11362,15 @@ package:
   category: main
   optional: false
 - name: tenacity
-  version: 8.2.3
+  version: 9.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-8.2.3-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1482e77f87c6a702a7e05ef22c9b197b
-    sha256: 860c11e7369d6a86fcc9c6cbca49d5c457f6c0a27faeacca4d46267f9dd10d78
+    md5: 42af51ad3b654ece73572628ad2882ae
+    sha256: 0d33171e1d303b57867f0cfcffb8a35031700acb3c52b1862064d8f4e1085538
   category: main
   optional: false
 - name: terminado
@@ -10604,102 +11400,94 @@ package:
     sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
   category: main
   optional: false
-- name: textwrap3
-  version: 0.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/textwrap3-0.9.2-py_0.tar.bz2
-  hash:
-    md5: 1f84e74e9dbe2e5ae38c58496bffaca8
-    sha256: d7b40d3a3f1c2e74bbea5ee845b34a30abc1ae8e4f2a92f4a58800e1e669c076
-  category: main
-  optional: false
 - name: threadpoolctl
-  version: 3.4.0
+  version: 3.5.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
   hash:
-    md5: b296278eef667c673bf51de6535bad88
-    sha256: 4f4ad4f2a4ee8875cf2cb9c80abf4c7383e5e53cfec41104da7058569d9063b7
+    md5: df68d78237980a159bd7149f33c0e8fd
+    sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
   category: main
   optional: false
 - name: tifffile
-  version: 2024.2.12
+  version: 2024.9.20
   manager: conda
   platform: linux-64
   dependencies:
     imagecodecs: '>=2023.8.12'
     numpy: '>=1.19.2'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2024.2.12-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2024.9.20-pyhd8ed1ab_0.conda
   hash:
-    md5: d5c8bef52be4e70c48b1400eec3eecc8
-    sha256: 5b629ab2eae0508ad554cc831fed72950d74909d6bcf2aebdfd01e0c0afca60b
+    md5: 6de55c7859ed314159eaf2b7b4f19cc7
+    sha256: 10b70ee019158ef75f2c861724b2b2c11002643031f862b3a8ca99014607ceed
   category: main
   optional: false
 - name: tiledb
-  version: 2.21.1
+  version: 2.26.1
   manager: conda
   platform: linux-64
   dependencies:
-    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
-    aws-sdk-cpp: '>=1.11.267,<1.11.268.0a0'
-    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
-    azure-storage-blobs-cpp: '>=12.10.0,<12.10.1.0a0'
-    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    aws-crt-cpp: '>=0.28.3,<0.28.4.0a0'
+    aws-sdk-cpp: '>=1.11.407,<1.11.408.0a0'
+    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
+    azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
+    azure-storage-blobs-cpp: '>=12.12.0,<12.12.1.0a0'
+    azure-storage-common-cpp: '>=12.7.0,<12.7.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    fmt: '>=10.2.1,<11.0a0'
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libcurl: '>=8.6.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libgoogle-cloud: '>=2.22.0,<2.23.0a0'
-    libgoogle-cloud-storage: '>=2.22.0,<2.23.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    fmt: '>=11.0.2,<12.0a0'
+    libabseil: '>=20240116.2,<20240117.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libgoogle-cloud: '>=2.29.0,<2.30.0a0'
+    libgoogle-cloud-storage: '>=2.29.0,<2.30.0a0'
+    libstdcxx: '>=13'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    spdlog: '>=1.12.0,<1.13.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.21.1-ha9641ad_1.conda
+    openssl: '>=3.3.2,<4.0a0'
+    spdlog: '>=1.14.1,<1.15.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.26.1-h4c922dd_1.conda
   hash:
-    md5: 0453962dfed0265093929b52f885b190
-    sha256: 7f5ee10edebe594158d935adc89c5c12f2cf4ba28a2a7ccba4dab3b9953de43c
+    md5: be7dcba29f39f6bd55015871d5301ee1
+    sha256: fe92c08c9d220ecef10e365386bc26363019f4ea3db04ba6cf2bb492741652e2
   category: main
   optional: false
 - name: tiledb-py
-  version: 0.27.1
+  version: 0.32.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    numpy: '>=1.19,<3'
     packaging: ''
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    tiledb: '>=2.21.1,<2.22.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.27.1-py310hf2cffed_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    tiledb: '>=2.26.1,<2.27.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.32.2-py311hb007ffc_0.conda
   hash:
-    md5: 42a51711a4a17584fc96000e0491707a
-    sha256: 60a93be8422b64a3147fa02d76c3c97687435ea60ded9305e94b338556614c9b
+    md5: d60138767ebb51971440cb5857e30c17
+    sha256: f5bb845383b7f93709d35bb018953fbb9076475b26f45b10055c86b0b0b32039
   category: main
   optional: false
 - name: tinycss2
-  version: 1.2.1
+  version: 1.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.5'
     webencodings: '>=0.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7234c9eefff659501cd2fe0d2ede4d48
-    sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
+    md5: f1acf5fdefa8300de697982bcb1761c9
+    sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
   category: main
   optional: false
 - name: tk
@@ -10708,7 +11496,7 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
   hash:
     md5: d453b98d9c83e71da0741bb0ff4d76bc
@@ -10728,66 +11516,67 @@ package:
   category: main
   optional: false
 - name: tomli
-  version: 2.0.1
+  version: 2.0.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+    md5: e977934e00b355ff55ed154904044727
+    sha256: 5e742ba856168b606ac3c814d247657b1c33b8042371f1a08000bdc5075bc0cc
   category: main
   optional: false
 - name: toolz
-  version: 0.12.1
+  version: 1.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-0.12.1-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2fcb582444635e2c402e8569bb94e039
-    sha256: 22b0a9790317526e08609d5dfdd828210ae89e6d444a9e954855fc29012e90c6
+    md5: 34feccdd4177f2d3d53c73fc44fd9a37
+    sha256: 6371cf3cf8292f2abdcc2bf783d6e70203d72f8ff0c1625f55a486711e276c75
   category: main
   optional: false
 - name: tornado
-  version: '6.4'
+  version: 6.4.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4-py310h2372a71_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h9ecbd09_1.conda
   hash:
-    md5: 48f39c24349d9ae5c8e8873c42fb6170
-    sha256: bf3f211554444e03ed4663c0704fada38e0440fa723f1e32e12243ab026e3817
+    md5: 616fed0b6f5c925250be779b05d1d7f7
+    sha256: 21390d0c5708581959ebd89702433c1d06a56ddd834797a194b217f98e38df53
   category: main
   optional: false
 - name: tqdm
-  version: 4.66.2
+  version: 4.66.6
   manager: conda
   platform: linux-64
   dependencies:
     colorama: ''
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 2b8dfb969f984497f3f98409a9545776
-    sha256: 416d1d9318f3267325ad7e2b8a575df20ff9031197b30c0222c3d3b023877260
+    md5: 92718e1f892e1e4623dcc59b9f9c4e55
+    sha256: 32c39424090a8cafe7994891a816580b3bd253eb4d4f5473bdefcf6a81ebc061
   category: main
   optional: false
 - name: traitlets
-  version: 5.14.2
+  version: 5.14.3
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
   hash:
-    md5: af5fa2d2186003472e766a23c46cae04
-    sha256: 9ea6073091c130470a51b51703c8d2d959434992e29c4aa4abeba07cd56533a3
+    md5: 3df84416a021220d8b5700c613af2dc5
+    sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
   category: main
   optional: false
 - name: traittypes
@@ -10804,7 +11593,7 @@ package:
   category: main
   optional: false
 - name: trajan
-  version: 0.6.0
+  version: 0.7.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -10821,30 +11610,31 @@ package:
     roaring-landmask: '>=0.7'
     scipy: '>=1.9'
     xarray: '>=2022.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/trajan-0.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trajan-0.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 05630293e11e8cb8870a7bd52f56e2c7
-    sha256: 5a2f74807ccbac5414422695f145317e0c769cac5c1966957af1307d8f20cd22
+    md5: f288b47f47bec59768b51e4741124050
+    sha256: 6a72bdc0766b95dc244e78b252950d9829220daa0e46fc17f94a1109212d0983
   category: main
   optional: false
 - name: trollimage
-  version: 1.23.1
+  version: 1.26.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     dask: ''
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    numpy: '>=1.19,<3'
     pillow: ''
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     rasterio: ''
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/trollimage-1.23.1-py310hcc13569_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/trollimage-1.26.0-py311h7db5c69_0.conda
   hash:
-    md5: 21dc230a6198ef1ce6d07d39a123b8e5
-    sha256: 017924e5d9daf2a59c6f3de95be6593b2e4f8bd92274575e199a9c60c8e753b0
+    md5: 3ad580e8f8d780e7dcd3bad40a60dbad
+    sha256: 54ce02f40079200ef0909e71d44da93d17f5d35ec228bcc06ac29369ab48fa42
   category: main
   optional: false
 - name: trollsift
@@ -10861,56 +11651,80 @@ package:
   category: main
   optional: false
 - name: typer
-  version: 0.11.1
+  version: 0.12.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    typer-slim-standard: 0.12.5
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: be70216cc1a5fe502c849676baabf498
+    sha256: da9ff9e27c5fa8268c2d5898335485a897d9496eef3b5b446cd9387a89d168de
+  category: main
+  optional: false
+- name: typer-slim
+  version: 0.12.5
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=8.0.0'
-    colorama: '>=0.4.3,<0.5.0'
-    python: '>=3.8'
-    rich: '>=10.11.0,<14.0.0'
-    shellingham: '>=1.3.0,<2.0.0'
-    typing-extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.11.1-pyhd8ed1ab_0.conda
+    python: '>=3.7'
+    typing_extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 4fe6ddb677ec48ac4a3cbef23969546d
-    sha256: 57d422b96c46a3a510475e87a4d2bc30e407db6e5a0ea2fb31922bf54b3d6b63
+    md5: a46aa56c0ca7cc2bd38baffc2686f0a6
+    sha256: 7be1876627495047f3f07c52c93ddc2ae2017b93affe58110a5474e5ebcb2662
+  category: main
+  optional: false
+- name: typer-slim-standard
+  version: 0.12.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    rich: ''
+    shellingham: ''
+    typer-slim: 0.12.5
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.5-hd8ed1ab_0.conda
+  hash:
+    md5: 2dc1ee4046de0692077e9aa9ba351d36
+    sha256: bb298b116159ec1085f6b29eaeb982006651a0997eda08de8b70cfb6177297f3
   category: main
   optional: false
 - name: types-python-dateutil
-  version: 2.9.0.20240316
+  version: 2.9.0.20241003
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
   hash:
-    md5: 7831efa91d57475373ee52fb92e8d137
-    sha256: 6630bbc43dfb72339fadafc521db56c9d17af72bfce459af195eecb01163de20
+    md5: 3d326f8a2aa2d14d51d8c513426b5def
+    sha256: 8489af986daebfbcd13d3748ba55431259206e37f184ab42a57e107fecd85e02
   category: main
   optional: false
 - name: typing-extensions
-  version: 4.10.0
+  version: 4.12.2
   manager: conda
   platform: linux-64
   dependencies:
-    typing_extensions: 4.10.0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.10.0-hd8ed1ab_0.conda
+    typing_extensions: 4.12.2
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
   hash:
-    md5: 091683b9150d2ebaa62fd7e2c86433da
-    sha256: 0698fe2c4e555fb44c27c60f7a21fa0eea7f5bf8186ad109543c5b056e27f96a
+    md5: 52d648bd608f5737b123f510bb5514b5
+    sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
   category: main
   optional: false
 - name: typing_extensions
-  version: 4.10.0
+  version: 4.12.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
   hash:
-    md5: 16ae769069b380646c47142d719ef466
-    sha256: 4be24d557897b2f6609f5d5f7c437833c62f4d4a96581e39530067e96a2d0451
+    md5: ebe6952715e1d5eb567eeebf25250fa7
+    sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
   category: main
   optional: false
 - name: typing_utils
@@ -10926,27 +11740,27 @@ package:
   category: main
   optional: false
 - name: tzcode
-  version: 2024a
+  version: 2024b
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2024a-h3f72095_0.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2024b-hb9d3cd8_0.conda
   hash:
-    md5: 32146e34aaec3745a08b6f49af3f41b0
-    sha256: d3ea2927cabd6c9f27ee0cb498f893ac0133687d6a9e65e0bce4861c732a18df
+    md5: db124840386e1f842f93372897d1b857
+    sha256: 20c72e7ba106338d51fdc29a717a54fcd52340063232e944dcd1d38fb6348a28
   category: main
   optional: false
 - name: tzdata
-  version: 2024a
+  version: 2024b
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
   hash:
-    md5: 161081fc7cec0bfda0d86d7cb595f8d8
-    sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+    md5: 8ac3367aafb1cc0a068483c580af8015
+    sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
   category: main
   optional: false
 - name: tzlocal
@@ -10954,12 +11768,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/tzlocal-5.2-py310hff52083_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/tzlocal-5.2-py311h38be061_1.conda
   hash:
-    md5: 1ed36ee28a5786722446433fd3d47d15
-    sha256: e3ce540820678133936e5124b361c910341a126844821df216dd40edc7246dae
+    md5: 7e754e038988abcc3caabafaff7e44b3
+    sha256: 697e4758827bc4bb9cf95e97b52dcfd2c1c3a569884db742ee5b1a17156d6d1d
   category: main
   optional: false
 - name: uc-micro-py
@@ -10974,33 +11788,20 @@ package:
     sha256: 54293cd94da3a6b978b353eb7897555055d925ad0008bc73e85cca19e2587ed0
   category: main
   optional: false
-- name: ucx
-  version: 1.15.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    rdma-core: '>=51.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-ha691c75_8.conda
-  hash:
-    md5: 3f9bc6137b240642504a6c9b07a10c25
-    sha256: 85b40ac6607c9e4e32bcb13e95da41ff48a10f813df0c1e74ff32412e1f7da35
-  category: main
-  optional: false
 - name: ujson
-  version: 5.9.0
+  version: 5.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ujson-5.9.0-py310hc6cd4ac_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/ujson-5.10.0-py311hfdbb021_1.conda
   hash:
-    md5: cab4b543b897dcf548edb3018fe45f9e
-    sha256: 0bd79d83d8e3f191eae23fab69b3c655093df6611780f3b3c6c390ee16ab5ede
+    md5: 273cf8bedf58f24aec8d960831f89c5a
+    sha256: abc89657cc51fa926cf5c05121fbfc0ebae8777644c70dbb36b67fc1e916e288
   category: main
   optional: false
 - name: unicodedata2
@@ -11008,13 +11809,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py311h9ecbd09_1.conda
   hash:
-    md5: 72637c58d36d9475fda24700c9796f19
-    sha256: 5ab2f2d4542ba0cc27d222c08ae61706babe7173b0c6dfa748aa37ff2fa9d824
+    md5: 00895577e2b4c24dca76675ab1862551
+    sha256: 5f277c801ca392512de9aa497fd8be3e168950600c438778dfc4234943c474fc
   category: main
   optional: false
 - name: uri-template
@@ -11030,66 +11832,110 @@ package:
   category: main
   optional: false
 - name: uriparser
-  version: 0.9.7
+  version: 0.9.8
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.7-h59595ed_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
   hash:
-    md5: c5edf07141147789784f89d5b4e4a9ad
-    sha256: ec997599b6dcfef34242c67b695c4704d9ba6cb0b9de8f390defa475a95cdb3f
+    md5: d71d3a66528853c0a1ac2c02d79a0284
+    sha256: 2aad2aeff7c69a2d7eecd7b662eef756b27d6a6b96f3e2c2a7071340ce14543e
   category: main
   optional: false
 - name: urllib3
-  version: 2.0.7
+  version: 1.26.19
   manager: conda
   platform: linux-64
   dependencies:
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
-    md5: 270e71c14d37074b1d066ee21cf0c4a6
-    sha256: 9fe14735dde74278c6f1710cbe883d5710fc98501a96031dec6849a8d8a1bb11
+    md5: 6bb37c314b3cc1515dcf086ffe01c46e
+    sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
   category: main
   optional: false
 - name: uvicorn
-  version: 0.29.0
+  version: 0.32.0
   manager: conda
   platform: linux-64
   dependencies:
+    __unix: ''
     click: '>=7.0'
     h11: '>=0.8'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    python: '>=3.8'
     typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.29.0-py310hff52083_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.32.0-pyh31011fe_1.conda
   hash:
-    md5: c940a9f3c4d8cab6cce8871db6de6ffc
-    sha256: 9199d0617fc3a45ec952b7153807b6f21d44faddb4d4981b848dcab9f4c8ec2f
+    md5: 3936b8ca7212040c07565e1379ced362
+    sha256: bc1dd02dfe8ba9654c7ba4f359af1a36f88fdc8299e57e25394c26075e7f5ff2
   category: main
   optional: false
 - name: voila
-  version: 0.5.5
+  version: 0.5.8
   manager: conda
   platform: linux-64
   dependencies:
     jupyter_client: '>=7.4.4,<=9'
     jupyter_core: '>=4.11.0'
-    jupyter_server: '>=2.0.0,<3'
+    jupyter_server: '>=1,<3'
     jupyterlab_server: '>=2.3.0,<3'
-    nbclient: '>=0.4.0,<0.8'
+    nbclient: '>=0.4.0'
     nbconvert: '>=6.4.5,<8'
     python: '>=3.8'
     traitlets: '>=5.0.3,<6'
     websockets: '>=9'
-  url: https://conda.anaconda.org/conda-forge/noarch/voila-0.5.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/voila-0.5.8-pyhd8ed1ab_1.conda
   hash:
-    md5: 8c3bf8f901d1c5e4406629a557f27754
-    sha256: 361a50968dffbc99f554ae351668040b89bf93884ec8a3b43600796788247dd3
+    md5: 9701084d46133cef517774a98761f083
+    sha256: 80602768a73d086c5ae190159bbd5e1a514e22ffb2d84d8738923b32eed20adc
+  category: main
+  optional: false
+- name: watchfiles
+  version: 0.24.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    anyio: '>=3.0.0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.24.0-py311h9e33e62_1.conda
+  hash:
+    md5: 31c07a7fc0a2bf4a34808a686bf3de19
+    sha256: ad31508aba4c726e95949a66a65605146dbc8aaccce3091617162da87f857cdb
+  category: main
+  optional: false
+- name: wayland
+  version: 1.23.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libexpat: '>=2.6.2,<3.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
+  hash:
+    md5: 0a732427643ae5e0486a727927791da1
+    sha256: 0884b2023a32d2620192cf2e2fc6784b8d1e31cf9f137e49e00802d4daf7d1c1
+  category: main
+  optional: false
+- name: wayland-protocols
+  version: '1.37'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    wayland: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
+  hash:
+    md5: 73ec79a77d31eb7e4a3276cd246b776c
+    sha256: f6cac1efd4d2a6e30c1671f0566d4e6ac3fe2dc34c9ff7f309bbbc916520ebcf
   category: main
   optional: false
 - name: wcwidth
@@ -11105,15 +11951,15 @@ package:
   category: main
   optional: false
 - name: webcolors
-  version: '1.13'
+  version: 24.8.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 166212fe82dad8735550030488a01d03
-    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
+    md5: eb48b812eb4fbb9ff238a6651fdbbcae
+    sha256: ec71f97c332a7d328ae038990b8090cbfa772f82845b5d2233defd167b7cc5ac
   category: main
   optional: false
 - name: webencodings
@@ -11129,80 +11975,69 @@ package:
   category: main
   optional: false
 - name: webob
-  version: 1.8.7
+  version: 1.8.9
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webob-1.8.7-pyhd8ed1ab_0.tar.bz2
+    legacy-cgi: '>=2.6'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/webob-1.8.9-pyhd8ed1ab_0.conda
   hash:
-    md5: a8192f3585f341ea66c60c189580ac67
-    sha256: 041b3bfd405ab535384fb94cac9426f1538acf9a238db9175c31cd3b8a4016e1
+    md5: ff98f23ad74d2a3256debcd9df65d37d
+    sha256: 533b1188a28365bb8339ea0db02d701022b92e3703cde05810c357e766b54eb3
   category: main
   optional: false
 - name: websocket-client
-  version: 1.7.0
+  version: 1.8.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 50ad31e07d706aae88b14a4ac9c73f23
-    sha256: d9b537d5b7c5aa7a02a4ce4c6b755e458bd8083b67752a73c92d113ccec6c10f
+    md5: f372c576b8774922da83cda2b12f9d29
+    sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
   category: main
   optional: false
 - name: websockets
-  version: 11.0.3
+  version: '13.1'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/websockets-11.0.3-py310h2372a71_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/websockets-13.1-py311h9ecbd09_0.conda
   hash:
-    md5: f13afd86456f48ac7b982f72513c0d1a
-    sha256: bc3f30f4133c579c3b6629ce6d7497aa774036bb8ba5b41b334c5df0f601662d
-  category: main
-  optional: false
-- name: werkzeug
-  version: 3.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    markupsafe: '>=2.1.1'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: af8d825d93dbe6331ee6d61c69869ca0
-    sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
+    md5: 764e663b48ba5560f3c633384a35ea4d
+    sha256: 531d6bf60ef0238a9143b28c732c42dc9787caac8204803c834423f5e483b9f5
   category: main
   optional: false
 - name: wheel
-  version: 0.43.0
+  version: 0.44.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
-    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
+    md5: d44e3b085abcaef02983c6305b84b584
+    sha256: d828764736babb4322b8102094de38074dedfc71f5ff405c9dfee89191c14ebc
   category: main
   optional: false
 - name: whitebox
-  version: 2.3.1
+  version: 2.3.5
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=6.0'
     python: '>=3.6'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/whitebox-2.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/whitebox-2.3.5-pyhd8ed1ab_0.conda
   hash:
-    md5: cc0b538b83e3aa2e4b2fac0bd513b2ec
-    sha256: ded2339e61cb9e26e99c146257ffdd576d0a58dd7a7f3e8827c1f2817ee84c86
+    md5: a67aed4c3697af8d04cc8a3467de6b3b
+    sha256: a28d3c7ab54da578e8a30740954fb461db56b09f78161f15c629d8a36382a8e8
   category: main
   optional: false
 - name: whiteboxgui
@@ -11223,15 +12058,15 @@ package:
   category: main
   optional: false
 - name: widgetsnbextension
-  version: 4.0.10
+  version: 4.0.13
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.10-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 521f489e3babeddeec638c2add7e9e64
-    sha256: 981b06c76a1a86bb84be09522768be0458274926b22f4b0225dfcdd30a6593e0
+    md5: 6372cd99502721bd7499f8d16b56268d
+    sha256: d155adc10f8c96f76d4468dbe37b33b4334dadf5cd4a95841aa009ca9bced5fa
   category: main
   optional: false
 - name: wrapt
@@ -11239,13 +12074,27 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py310h2372a71_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py311h9ecbd09_1.conda
   hash:
-    md5: d9dc9c45bdc2b38403e6b388581e92f0
-    sha256: 2adc15cd1e66845c1ab498735e2f828003e2d5fe20eed1febddb712f58793c31
+    md5: 810ae646bcc50a017380336d874e4014
+    sha256: 426ee582e676e15a85846743060710fc4dbe4dd562b21d80d751694ffa263e41
+  category: main
+  optional: false
+- name: wsproto
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    h11: '>=0.9.0,<1.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 00ba804b54f451d102f6a7615f08470d
+    sha256: 66bd3f2db31fb62a2ff1f48d2c69ccdd2fa4467741149a0ad5c0bd097e0ac0e7
   category: main
   optional: false
 - name: x264
@@ -11274,18 +12123,18 @@ package:
   category: main
   optional: false
 - name: xarray
-  version: 2024.3.0
+  version: 2024.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    numpy: '>=1.23'
-    packaging: '>=22'
-    pandas: '>=1.5'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.3.0-pyhd8ed1ab_0.conda
+    numpy: '>=1.24'
+    packaging: '>=23.1'
+    pandas: '>=2.1'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 772d7ee42b65d0840130eabd5bd3fc17
-    sha256: 74e4cea340517ce7c51c36efc1d544d3a98fcdb62a429b6b1a59a1917b412c10
+    md5: 53e365732dfa053c4d19fc6b927392c4
+    sha256: a35c8291de55f96ecc9121d1ebd4995977ea2f51d9e529e97749abc108afb0e4
   category: main
   optional: false
 - name: xarray-sentinel
@@ -11305,28 +12154,23 @@ package:
   category: main
   optional: false
 - name: xarray-spatial
-  version: 0.3.7
+  version: 0.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    dask-core: ''
-    datashader: ''
-    noise: '>=1.2.2'
+    datashader: '>=0.15.0'
     numba: ''
-    numpy: <=1.23.4
-    pyct-core: ''
-    python: '>=3.7'
-    requests: ''
-    scipy: ''
+    numpy: ''
+    python: '>=3.8'
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.3.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1f7e2c30000b8e556e8bc4412c3a0d5e
-    sha256: a38d6a4a70f194ea06aaa49676c4d71e31e242f0ea5ae7d39fc0a58db6d6c503
+    md5: 892f97df8ce15d77157696d2d38866f4
+    sha256: b6211a7e1eb3dce320b2baa11134561d29bad46a37e273bab69461f4e9d80251
   category: main
   optional: false
 - name: xarrayutils
-  version: 2.0.0
+  version: 2.0.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -11334,13 +12178,13 @@ package:
     dask: ''
     matplotlib-base: ''
     numpy: ''
-    python: '>=3.8'
+    python: '>=3.9'
     scipy: ''
-    xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarrayutils-2.0.0-pyhd8ed1ab_0.conda
+    xarray: '>=0.14.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/xarrayutils-2.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 674792bec36e73850f97f75f75a66e42
-    sha256: 3e15cf589362237767aa2176e0f8482e79c9218cdecf2debe3180e502f46a150
+    md5: 4b551d4d8b32ba7c9714027edbaadf64
+    sha256: 505a7e971aafc32f67a9809ea1c1782bca505a3e0d834fecee2b4b79400ab650
   category: main
   optional: false
 - name: xcape
@@ -11352,53 +12196,57 @@ package:
     libgcc-ng: '>=12'
     libgfortran-ng: ''
     libgfortran5: '>=10.4.0'
-    numpy: '>=1.21.6,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    numpy: '>=1.23.4,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     xarray: '>=0.14.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcape-0.1.4-py310h4828a9c_3.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcape-0.1.4-py311ha29c927_3.tar.bz2
   hash:
-    md5: 0cad7067a8c4cfb0e4e222e504283daa
-    sha256: cc233527a372cbfbe59c07ef34883b0afa37a956b0ba15b42aa2382783d12c3d
+    md5: 5c0f7517ea92555ee9a040fd8fb8b4fa
+    sha256: 7bf7120bc45b6b3b2ea981ca26a63129ebd94007747209076df68ddaeebb2fe2
   category: main
   optional: false
 - name: xclim
-  version: 0.48.2
+  version: 0.53.1
   manager: conda
   platform: linux-64
   dependencies:
     boltons: '>=20.1'
     bottleneck: '>=1.3.1'
-    cf_xarray: '>=0.6.1'
+    cf_xarray: '>=0.9.3'
     cftime: '>=1.4.1'
     click: '>=8.1'
     dask: '>=2.6'
-    jsonpickle: ''
-    numba: ''
-    numpy: '>=1.20.0'
+    filelock: '>=3.14.0'
+    jsonpickle: '>=3.1.0'
+    numba: '>=0.54.1'
+    numpy: '>=1.23.0'
+    packaging: '>=24.0'
     pandas: '>=2.2.0'
-    pint: '>=0.10'
-    pyarrow: ''
-    python: '>=3.9'
-    pyyaml: ''
-    scikit-learn: '>=0.21.3'
+    pint: '>=0.18'
+    platformdirs: '>=3.2'
+    pyarrow: '>=10.0.1'
+    python: '>=3.10'
+    pyyaml: '>=6.0.1'
+    scikit-learn: '>=1.1.0'
     scipy: '>=1.9.0'
-    statsmodels: ''
+    statsmodels: '>=0.14.2'
     xarray: '>=2023.11.0'
-    yamale: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xclim-0.48.2-pyhd8ed1ab_0.conda
+    yamale: '>=5.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/xclim-0.53.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 34089f353cc18239192729598ac5638f
-    sha256: b38a3d887b8e8ae69354e10340df9ab2ccc4a4d4407c7e7d4798eb13b1603edd
+    md5: 095e59e596d7f02edc0ea8789570bedd
+    sha256: b092f8347c6cc88c71b271d966cf93e79b31267ccd8a1cd1f7e356c3a49c0141
   category: main
   optional: false
 - name: xcube
-  version: 1.4.1
+  version: 1.7.1
   manager: conda
   platform: linux-64
   dependencies:
-    adlfs: '>=2023.1'
     affine: '>=2.2'
+    botocore: '>=1.34.51'
+    cftime: '>=1.6.3'
     click: '>=8.0'
     cmocean: '>=2.0'
     dask: '>=2021.6'
@@ -11406,44 +12254,38 @@ package:
     deprecated: '>=1.2'
     distributed: '>=2021.6'
     fiona: '>=1.8'
-    fontconfig: ''
     fsspec: '>=2021.6'
     gdal: '>=3.0'
     geopandas: '>=0.8'
     jdcal: '>=1.4'
     jsonschema: '>=3.2'
-    lz4: ''
     mashumaro: ''
-    matplotlib-base: '>=3.0'
+    matplotlib-base: '>=3.8.3'
     netcdf4: '>=1.5'
     numba: '>=0.52'
+    numcodecs: '>=0.12.1'
     numpy: '>=1.16'
-    openssl: ''
     pandas: '>=1.3'
     pillow: '>=6.0'
     pyjwt: '>=1.7'
     pyproj: '>=3.0'
     python: '>=3.9'
-    python-blosc: ''
     pyyaml: '>=5.4'
     rasterio: '>=1.2'
     requests: '>=2.25'
-    requests-oauthlib: '>=1.3'
     rfc3339-validator: '>=0.1'
     rioxarray: '>=0.11'
     s3fs: '>=2021.6'
-    scipy: '>=1.6.0'
     setuptools: '>=41.0'
     shapely: '>=1.6'
     tornado: '>=6.0'
     urllib3: '>=1.26'
-    werkzeug: ''
     xarray: '>=2022.6'
     zarr: '>=2.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/xcube-1.4.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xcube-1.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: fe104c0fffc16c38895d0c94f41cc336
-    sha256: be1ae93747dce51f19663592bf4349c23ebd11aee22817e4d3a212ae17fd24f1
+    md5: d25aa0ca4e078cb6c60f2c30e820bf6f
+    sha256: 161daf78a2b5bc7ea672fe86359f8e1cbe9a944f6889e793d5c9ce8dff215789
   category: main
   optional: false
 - name: xerces-c
@@ -11451,34 +12293,34 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=75.1,<76.0a0'
+    libgcc: '>=13'
     libnsl: '>=2.0.1,<2.1.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-hac6953d_0.conda
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
   hash:
-    md5: 63b80ca78d29380fe69e69412dcbe4ac
-    sha256: 75d06ca406f03f653d7a3183f2a1ccfdb3a3c6c830493933ec4c3c98e06a32bb
+    md5: 9dda9667feba914e0e80b95b82f7402b
+    sha256: 339ab0ff05170a295e59133cd0fa9a9c4ba32b6941c8a2a73484cc13f81e248a
   category: main
   optional: false
 - name: xesmf
-  version: 0.8.4
+  version: 0.8.8
   manager: conda
   platform: linux-64
   dependencies:
     cf_xarray: '>=0.5.1'
-    esmpy: '>=8.0.0'
+    esmpy: '>=8.0.0,!=8.4.0,!=8.4.1,!=8.4.2'
     numba: '>=0.55.2'
     numpy: '>=1.16'
     python: '>=3.8'
     shapely: ''
     sparse: '>=0.8.0'
     xarray: '>=0.16.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/xesmf-0.8.4-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xesmf-0.8.8-pyhd8ed1ab_0.conda
   hash:
-    md5: 9fff981af43f3226bac0c91e9bf67f2e
-    sha256: 6353e92580722d4b2f1ffd414c384bfdcdac7ae59d388168acceb8b4b04efcc6
+    md5: ecb541b6f97cdedff14644bc2b6a1605
+    sha256: 5f253e4ef9236e812b41650686a8a8f2c6316c1c3df086d448bbfae8cd826128
   category: main
   optional: false
 - name: xgcm
@@ -11521,14 +12363,14 @@ package:
     libgcc-ng: '>=12'
     libgfortran-ng: ''
     libgfortran5: '>=10.4.0'
-    numpy: '>=1.21.6,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
+    numpy: '>=1.23.4,<2.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
     xarray: '>=0.13.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xlayers-0.2.2-py310h4828a9c_5.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/xlayers-0.2.2-py311ha29c927_5.tar.bz2
   hash:
-    md5: 4d9a24650eb7a1586c9a77f91136ea1c
-    sha256: ff52593af89943f2a94a94a98253e743d379f76321f615cb2cc656ef951b6803
+    md5: a53d9d6f152f074680d0025b38b353c1
+    sha256: 83a32dd268d797f5374048fdee941dc5ac351c51973e479a1308eaabab6568af
   category: main
   optional: false
 - name: xmip
@@ -11568,53 +12410,16 @@ package:
   category: main
   optional: false
 - name: xmlschema
-  version: 3.2.0
+  version: 3.4.2
   manager: conda
   platform: linux-64
   dependencies:
     elementpath: <5.0.0,>=4.4.0
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xmlschema-3.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xmlschema-3.4.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 6635a1e9274869ec4b066df65d3b1925
-    sha256: a04676e5aa944a73907d07abc94b43901b53b5936e11f154f40d094817676c24
-  category: main
-  optional: false
-- name: xorg-fixesproto
-  version: '5.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-xextproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
-  hash:
-    md5: 65ad6e1eb4aed2b0611855aff05e04f6
-    sha256: 5d2af1b40f82128221bace9466565eca87c97726bb80bbfcd03871813f3e1876
-  category: main
-  optional: false
-- name: xorg-inputproto
-  version: 2.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
-  hash:
-    md5: bcd1b3396ec6960cbc1d2855a9e60b2b
-    sha256: 6c8c2803de0f643f8bad16ece3f9a7259e4a49247543239c182d66d5e3a129a7
-  category: main
-  optional: false
-- name: xorg-kbproto
-  version: 1.0.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
-  hash:
-    md5: 4b230e8381279d76131116660f5a241a
-    sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+    md5: de317289e05a302d1a0f5336e98751a3
+    sha256: 7a55fd47327b12297f7c98ece7ecc832d48ce7c6e75a8d37cff7f246b3e68f81
   category: main
   optional: false
 - name: xorg-libice
@@ -11622,11 +12427,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
   hash:
-    md5: b462a33c0be1421532f28bfe8f4a7514
-    sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
+    md5: 19608a9656912805b2b9a2f6bd257b04
+    sha256: ec276da68d1c4a3d34a63195b35ca5b248d4aff0812464dcd843d74649b5cec4
   category: main
   optional: false
 - name: xorg-libsm
@@ -11634,29 +12440,29 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     libuuid: '>=2.38.1,<3.0a0'
     xorg-libice: '>=1.1.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
   hash:
-    md5: 93ee23f12bc2e684548181256edd2cf6
-    sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
+    md5: 05a8ea5f446de33006171a7afe6ae857
+    sha256: 70e903370977d44c9120a5641ab563887bd48446e9ef6fc2a3f5f60531c2cd6c
   category: main
   optional: false
 - name: xorg-libx11
-  version: 1.8.7
+  version: 1.8.10
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    xorg-kbproto: ''
-    xorg-xextproto: '>=7.3.0,<8.0a0'
-    xorg-xproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libxcb: '>=1.17.0,<2.0a0'
+    xorg-xorgproto: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
   hash:
-    md5: 49e482d882669206653b095f5206c05b
-    sha256: 7a02a7beac472ae2759498550b5fc5261bf5be7a9a2b4648a3f67818a7bfefcf
+    md5: 0b666058a179b744a622d0a4a0c56353
+    sha256: c4650634607864630fb03696474a0535f6fce5fda7d81a6462346e071b53dfa7
   category: main
   optional: false
 - name: xorg-libxau
@@ -11664,67 +12470,69 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
   hash:
-    md5: 2c80dc38fface310c9bd81b17037fee5
-    sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+    md5: 77cbc488235ebbaab2b6e912d3934bae
+    sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
   category: main
   optional: false
 - name: xorg-libxdmcp
-  version: 1.1.3
+  version: 1.1.5
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
   hash:
-    md5: be93aabceefa2fac576e971aef407908
-    sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+    md5: 8035c64cb77ed555e3f150b7b3972480
+    sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
   category: main
   optional: false
 - name: xorg-libxext
-  version: 1.3.4
+  version: 1.3.6
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    xorg-libx11: '>=1.7.2,<2.0a0'
-    xorg-xextproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
   hash:
-    md5: 82b6df12252e6f32402b96dacc656fec
-    sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
+    md5: febbab7d15033c913d53c7a2c102309d
+    sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
   category: main
   optional: false
 - name: xorg-libxfixes
-  version: 5.0.3
+  version: 6.0.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-fixesproto: ''
-    xorg-libx11: '>=1.7.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
   hash:
-    md5: e9a21aa4d5e3e5f1aed71e8cefd46b6a
-    sha256: 1e426a1abb774ef1dcf741945ed5c42ad12ea2dc7aeed7682d293879c3e1e4c3
+    md5: 4bdb303603e9821baf5fe5fdff1dc8f8
+    sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
   category: main
   optional: false
 - name: xorg-libxi
-  version: 1.7.10
+  version: 1.8.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-inputproto: ''
-    xorg-libx11: '>=1.7.0,<2.0a0'
-    xorg-libxext: 1.3.*
-    xorg-libxfixes: 5.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-h7f98852_0.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
   hash:
-    md5: e77615e5141cad5a2acaa043d1cf0ca5
-    sha256: 745c1284a96b4282fe6fe122b2643e1e8c26a7ff40b733a8f4b61357238c4e68
+    md5: 17dcc85db3c7886650b8908b183d6876
+    sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
   category: main
   optional: false
 - name: xorg-libxrender
@@ -11732,25 +12540,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-renderproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-xorgproto: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
   hash:
-    md5: ed67c36f215b310412b2af935bf3e530
-    sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
-  category: main
-  optional: false
-- name: xorg-renderproto
-  version: 0.11.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
-  hash:
-    md5: 06feff3d2634e3097ce2fe681474b534
-    sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
+    md5: a7a49a8b85122b49214798321e2e96b4
+    sha256: f1217e902c0b1d8bc5d3ce65e483ebf38b049c823c9117b7198cfb16bd2b9143
   category: main
   optional: false
 - name: xorg-xextproto
@@ -11758,23 +12555,25 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
   hash:
-    md5: bce9f945da8ad2ae9b1d7165a64d0f87
-    sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
+    md5: bc4cd53a083b6720d61a1519a1900878
+    sha256: f302a3f6284ee9ad3b39e45251d7ed15167896564dc33e006077a896fd3458a6
   category: main
   optional: false
-- name: xorg-xproto
-  version: 7.0.31
+- name: xorg-xorgproto
+  version: '2024.1'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
   hash:
-    md5: b4a4381d54784606820704f7b5f05a15
-    sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
+    md5: 7c21106b851ec72c037b162c216d8f05
+    sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
   category: main
   optional: false
 - name: xpublish
@@ -11818,15 +12617,15 @@ package:
   category: main
   optional: false
 - name: xyzservices
-  version: 2023.10.1
+  version: 2024.9.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2023.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1e0d85c0e2fef9539218da185b285f54
-    sha256: da655e2e0a742fddefeeaf2dd828b62a1820a3755d13341e1a555a10fcb9cf81
+    md5: 156c91e778c1d4d57b709f8c5333fd06
+    sha256: 2dd2825b5a246461a95a0affaf7e1d459f7cc0ae68ad2dd8aab360c2e5859488
   category: main
   optional: false
 - name: xz
@@ -11842,16 +12641,16 @@ package:
   category: main
   optional: false
 - name: yamale
-  version: 4.0.4
+  version: 5.2.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
     pyyaml: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/yamale-4.0.4-pyh6c4a22f_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/yamale-5.2.1-pyhca7485f_0.conda
   hash:
-    md5: cc9f59f147740d88679bf1bd94dbe588
-    sha256: ef2531599d18da481f9d299c22ca138902b227e849ced5043a4e2c38772f8375
+    md5: c089f90a086b6214c5606368d0d3bad0
+    sha256: b747e78b7476e2e59963457cccffee9f2845009f9ed5a66b9aa18d490e001015
   category: main
   optional: false
 - name: yaml
@@ -11867,35 +12666,37 @@ package:
   category: main
   optional: false
 - name: yarl
-  version: 1.9.4
+  version: 1.16.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     idna: '>=2.0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     multidict: '>=4.0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.4-py310h2372a71_0.conda
+    propcache: '>=0.2.0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.16.0-py311h9ecbd09_0.conda
   hash:
-    md5: 4ad35c8f6a64a6ab708780dad603aef4
-    sha256: 0851ac8c66e99faa9c885a2905c2b7b227a051c008cfaed97eeec0f82a9cdbcf
+    md5: d9c23163e7ac5f8926372c7d792a996f
+    sha256: 949fee5b985113293c10a925ff9290deb5552d185f99bb17f9b0da51c9941f77
   category: main
   optional: false
 - name: zarr
-  version: 2.17.1
+  version: 2.18.3
   manager: conda
   platform: linux-64
   dependencies:
     asciitree: ''
     fasteners: ''
     numcodecs: '>=0.10.0'
-    numpy: '>=1.20,!=1.21.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zarr-2.17.1-pyhd8ed1ab_0.conda
+    numpy: '>=1.24,<3.0'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 8c67aa8327cbab135ea576568df3190c
-    sha256: 6613f7a525e8cb23d9b098e566e0a948352bb7748c9afcf2298f246c939ed5d9
+    md5: 41abde21508578e02e3fd492e82a05cd
+    sha256: 0fd9bf7ba90088115c52dad7b9d44fbffeabe34cb35299b2c38d5f17851fda36
   category: main
   optional: false
 - name: zeromq
@@ -11903,13 +12704,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    krb5: '>=1.21.3,<1.22.0a0'
+    libgcc: '>=13'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_6.conda
   hash:
-    md5: 7fc9d3288d2420bb3637647621018000
-    sha256: 3bec658f5c23abf5e200d98418add7a20ff7b45c928ad4560525bef899496256
+    md5: 113506c8d2d558e733f5c38f6bf08c50
+    sha256: e67288b1c98a31ee58a5c07bdd873dbe08e75f752e1ad605d5e8c0697339903e
   category: main
   optional: false
 - name: zfp
@@ -11917,13 +12720,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zfp-1.0.1-h59595ed_0.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zfp-1.0.1-h5888daf_2.conda
   hash:
-    md5: fd486bffbf0d6841cf1456a8f2e3a995
-    sha256: 52c3bb8ab48892a2851e84764b0d35589434aebebe7941d44d9aeffde53c26d3
+    md5: e0409515c467b87176b070bff5d9442e
+    sha256: 0dfafc75c72f308c0200836f2b973766cdcb8741b1ab61e0b462a34dd6b6ad20
   category: main
   optional: false
 - name: zict
@@ -11939,53 +12743,73 @@ package:
   category: main
   optional: false
 - name: zipp
-  version: 3.17.0
+  version: 3.20.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+    md5: 4daaed111c05672ae669f7036ee5bba3
+    sha256: 1e84fcfa41e0afdd87ff41e6fbb719c96a0e098c1f79be342293ab0bd8dea322
   category: main
   optional: false
 - name: zlib
-  version: 1.2.13
+  version: 1.3.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: 1.2.13
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libzlib: 1.3.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
   hash:
-    md5: 68c34ec6149623be41a1933ab996a209
-    sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
+    md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+    sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
   category: main
   optional: false
 - name: zlib-ng
-  version: 2.0.7
+  version: 2.2.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.0.7-h0b41bf4_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.2.2-h5888daf_0.conda
   hash:
-    md5: 49e8329110001f04923fe7e864990b0c
-    sha256: 6b3a22b7cc219e8d83f16c1ceba67aa51e0b7e3bcc4a647b97a0a510559b0477
+    md5: 135fd3c66bccad3d2254f50f9809e86a
+    sha256: 9288b88a2448a6ef9824ff4a9f9384f45f6444b009b9fa3e5f335d0c52e86e4b
+  category: main
+  optional: false
+- name: zstandard
+  version: 0.23.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cffi: '>=1.11'
+    libgcc: '>=13'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311hbc35293_1.conda
+  hash:
+    md5: aec590674ba365e50ae83aa2d6e1efae
+    sha256: a5cf0eef1ffce0d710eb3dffcb07d9d5922d4f7a141abc96f6476b98600f718f
   category: main
   optional: false
 - name: zstd
-  version: 1.5.5
+  version: 1.5.6
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+    libzlib: '>=1.2.13,<2.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
   hash:
-    md5: 04b88013080254850d6c01ed54810589
-    sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+    md5: 4d056880988120e29d75bfff282e0f45
+    sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
   category: main
   optional: false

--- a/python/environment.yml
+++ b/python/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - jupyter-server-proxy =4.1.4
   - jupyterhub-singleuser =4.1.4
   - jupyterlab =4.1.5
-  - nbgitpuller =1.2.0
+  - nbgitpuller =1.2.1
 
   # OTHER STUFF
   - pip>=20


### PR DESCRIPTION
Need to upgrade to [`nbgitpuller`](https://github.com/jupyterhub/nbgitpuller) 1.2.1 for compatibility with the JupyterHub 4.1 (updated at 560c2cfc79c4e284bba5b39ff161e89edf4ded4c) See changelog entry at https://github.com/jupyterhub/nbgitpuller/blob/1.2.1/CHANGELOG.md#121---2024-03-29