### PR TITLE
Install mkl variant of numexpr

### DIFF
--- a/python/conda-lock.yml
+++ b/python/conda-lock.yml
@@ -13,7 +13,7 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 178246e2f0e25935d1b6853118172963ae7b28e0cb171fd60b2eaa22898fbe53
+    linux-64: 2c4243db18fe7fc6d06ae407652dc09537b7f258127f3a8a300d13d01d8fb3a7
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -22,28 +22,16 @@ metadata:
   sources:
   - environment.yml
 package:
-- name: _libgcc_mutex
-  version: '0.1'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-  hash:
-    md5: d7c89558ba9fa0495403155b64376d81
-    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
-  category: main
-  optional: false
 - name: _openmp_mutex
   version: '4.5'
   manager: conda
   platform: linux-64
   dependencies:
-    _libgcc_mutex: '0.1'
-    libgomp: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+    llvm-openmp: '>=9.0.1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-3_kmp_llvm.conda
   hash:
-    md5: 73aaf86a425cc6e73fcf236a5a46396d
-    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+    md5: ee5c2118262e30b972bc0b4db8ef0ba5
+    sha256: cec7343e76c9da6a42c7e7cba53391daa6b46155054ef61a5ef522ea27c5a058
   category: main
   optional: false
 - name: adal
@@ -63,21 +51,35 @@ package:
   category: main
   optional: false
 - name: adlfs
-  version: 2024.7.0
+  version: 2024.12.0
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: '>=3.7.0'
-    azure-core: '>=1.23.1,<2.0.0'
-    azure-datalake-store: '>=0.0.46,<0.1'
+    azure-core: '>=1.28.0,<2.0.0'
+    azure-datalake-store: '>=0.0.53,<0.1'
     azure-identity: ''
-    azure-storage-blob: '>=12.12.0'
+    azure-storage-blob: '>=12.17.0'
     fsspec: '>=2023.12.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/adlfs-2024.7.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/adlfs-2024.12.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0d774613255df3ee00340b616d00f0d0
-    sha256: 517d70e2146a5c3cd6f535eba0f358cc290e9d0eb58dd3482f040846a5d3104a
+    md5: b849c43bf1ec065aac64143127ba1244
+    sha256: 6278afdaf8451a1f3426eef99e0922723a9d742e4c88233430101ec060b6cce4
+  category: main
+  optional: false
+- name: adwaita-icon-theme
+  version: '48.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+    hicolor-icon-theme: ''
+    librsvg: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
+  hash:
+    md5: 11539f9e49efaa281da735ded100b152
+    sha256: 63e532087119112c81d81c067e00d1fd49ff1b842ffea4469b78b505be63c042
   category: main
   optional: false
 - name: affine
@@ -85,27 +87,31 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ae5f4ad87126c55ba3f690ef07f81d64
-    sha256: fbf0288cae7c6e5005280436ff73c95a36c5a4c978ba50175cc8e3eb22abc5f9
+    md5: 8c4061f499edec6b8ac7000f6d586829
+    sha256: 0deeaf0c001d5543719db9b2686bc1920c86c7e142f9bec74f35e1ce611b1fc2
   category: main
   optional: false
 - name: aiobotocore
-  version: 2.15.1
+  version: 2.21.1
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: '>=3.9.2,<4.0.0'
     aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.35.16,<1.35.24'
-    python: '>=3.8'
+    botocore: '>=1.37.0,<1.37.2'
+    jmespath: '>=0.7.1,<2.0.0'
+    multidict: '>=6.0.0,<7.0.0'
+    python: '>=3.9'
+    python-dateutil: '>=2.1,<3.0.0'
+    urllib3: '>=1.25.4,!=2.2.0,<3'
     wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.15.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.21.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 341f4502c79c3e863adc7273078d2cdb
-    sha256: d888dd7771667862ede7c8bbef09d06c00239e4e5e3caf7fd625d32ab731c35c
+    md5: 843cfdc4c1222b19d6fd18c4a51c660e
+    sha256: 6e8837eb3618dee7ab70ad115f8efd83f5697b885de36cdd5093ccab4240c4fa
   category: main
   optional: false
 - name: aiohttp
@@ -133,25 +139,25 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 222c275312d71dd318108df50d6452a1
-    sha256: b1a2574b136938fc4cc54403766032575a046a611d95899537ba2a6e0b6d98f1
+    md5: 3eb47adbffac44483f59e580f8600a1e
+    sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
   category: main
   optional: false
 - name: aiosignal
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: linux-64
   dependencies:
     frozenlist: '>=1.1.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: d1e1eb7e21a9e2c74279d87dafb68156
-    sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
+    md5: 1a3981115a398535dbe3f6d5faae3d36
+    sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
   category: main
   optional: false
 - name: aiosqlite
@@ -159,29 +165,40 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     typing-extensions: '>=3.7.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosqlite-0.20.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosqlite-0.20.0-pyhaa4b35c_1.conda
   hash:
-    md5: 4904ac8e78fa697150e874e4b2dbf6e5
-    sha256: 93f6e9dd42c611f1d64efce431844ebe10cb785399de1872bc266067386f2e20
+    md5: f4dcae514c7e1f1e70299d3e4ab57c8c
+    sha256: 636f28e042d52cbcc4ab7a26fcf5e20543fc3f4949e9e3241e305a4266e780db
   category: main
   optional: false
 - name: alembic
-  version: 1.14.0
+  version: 1.15.1
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: ''
-    importlib_resources: ''
     mako: ''
-    python: '>=3.8'
-    sqlalchemy: '>=1.3.0'
-    typing_extensions: '>=4'
-  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.14.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    sqlalchemy: '>=1.4.0'
+    typing_extensions: '>=4.12'
+  url: https://conda.anaconda.org/conda-forge/noarch/alembic-1.15.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 4882d44aa5f5d9de49ba84266cfe56b1
-    sha256: c6ae340d7964174974a0f0d7a830644c013316d81fed43da2d7f377809be0474
+    md5: 3b03a8229e613009c7832cb8e4d79cd9
+    sha256: 307da0338b29b8ef5aede18daa09d0b80c47cd62ffd4618167871fa9114cf098
+  category: main
+  optional: false
+- name: alsa-lib
+  version: 1.2.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.13-hb9d3cd8_0.conda
+  hash:
+    md5: ae1370588aa6a5157c34c73e9bbb36a0
+    sha256: f507b58f77eabc0cc133723cb7fc45c053d551f234df85e70fb3ede082b0cd53
   category: main
   optional: false
 - name: annotated-types
@@ -189,12 +206,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     typing-extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 7e9f4612544c8edbfd6afad17f1bd045
-    sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
+    md5: 2934f256a8acfe48f6ebb4fce6cde29c
+    sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
   category: main
   optional: false
 - name: ansicolors
@@ -209,48 +226,50 @@ package:
     sha256: e78147c36ed63f758cc8d39436bc1af89bb07441934cccbb9711d8b3cccc48c0
   category: main
   optional: false
-- name: antlr-python-runtime
-  version: 4.13.2
+- name: antimeridian
+  version: 0.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/antlr-python-runtime-4.13.2-pyhd8ed1ab_0.conda
+    click: '>=8.1,=8.*'
+    numpy: '>=1.22.4'
+    python: '>=3.10'
+    shapely: '>=2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/antimeridian-0.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: c313ebd3419477fbd356c24b984669ba
-    sha256: 906b27bdd26a3a15b1485e9b7ac4c280cd329b5cc33a1c778e6a3ff3510570a1
+    md5: ea5fdd6f4dfe505780dd64af447c21ae
+    sha256: 14d16d6f39e8d723bac3dda96a8510a590336a398f0c0b78fb31c040ee5352bc
   category: main
   optional: false
 - name: anyio
-  version: 4.6.2.post1
+  version: 4.9.0
   manager: conda
   platform: linux-64
   dependencies:
     exceptiongroup: '>=1.0.2'
     idna: '>=2.8'
-    python: '>=3.9'
+    python: ''
     sniffio: '>=1.1'
-    typing_extensions: '>=4.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.9.0-pyh29332c3_0.conda
   hash:
-    md5: 688697ec5e9588bdded167d19577625b
-    sha256: 4b54b7ce79d818e3cce54ae4d552dba51b7afac160ceecdefd04b3917a37c502
+    md5: 9749a2c77a7c40d432ea0927662d7e52
+    sha256: b28e0f78bb0c7962630001e63af25a89224ff504e135a02e50d4d80b6155d386
   category: main
   optional: false
 - name: anywidget
-  version: 0.9.13
+  version: 0.9.18
   manager: conda
   platform: linux-64
   dependencies:
-    ipywidgets: ''
-    psygnal: ''
-    python: '>=3.7'
-    typing_extensions: ''
-    watchfiles: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.13-pyhd8ed1ab_0.conda
+    ipywidgets: '>=7.6.0'
+    psygnal: '>=0.8.1'
+    python: '>=3.9'
+    typing_extensions: '>=4.2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.18-pyhd8ed1ab_0.conda
   hash:
-    md5: 5163983551f7a4361b0a6bcc85334e0c
-    sha256: dbe8cd33de4c1eb1edd3578866d54497a6f51b8ee232bc522a2e497e7926bac0
+    md5: a196eb5a011dad49f6011b5a764654f4
+    sha256: 51b282c0144acd119d508ac220fb1e699ea6fe9f392159403d2f2d347311b7d9
   category: main
   optional: false
 - name: aom
@@ -266,59 +285,16 @@ package:
     sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
   category: main
   optional: false
-- name: apache-beam
-  version: 2.60.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cloudpickle: '>=2.2.1,<2.3.dev0'
-    crcmod: '>=1.7,<2.0'
-    dill: '>=0.3.1.1,<0.3.2'
-    fastavro: '>=0.23.6,<2'
-    fasteners: '>=0.3,<1.0'
-    grpcio: '>=1.33.1,<2,!=1.48.0,!=1.59.*,!=1.60.*,!=1.61.*,!=1.62.0,!=1.62.1,<1.66.0'
-    httplib2: '>=0.8,<0.23.0'
-    jsonpickle: '>=3.0.0,<4.0.0'
-    jsonschema: '>=4.0.0,<5.0.0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-    numpy: '>=1.22.4,<2.0a0'
-    objsize: '>=0.6.1,<0.8.0'
-    orjson: '>=3.9.7,<4'
-    packaging: '>=22.0'
-    proto-plus: '>=1.7.1,<2'
-    protobuf: '>=3.20.3,<4.26.0,!=4.0.*,!=4.21.*,!=4.22.0,!=4.23.*,!=4.24.*'
-    pyarrow: '>=3.0.0,<17.0.0'
-    pyarrow-hotfix: <1
-    pydot: '>=1.2.0,<2'
-    pymongo: '>=3.8.0,<5.0.0'
-    python: '>=3.10,<3.11.0a0'
-    python-dateutil: '>=2.8.0,<3'
-    python-hdfs: '>=2.1.0,<3.0.0'
-    python_abi: 3.10.*
-    pytz: '>=2018.3'
-    redis-py: '>=5.0.0,<6'
-    regex: '>=2020.6.8'
-    requests: '>=2.24.0,<3.0.0'
-    typing-extensions: '>=3.7.0'
-    zstandard: '>=0.18.0,<1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/apache-beam-2.60.0-py310h89e8f5a_0.conda
-  hash:
-    md5: f4376144719ee45f253b59596034483f
-    sha256: e9b1895a00ad99f5e7a83fc9ad6146a86eabe2c7fd85b2eab961a3228548488b
-  category: main
-  optional: false
 - name: appdirs
   version: 1.4.4
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 5f095bc6454094e96f146491fd03633b
-    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+    md5: f4e90937bbfc3a4a92539545a37bb448
+    sha256: 5b9ef6d338525b332e17c3ed089ca2f53a5d74b7a7b432747d29c6466e39346d
   category: main
   optional: false
 - name: applicationinsights
@@ -334,34 +310,33 @@ package:
   category: main
   optional: false
 - name: apprise
-  version: 1.9.0
+  version: 1.9.2
   manager: conda
   platform: linux-64
   dependencies:
     certifi: ''
     click: '>=5.0'
-    dataclasses: ''
     markdown: ''
-    python: '>=3.7'
+    python: '>=3.9'
     pyyaml: ''
     requests: ''
     requests-oauthlib: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/apprise-1.9.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/apprise-1.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 943136b2560e6658a96613b063bc1b7c
-    sha256: 7e0e2063d5d79f1fc64787be65019f7c9ec97a724a89a9a52fa746fc420f28af
+    md5: 8452998f2cb3c6b7ffd8afd0d709f1e8
+    sha256: 0d0e891e707a25c91081c7d39057682ff8ccfa50d082ebb7a98bc15df620f5be
   category: main
   optional: false
 - name: argcomplete
-  version: 3.5.1
+  version: 3.6.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.5.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: f1f7b435e0e99368020f21447e477b70
-    sha256: b2c1cb869915a96d5e2d922719edf2fc6824a15ecf666ecc18fc281d2177d224
+    md5: a987028d24022ab69e89efda50589832
+    sha256: b5096f97fdcbf07899209f7a8c0958e4318ab167bcccb47f578c633ef33d72de
   category: main
   optional: false
 - name: argon2-cffi
@@ -370,12 +345,12 @@ package:
   platform: linux-64
   dependencies:
     argon2-cffi-bindings: ''
-    python: '>=3.7'
+    python: '>=3.9'
     typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
-    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
+    md5: a7ee488b71c30ada51c48468337b85ba
+    sha256: 7af62339394986bc470a7a231c7f37ad0173ffb41f6bc0e8e31b0be9e3b9d20f
   category: main
   optional: false
 - name: argon2-cffi-bindings
@@ -395,7 +370,7 @@ package:
   category: main
   optional: false
 - name: arro3-compute
-  version: 0.4.2
+  version: 0.4.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -404,14 +379,14 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/arro3-compute-0.4.2-py310hd1c3b64_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/arro3-compute-0.4.6-py310hd1c3b64_0.conda
   hash:
-    md5: 4fdfb7245dd428a525e15c2a4ccbd962
-    sha256: 8949bfe7f53b3fb885fa4047df49e47e3e122a55d390a2abcae6a2928c77ac8d
+    md5: f1552047fd322717b195f9dae81ad0b2
+    sha256: e2ac5a8abd005c7c8bd99f71ab37571326b03ab592c80d283f404d0455d43a92
   category: main
   optional: false
 - name: arro3-core
-  version: 0.4.2
+  version: 0.4.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -419,14 +394,14 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/arro3-core-0.4.2-py310h4919010_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/arro3-core-0.4.6-py310h4919010_0.conda
   hash:
-    md5: 6f29da8aed53e56ff9fa22d66cba1414
-    sha256: 7041e90c3cf787776a3fc5e7d12e68b1a58900fbeaeef3872747ef36e599f9ad
+    md5: 229a7bbd904d85aacb89adadc7675151
+    sha256: 79094e482eb46df5d3c4ab6ac354bc48338d5e2da6c1ba7347b7236cd8ad9664
   category: main
   optional: false
 - name: arro3-io
-  version: 0.4.2
+  version: 0.4.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -435,10 +410,10 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/arro3-io-0.4.2-py310hd49420d_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/arro3-io-0.4.6-py310hd49420d_0.conda
   hash:
-    md5: ce47b8890cbfd0a8ec7e1e0f5b6172f9
-    sha256: 75ba0faa3cfe9660c7a00e7ba1e0ae3232d0d62af2bf1a5f62df18eca02bc2c5
+    md5: 3164ca5b1188fbe64be51c92f3054f68
+    sha256: d38be4e1aa824eb1867cfbabce952bd154456918aea6f232c7157f04eb108370
   category: main
   optional: false
 - name: arrow
@@ -446,13 +421,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     python-dateutil: '>=2.7.0'
     types-python-dateutil: '>=2.8.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
   hash:
-    md5: b77d8c2313158e6e461ca0efb1c2c508
-    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
+    md5: 46b53236fdd990271b03c3978d4218a9
+    sha256: c4b0bdb3d5dee50b60db92f99da3e4c524d5240aafc0a5fcc15e45ae2d1a3cd1
   category: main
   optional: false
 - name: asciitree
@@ -473,21 +448,21 @@ package:
   platform: linux-64
   dependencies:
     async-exit-stack: ''
-    python: '>=3.7'
+    python: '>=3.9'
     sniffio: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/asgi-lifespan-2.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/asgi-lifespan-2.1.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ac544dcf5d90cd6c0105272edfa89784
-    sha256: 3f8cac9823885ca132659e5b1965c4f6bb01e8a87d1c6f494e267ed58a1b1459
+    md5: fcc81bc91baba7c858406963e720196d
+    sha256: 50b0bb2d6feb62a7083f25e3ef4ea2b13ca44c24401dc1bb2dcedc58c213ace5
   category: main
   optional: false
 - name: astropy
-  version: 6.1.4
+  version: 6.1.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    astropy-iers-data: '>=0.2024.8.27.10.28.29'
+    astropy-iers-data: '>=0.2024.10.28.0.34.7'
     importlib-metadata: ''
     libgcc: '>=13'
     numpy: '>=1.23'
@@ -496,35 +471,34 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     pyyaml: '>=3.13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-6.1.4-py310hf462985_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/astropy-6.1.7-py310hf462985_0.conda
   hash:
-    md5: 0000d3a2930ee27eeffbf7530300bec6
-    sha256: 7f397bae52ddcb00e66a5830cd3da5d2c4b5587ba279763a1e9ac61078e9670c
+    md5: b1b72b1c8205f2dba8c976bdf4b9fd14
+    sha256: 9cafabb1f950055717abda76db080e40743794f39c924a137e44fce97bb8e14b
   category: main
   optional: false
 - name: astropy-iers-data
-  version: 0.2024.11.4.0.33.34
+  version: 0.2025.3.24.0.35.32
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2024.11.4.0.33.34-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/astropy-iers-data-0.2025.3.24.0.35.32-pyhd8ed1ab_0.conda
   hash:
-    md5: f6bd24ec85da8f1291f221acf8d8a54c
-    sha256: 327cfe1281bfc21869c53d709a36a94fec602a9573af785d6e3739005202854f
+    md5: 4b89c326c6f34d721ebd7f3611f8688f
+    sha256: 76a1486e6ef390b033c40f4fa4217c0a6201d5e01f6d46aaeb57d26c8b1af5c5
   category: main
   optional: false
 - name: asttokens
-  version: 2.4.1
+  version: 3.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-    six: '>=1.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+    md5: 8f587de4bcf981e26228f268df374a9b
+    sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
   category: main
   optional: false
 - name: async-exit-stack
@@ -532,24 +506,24 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-exit-stack-1.0.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/async-exit-stack-1.0.1-pyhd8ed1ab_1.conda
   hash:
-    md5: c76151135c040e151b2ab21d3b7636fd
-    sha256: 25ef477d4de8a71404e1c7fc39ad06dbc7dd9e65041c037ffe649dfc2fd16d2b
+    md5: f9cba419109aa1903871e08f1d8b74ee
+    sha256: 2c0fb4e80590d96c833bec445f465986af5ee195944796040d04e2c46029573a
   category: main
   optional: false
 - name: async-lru
-  version: 2.0.4
+  version: 2.0.5
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: ''
     typing_extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.5-pyh29332c3_0.conda
   hash:
-    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
-    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
+    md5: d9d0f99095a9bb7e3641bca8c6ad2ac7
+    sha256: 3b7233041e462d9eeb93ea1dfe7b18aca9c358832517072054bb8761df0c324b
   category: main
   optional: false
 - name: async-timeout
@@ -570,11 +544,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/async_generator-1.10-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/async_generator-1.10-pyhd8ed1ab_2.conda
   hash:
-    md5: bcee238f99c34ca11add65c1684c5a2d
-    sha256: 8647ec9fba010c7fd34a00c0c2a04902141f1c5c1d55d80e6c7b99649b6a1c72
+    md5: 0c07617cd436b9cd5570dc34f3af642b
+    sha256: 31d9aa56d16f2d20bd5cfb5f8092147fdd5e3854c0beffa121d26937f4b4b3d7
   category: main
   optional: false
 - name: asyncache
@@ -583,11 +557,11 @@ package:
   platform: linux-64
   dependencies:
     cachetools: '>=5.2.0,<6.0.0'
-    python: '>=3.8,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asyncache-0.3.1-pyhd8ed1ab_0.conda
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/asyncache-0.3.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 87bb8184ced6d84991c7c9c439b409fb
-    sha256: b68f5773ba39b310a690414ac36f78de46ed74fb4e27e06a5cf92eb6ca3cdcef
+    md5: 3dc46597d60137ec86d35f4d7a2cd0a8
+    sha256: a2343011bb8c4bd71baa57ff8456e7afdc5636738b7cee9d9353d4b52ac1a41c
   category: main
   optional: false
 - name: asyncpg
@@ -606,6 +580,39 @@ package:
     sha256: c4f71a27661eb953b3721b7368b02febf187e6fffe78ec3d092137495861c058
   category: main
   optional: false
+- name: at-spi2-atk
+  version: 2.38.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    at-spi2-core: '>=2.40.0,<2.41.0a0'
+    atk-1.0: '>=2.36.0'
+    dbus: '>=1.13.6,<2.0a0'
+    libgcc-ng: '>=9.3.0'
+    libglib: '>=2.68.1,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+  hash:
+    md5: 6b889f174df1e0f816276ae69281af4d
+    sha256: 26ab9386e80bf196e51ebe005da77d57decf6d989b4f34d96130560bc133479c
+  category: main
+  optional: false
+- name: at-spi2-core
+  version: 2.40.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    dbus: '>=1.13.6,<2.0a0'
+    libgcc-ng: '>=9.3.0'
+    libglib: '>=2.68.3,<3.0a0'
+    xorg-libx11: ''
+    xorg-libxi: ''
+    xorg-libxtst: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+  hash:
+    md5: 8cb2fc4cd6cc63f1369cfa318f581cc3
+    sha256: c4f9b66bd94c40d8f1ce1fad2d8b46534bdefda0c86e3337b28f6c25779f258d
+  category: main
+  optional: false
 - name: atk-1.0
   version: 2.38.0
   manager: conda
@@ -620,20 +627,32 @@ package:
     sha256: df682395d05050cd1222740a42a551281210726a67447e5258968dd55854302e
   category: main
   optional: false
-- name: attrs
-  version: 24.2.0
+- name: attr
+  version: 2.5.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
   hash:
-    md5: 6732fa52eb8e66e5afeb32db8701a791
-    sha256: 28dba85a7e0f7fb57d7315e13f603d1e41b83c5b88aa2a602596b52c833a2ff8
+    md5: d9c69a24ad678ffce24c6543a0176b00
+    sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
+  category: main
+  optional: false
+- name: attrs
+  version: 25.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+  hash:
+    md5: a10d11958cadc13fdb43df75f8b1903f
+    sha256: 99c53ffbcb5dc58084faf18587b215f9ac8ced36bbfb55fa807c00967e419019
   category: main
   optional: false
 - name: av
-  version: 13.1.0
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -644,369 +663,353 @@ package:
     pillow: ''
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/av-13.1.0-py310h94b1f55_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/av-14.2.0-py310h94b1f55_0.conda
   hash:
-    md5: 4069556279ad08b09671962fd405c552
-    sha256: 18caf1baf0686591861cf722b237eb370995a6220c8f0a296430f59b13711b4d
+    md5: 7fbe898ba27ff510e408c7d095410f16
+    sha256: dea5c77816e323ef9d902b8c91cc4d5223195a5d10b185e387991392b5b0ef7b
   category: main
   optional: false
 - name: aws-c-auth
-  version: 0.7.31
+  version: 0.8.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
-    aws-c-http: '>=0.8.10,<0.8.11.0a0'
-    aws-c-io: '>=0.14.19,<0.14.20.0a0'
-    aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-c-sdkutils: '>=0.2.2,<0.2.3.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.31-he1a10d6_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.1-h205f482_0.conda
   hash:
-    md5: 76550a294cc78aaccfca7824bb4814ce
-    sha256: 83fa4b24101cd85da825dcbb7611390c2a6e31a3fc17abb4d1ee5b8c40bdaa5a
+    md5: 9c500858e88df50af3cc883d194de78a
+    sha256: ebe5e33249f37f6bb481de99581ebdc92dbfcf1b6915609bcf3c9e78661d6352
   category: main
   optional: false
 - name: aws-c-cal
-  version: 0.7.4
+  version: 0.8.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     libgcc: '>=13'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.4-hae4d56a_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.1-h1a47875_3.conda
   hash:
-    md5: cdc628e4ffb4ffcd476e3847267e1689
-    sha256: 4bfed63898a1697364ce9621e1fc09c98f143777b0ca60655eb812efa5bf246d
+    md5: 55a8561fdbbbd34f50f57d9be12ed084
+    sha256: 095ac824ea9303eff67e04090ae531d9eb33d2bf8f82eaade39b839c421e16e8
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.29
+  version: 0.10.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.29-hb9d3cd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.6-hb9d3cd8_0.conda
   hash:
-    md5: acc51b49fd7467c8dfe4343001b812b4
-    sha256: b3b50f518e9afad383f6851bf7000cf8b343d7d3ca71558df233ee7b4bfc2919
+    md5: d7d4680337a14001b0e043e96529409b
+    sha256: 496e92f2150fdc351eacf6e236015deedb3d0d3114f8e5954341cbf9f3dda257
   category: main
   optional: false
 - name: aws-c-compression
-  version: 0.2.19
+  version: 0.3.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.19-h2bff981_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-h4e1184b_5.conda
   hash:
-    md5: 87a059d4d2ab89409496416119dd7152
-    sha256: 908a416ff3f62b09bed436e1f77418f54115412244734d3960b11d586dd0749f
+    md5: 3f4c1197462a6df2be6dc8241828fe93
+    sha256: 62ca84da83585e7814a40240a1e750b1563b2680b032a471464eccc001c3309b
   category: main
   optional: false
 - name: aws-c-event-stream
-  version: 0.4.3
+  version: 0.5.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
-    aws-c-io: '>=0.14.19,<0.14.20.0a0'
-    aws-checksums: '>=0.1.20,<0.1.21.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.3-h19b0707_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h7959bf6_11.conda
   hash:
-    md5: df38f56123f30d61de24474e600e7d41
-    sha256: 951f96eb45a439a36935dc2099e10c902518ec511a287c1685ca65a88a9accaa
+    md5: 9b3fb60fe57925a92f399bc3fc42eccf
+    sha256: 10d7240c7db0c941fb1a59c4f8ea6689a434b03309ee7b766fa15a809c553c02
   category: main
   optional: false
 - name: aws-c-http
-  version: 0.8.10
+  version: 0.9.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
-    aws-c-compression: '>=0.2.19,<0.2.20.0a0'
-    aws-c-io: '>=0.14.19,<0.14.20.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-compression: '>=0.3.0,<0.3.1.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.10-h14a7884_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.2-hefd7a92_4.conda
   hash:
-    md5: 6147c6b6cef67adcb85516f5cf775be7
-    sha256: 0561267292739a451d7d389f100330fefafb97859962f617cd5268c96400e3aa
+    md5: 5ce4df662d32d3123ea8da15571b6f51
+    sha256: 4a330206bd51148f6c13ca0b7a4db40f29a46f090642ebacdeb88b8a4abd7f99
   category: main
   optional: false
 - name: aws-c-io
-  version: 0.14.19
+  version: 0.15.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     libgcc: '>=13'
-    s2n: '>=1.5.5,<1.5.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.19-hc9e6898_1.conda
+    s2n: '>=1.5.11,<1.5.12.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.3-h173a860_6.conda
   hash:
-    md5: ec84785f7ae14ed43156a54aec33bb14
-    sha256: 35f9719fb9d5ddf4955a432d73d910261d60754d20b58de2be2701a2e68a9cfb
+    md5: 9a063178f1af0a898526cc24ba7be486
+    sha256: 335d822eead0a097ffd23677a288e1f18ea22f47a92d4f877419debb93af0e81
   category: main
   optional: false
 - name: aws-c-mqtt
-  version: 0.10.7
+  version: 0.11.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
-    aws-c-http: '>=0.8.10,<0.8.11.0a0'
-    aws-c-io: '>=0.14.19,<0.14.20.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.7-hb8d5873_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h11f4f37_12.conda
   hash:
-    md5: 8dc25ca24c1a50b8295a848c384ede99
-    sha256: b30a3d8ba9352760c30f696b65486fe0e1d3cfe771f114b008a70ad440eb00c0
+    md5: 96c3e0221fa2da97619ee82faa341a73
+    sha256: 512d3969426152d9d5fd886e27b13706122dc3fa90eb08c37b0d51a33d7bb14a
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.6.7
+  version: 0.7.9
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.7.31,<0.7.32.0a0'
-    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
-    aws-c-http: '>=0.8.10,<0.8.11.0a0'
-    aws-c-io: '>=0.14.19,<0.14.20.0a0'
-    aws-checksums: '>=0.1.20,<0.1.21.0a0'
+    aws-c-auth: '>=0.8.1,<0.8.2.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
     libgcc: '>=13'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.7-h666547d_0.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.9-he1b24dc_1.conda
   hash:
-    md5: 7f59dcbbd4eab14ca9256f20b43849eb
-    sha256: fe006f58bd9349ab7cd4cd864dd4e83409e89764b10d9d7eb7ec148e2f964465
+    md5: caafc32928a5f7f3f7ef67d287689144
+    sha256: 15fbdedc56850f8be5be7a5bcaea1af09c97590e631c024ae089737fc932fc42
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.1.19
+  version: 0.2.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-h2bff981_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.2-h4e1184b_0.conda
   hash:
-    md5: 5a8afd37e2dfe464d68e63d1c38b08c5
-    sha256: ef65ca9eb9f32ada6fb1b47759374e7ef4f85db002f2265ebc8fd61718284cbc
+    md5: dcd498d493818b776a77fbc242fbf8e4
+    sha256: 0424e380c435ba03b5948d02e8c958866c4eee50ed29e57f99473a5f795a4cfc
   category: main
   optional: false
 - name: aws-checksums
-  version: 0.1.20
+  version: 0.2.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.20-h2bff981_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-h4e1184b_4.conda
   hash:
-    md5: 8b424cf6b3cfc5cffe98bf4d16c032fb
-    sha256: e1793f2e52fe04ef3a6b2069abda7960d061c6f7af1f0d5f616d43e7a7c40e3c
+    md5: 74e8c3e4df4ceae34aa2959df4b28101
+    sha256: 1ed9a332d06ad595694907fad2d6d801082916c27cd5076096fda4061e6d24a8
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.28.3
+  version: 0.29.9
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.7.31,<0.7.32.0a0'
-    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
-    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
-    aws-c-http: '>=0.8.10,<0.8.11.0a0'
-    aws-c-io: '>=0.14.19,<0.14.20.0a0'
-    aws-c-mqtt: '>=0.10.7,<0.10.8.0a0'
-    aws-c-s3: '>=0.6.7,<0.6.8.0a0'
-    aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
+    aws-c-auth: '>=0.8.1,<0.8.2.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-c-mqtt: '>=0.11.0,<0.11.1.0a0'
+    aws-c-s3: '>=0.7.9,<0.7.10.0a0'
+    aws-c-sdkutils: '>=0.2.2,<0.2.3.0a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.28.3-hbe26082_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.9-he0e7f3f_2.conda
   hash:
-    md5: 80d5fac04be0e6c2774f57eb7529f145
-    sha256: a9c23a685929b24fcd032daae36b61c4862912abf0a0a8735aeef53418c5bce6
+    md5: 8a4e6fc8a3b285536202b5456a74a940
+    sha256: c1930569713bd5231d48d885a5e3707ac917b428e8f08189d14064a2bb128adc
   category: main
   optional: false
 - name: aws-sdk-cpp
-  version: 1.11.407
+  version: 1.11.489
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
-    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
-    aws-checksums: '>=0.1.20,<0.1.21.0a0'
-    aws-crt-cpp: '>=0.28.3,<0.28.4.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
+    aws-crt-cpp: '>=0.29.9,<0.29.10.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.407-h25d6d5c_1.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.489-h4d475cb_0.conda
   hash:
-    md5: 0f2bd0128d59a45c9fd56151eab0b37e
-    sha256: f05d43f3204887cec9a9853a9217f06562b28161950b5485aed1f8afe42aad17
+    md5: b775e9f46dfa94b228a81d8e8c6d8b1d
+    sha256: 08d6b7d2ed17bfcc7deb903c7751278ee434abdb27e3be0dceb561f30f030c75
   category: main
   optional: false
 - name: awscli
-  version: 2.19.2
+  version: 2.25.3
   manager: conda
   platform: linux-64
   dependencies:
-    awscrt: '>=0.19.18,<=0.22.0'
+    awscrt: 0.23.8
     colorama: '>=0.2.5,<0.4.7'
     cryptography: '>=40.0.0,<43.0.2'
     distro: '>=1.5.0,<1.9.0'
     docutils: '>=0.10,<0.20'
     jmespath: '>=0.7.1,<1.1.0'
-    prompt_toolkit: '>=3.0.24,<3.0.39'
+    prompt-toolkit: '>=3.0.24,<3.0.39'
     python: '>=3.10,<3.11.0a0'
     python-dateutil: '>=2.1,<=2.9.0'
     python_abi: 3.10.*
     ruamel.yaml: '>=0.15.0,<=0.17.21'
     ruamel.yaml.clib: '>=0.2.0,<=0.2.8'
     urllib3: '>=1.25.4,<1.27'
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.19.2-py310hff52083_0.conda
+    zipp: <3.21.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.25.3-py310hff52083_0.conda
   hash:
-    md5: d080d0de97633662f27044df1407168c
-    sha256: fabc492e243059191b38234f2451769340d59b8283b05e6d6f3ff77f51496402
+    md5: a1510777b8d15707d5a48bc20510e5d2
+    sha256: 0c08186dc83770a5570ceb1b2dcbaaef2509a45d97f8eca9e99876d4d5d1d365
   category: main
   optional: false
 - name: awscrt
-  version: 0.22.0
+  version: 0.23.8
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.7.31,<0.7.32.0a0'
-    aws-c-cal: '>=0.7.4,<0.7.5.0a0'
-    aws-c-common: '>=0.9.29,<0.9.30.0a0'
-    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
-    aws-c-http: '>=0.8.10,<0.8.11.0a0'
-    aws-c-io: '>=0.14.19,<0.14.20.0a0'
-    aws-c-mqtt: '>=0.10.7,<0.10.8.0a0'
-    aws-c-s3: '>=0.6.7,<0.6.8.0a0'
-    aws-checksums: '>=0.1.20,<0.1.21.0a0'
+    aws-c-auth: '>=0.8.1,<0.8.2.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-c-mqtt: '>=0.11.0,<0.11.1.0a0'
+    aws-c-s3: '>=0.7.9,<0.7.10.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-    s2n: '>=1.5.5,<1.5.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.22.0-py310hab15552_5.conda
+    s2n: '>=1.5.11,<1.5.12.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.23.8-py310h2abebbc_0.conda
   hash:
-    md5: 96b279f1d40683cb3dda0c71814f71da
-    sha256: 8ffa0eb0e0a16b5db8e143eff89f5d69b581ce3672c35669e09aebe49d024166
+    md5: b2702872eb1271806f192f0b1a4a556e
+    sha256: 7213b01cc779449371126616d69722c06a2fd76b1fa421ff1c30c26fa571b1d2
   category: main
   optional: false
 - name: azure-cli-core
-  version: 2.0.61
+  version: 2.68.0
   manager: conda
   platform: linux-64
   dependencies:
-    adal: '>=1.2.0'
-    antlr-python-runtime: ''
-    argcomplete: '>=1.8.0'
-    azure-cli-telemetry: ''
-    azure-mgmt-resource: 2.1.0
-    colorama: '>=0.3.9'
-    humanfriendly: '>=4.7'
+    argcomplete: '>=3.5.2'
+    azure-cli-telemetry: '>=1.1.0'
+    azure-mgmt-core: '>=1.2.0,<2'
+    cryptography: ''
+    distro: ''
+    humanfriendly: '>=10.0'
     jmespath: ''
-    knack: 0.5.1
-    msrest: '>=0.4.4'
-    msrestazure: '>=0.4.25'
-    paramiko: '>=2.0.8'
-    pip: ''
-    pygments: ''
-    pyjwt: ''
+    knack: '>=0.11.0'
+    msal: '>=1.31.1'
+    msal_extensions: '>=1.2.0'
+    msrestazure: ~=0.6.4
+    packaging: '>=20.9'
+    pkginfo: '>=1.5.0.1'
+    psutil: '>=5.9'
+    pyjwt: '>=2.1.0'
     pyopenssl: '>=17.1.0'
-    python: '>=3'
-    pyyaml: ''
+    pysocks: '>=1.6.0'
+    python: '>=3.9'
     requests: '>=2.20.0'
-    six: ''
-    tabulate: '>=0.7.7,<=0.8.2'
-    wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-cli-core-2.0.61-py_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-cli-core-2.68.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3c19b2489b0d1f239220ec0acba70b3d
-    sha256: 9015ec646c39447b177d664d03ad59b6a9472fcd3783fba2f129d033a92ba27c
+    md5: f06fcf878a1a6608091165db51203edb
+    sha256: b1ed81fecf913684c55dbb8f12d0d38d30422a3e4f375d4f3d3dacba07791b72
   category: main
   optional: false
 - name: azure-cli-telemetry
-  version: 1.0.2
+  version: 1.1.0.post20250227030620
   manager: conda
   platform: linux-64
   dependencies:
-    applicationinsights: '>=0.11.1'
-    portalocker: 1.2.1
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-cli-telemetry-1.0.2-py310hff52083_4.tar.bz2
+    applicationinsights: '>=0.11.1,<0.12'
+    portalocker: '>=1.6,<3'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-cli-telemetry-1.1.0.post20250227030620-pyhd8ed1ab_0.conda
   hash:
-    md5: 7e93b7ecebed6668566a00e5f4de628c
-    sha256: a998855d79a07c5be5968ac10668e0ca10fa4a8ede9546ac4a069136e6c72a82
-  category: main
-  optional: false
-- name: azure-common
-  version: 1.1.28
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-common-1.1.28-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 36a0b7a0497cfdb87e62c809947dd81c
-    sha256: 72d839dd1189f69605a39e82869e98f13a6556dfd8cf1552b34de21ccc735d42
+    md5: 37ee5de05b5a145ba392bd1ab447a8a6
+    sha256: 0bc5c4eebe114514dae4231893ad8917fe953ca02507db0f7ba0ab55e2f4bf78
   category: main
   optional: false
 - name: azure-core
-  version: 1.31.0
+  version: 1.32.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     requests: '>=2.21.0'
     six: '>=1.11.0'
-    typing-extensions: '>=4.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.31.0-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.32.0-pyhff2d567_0.conda
   hash:
-    md5: 33af32b1c21eb1fa7f0e2d9ecd0ea231
-    sha256: 289290d374c5ff2cfb58e429c5ca35f31f180bdc65c6c17437cdf4990831e579
+    md5: 50e7543a5b44a98b129a1c59e3938b97
+    sha256: 5e2eb5c80e0d7c701e645344d83dea6ac634df83c9c3918c80c996d2ab1b3163
   category: main
   optional: false
 - name: azure-core-cpp
-  version: 1.13.0
+  version: 1.14.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.13.0-h935415a_0.conda
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
   hash:
-    md5: debd1677c2fea41eb2233a260f48a298
-    sha256: b7e0a22295db2e1955f89c69cefc32810309b3af66df986d9fb75d89f98a80f7
+    md5: 0a8838771cc2e985cd295e01ae83baf1
+    sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
   category: main
   optional: false
 - name: azure-data-tables
@@ -1016,158 +1019,158 @@ package:
   dependencies:
     azure-core: <2.0.0,>=1.24.0
     isodate: '>=0.6.0'
-    python: '>=3.7'
+    python: '>=3.9'
     typing-extensions: '>=4.3.0'
     yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-data-tables-12.4.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-data-tables-12.4.4-pyhd8ed1ab_1.conda
   hash:
-    md5: bdcf11e8c7bc83a9d2a481ef932c8973
-    sha256: d24d17735b835c6397fa0fbc78206f90031b60a07132c7235d179a22b283a7b4
+    md5: 5b83a9a3b0a021e1c2d1de841b700dca
+    sha256: 617e0585f431c7e67174745b75c3efa817eae61270fcc3d526ce37aacbe544d2
   category: main
   optional: false
 - name: azure-datalake-store
-  version: 0.0.51
+  version: 0.0.53
   manager: conda
   platform: linux-64
   dependencies:
-    adal: '>=0.4.2'
     cffi: ''
-    python: ''
+    msal: '>=1.16.0,<2'
+    python: '>=3.9'
     requests: '>=2.20.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-datalake-store-0.0.51-pyh9f0ad1d_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-datalake-store-0.0.53-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a6d240a3a8198dce8508a5409b4737e
-    sha256: 8ba71f78851d238d8dc9f469f88b2f5619c7f6f5d009a96bcbd8bd595ed85273
+    md5: ae3e0befc6f7d9e170b57bb735ed9150
+    sha256: e36b90b44b8b989cedf9fcda182a1dc30546197d1dcc174c9b380f160543d124
   category: main
   optional: false
 - name: azure-identity
-  version: 1.17.1
+  version: 1.21.0
   manager: conda
   platform: linux-64
   dependencies:
-    azure-core: '>=1.23.0'
+    azure-core: '>=1.31.0'
     cryptography: '>=2.5'
-    msal: '>=1.24.0'
-    msal_extensions: '>=0.3.0'
-    python: '>=3.7'
-    typing-extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-identity-1.17.1-pyhd8ed1ab_0.conda
+    msal: '>=1.30.0'
+    msal_extensions: '>=1.2.0'
+    python: '>=3.9'
+    typing_extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-identity-1.21.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 137b53f8ac9b81798f07bdcf2248fab4
-    sha256: d57802f1f3b96c57d867cfb0b782c103936fb62fa9da3c456ebe17a202b045fc
+    md5: 0fb0d9c55097123a36089cc46aa8d65f
+    sha256: 8cd28da047a7800e41358cb0f711f9510797c3245e19931d0109982c70dd58c4
   category: main
   optional: false
 - name: azure-identity-cpp
-  version: 1.8.0
+  version: 1.10.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hd126650_2.conda
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
   hash:
-    md5: 36df3cf05459de5d0a41c77c4329634b
-    sha256: f85452eca3ae0e156b1d1a321a1a9f4f58d44ff45236c0d8602ab96aaad3c6ba
+    md5: 73f73f60854f325a55f1d31459f2ab73
+    sha256: 286b31616c191486626cb49e9ceb5920d29394b9e913c23adb7eb637629ba4de
   category: main
   optional: false
-- name: azure-mgmt-resource
-  version: 2.1.0
+- name: azure-mgmt-core
+  version: 1.5.0
   manager: conda
   platform: linux-64
   dependencies:
-    azure-common: '>=1.1'
-    msrestazure: '>=0.4.11'
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-mgmt-resource-2.1.0-py_0.tar.bz2
+    azure-core: '>=1.31.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-mgmt-core-1.5.0-pyhd8ed1ab_1.conda
   hash:
-    md5: c8e360823038e62f0808d74b52622f2f
-    sha256: 7a903c774969cb5284989110a82875e04fa752511f94864c19cf59ae21a7d412
+    md5: 0e8e3e439ce795520f7a9e7d6305ddc2
+    sha256: 609ceeaa0b5f317b1c3c42980b2481b3b927d1ca1c4edc3a4f3f30c56fe9e843
   category: main
   optional: false
 - name: azure-storage-blob
-  version: 12.23.1
+  version: 12.25.0
   manager: conda
   platform: linux-64
   dependencies:
     azure-core: '>=1.30.0'
     cryptography: '>=2.1.4'
     isodate: '>=0.6.1'
-    python: '>=3.8'
+    python: '>=3.9'
     typing-extensions: '>=4.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-storage-blob-12.23.1-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-storage-blob-12.25.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1e9f92b04ddfb72ba0cd6f2298422a5a
-    sha256: e2c84cc661d8cde7727bbd002fb5d4be22a22271d71e0dda018c723506987ff6
+    md5: c4126766ccaa7064c47d8c7392bf56b8
+    sha256: a2073303af05976f74f92f185192f4202b3b1572bb53f88918b5589c3d8ba3de
   category: main
   optional: false
 - name: azure-storage-blobs-cpp
+  version: 12.13.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-storage-common-cpp: '>=12.8.0,<12.8.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+  hash:
+    md5: 7eb66060455c7a47d9dcdbfa9f46579b
+    sha256: 2606260e5379eed255bcdc6adc39b93fb31477337bcd911c121fc43cd29bf394
+  category: main
+  optional: false
+- name: azure-storage-common-cpp
+  version: 12.8.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libxml2: '>=2.12.7,<3.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+  hash:
+    md5: 13de36be8de3ae3f05ba127631599213
+    sha256: 273475f002b091b66ce7366da04bf164c3732c03f8692ab2ee2d23335b6a82ba
+  category: main
+  optional: false
+- name: azure-storage-files-datalake-cpp
   version: 12.12.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
-    azure-storage-common-cpp: '>=12.7.0,<12.7.1.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.12.0-hd2e3451_0.conda
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-storage-blobs-cpp: '>=12.13.0,<12.13.1.0a0'
+    azure-storage-common-cpp: '>=12.8.0,<12.8.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
   hash:
-    md5: 61f1c193452f0daa582f39634627ea33
-    sha256: 69a0f5c2a08a1a40524b343060debb8d92295e2cc5805c3db56dad7a41246a93
-  category: main
-  optional: false
-- name: azure-storage-common-cpp
-  version: 12.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.7,<3.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.7.0-h10ac4d7_1.conda
-  hash:
-    md5: ab6d507ad16dbe2157920451d662e4a1
-    sha256: 1030fa54497a73eb78c509d451f25701e2e781dc182e7647f55719f1e1f9bee8
-  category: main
-  optional: false
-- name: azure-storage-files-datalake-cpp
-  version: 12.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
-    azure-storage-blobs-cpp: '>=12.12.0,<12.12.1.0a0'
-    azure-storage-common-cpp: '>=12.7.0,<12.7.1.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.11.0-h325d260_1.conda
-  hash:
-    md5: 11d926d1f4a75a1b03d1c053ca20424b
-    sha256: 1726fa324bb402e52d63227d6cb3f849957cd6841f8cb8aed58bb0c81203befb
+    md5: 7c1980f89dd41b097549782121a73490
+    sha256: 5371e4f3f920933bb89b926a85a67f24388227419abd6e99f6086481e5e8d5f2
   category: main
   optional: false
 - name: babel
-  version: 2.16.0
+  version: 2.17.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     pytz: '>=2015.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.16.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6d4e9ecca8d88977147e109fc7053184
-    sha256: fce1d78e42665bb26d3f2b45ce9cacf0d9dbe4c1b2db3879a384eadee53c6231
+    md5: 0a01c169f0ab0f91b26e77a3301fbfe4
+    sha256: 1c656a35800b7f57f7371605bc6507c8d3ad60fbaaec65876fce7f73df1fc8ac
   category: main
   optional: false
 - name: bcrypt
-  version: 4.2.0
+  version: 4.3.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -1175,23 +1178,24 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.2.0-py310h505e2c1_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.3.0-py310h505e2c1_0.conda
   hash:
-    md5: a3e0cffbbb63775dae589352dc9f7f3d
-    sha256: 982c774fa5669f95fe1e8076eb7100329d40572d4823c6411ebdc9497f8e6424
+    md5: fed763c2254a66817409395e7f270af4
+    sha256: 21ecb5510301ee1419449d4a44280bbad5e243b5e58ba3192ff1c33e79a8b2a9
   category: main
   optional: false
 - name: beautifulsoup4
-  version: 4.12.3
+  version: 4.13.3
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     soupsieve: '>=1.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.3-pyha770c72_0.conda
   hash:
-    md5: 332493000404d8411859539a5a630865
-    sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
+    md5: 373374a3ed20141090504031dc7b693e
+    sha256: 4ce42860292a57867cfc81a5d261fb9886fc709a34eca52164cc8bbf6d03de9f
   category: main
   optional: false
 - name: binutils
@@ -1200,10 +1204,10 @@ package:
   platform: linux-64
   dependencies:
     binutils_impl_linux-64: '>=2.43,<2.44.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_4.conda
   hash:
-    md5: 348619f90eee04901f4a70615efff35b
-    sha256: 92be0f8ccd501ceeb3c782e2182e6ea04dca46799038176de40a57bca45512c5
+    md5: 29782348a527eda3ecfc673109d28e93
+    sha256: 99a94eead18e7704225ac43682cce3f316fd33bc483749c093eaadef1d31de75
   category: main
   optional: false
 - name: binutils_impl_linux-64
@@ -1213,10 +1217,10 @@ package:
   dependencies:
     ld_impl_linux-64: '2.43'
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_4.conda
   hash:
-    md5: cf0c5521ac2a20dfa6c662a4009eeef6
-    sha256: 267e78990247369b13234bda270f31beb56a600b4851a8244e31dd9ad85b3b17
+    md5: ef67db625ad0d2dce398837102f875ed
+    sha256: 194d771be287dc973f6057c0747010ce28adf960f38d6e03ce3e828d7b74833e
   category: main
   optional: false
 - name: binutils_linux-64
@@ -1225,10 +1229,10 @@ package:
   platform: linux-64
   dependencies:
     binutils_impl_linux-64: '2.43'
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_4.conda
   hash:
-    md5: 18aba879ddf1f8f28145ca6fcb873d8c
-    sha256: df52bd8b8b2a20a0c529d9ad08aaf66093ac318aa8a33d270f18274341a77062
+    md5: c87e146f5b685672d4aa6b527c6d3b5e
+    sha256: fe662a038dc14334617940f42ede9ba26d4160771255057cb14fb1a81ee12ac1
   category: main
   optional: false
 - name: bleach
@@ -1236,24 +1240,37 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
+    python: ''
     webencodings: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
   hash:
-    md5: 461bcfab8e65c166e297222ae919a2d4
-    sha256: 01be7fb5163e7c31356a18c259ddc19a5431b8b974dc65e2427b88c2d30034f3
+    md5: f0b4c8e370446ef89797608d60a564b3
+    sha256: a05971bb80cca50ce9977aad3f7fc053e54ea7d5321523efc7b9a6e12901d3cd
   category: main
   optional: false
-- name: blinker
-  version: 1.8.2
+- name: bleach-with-css
+  version: 6.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.8.2-pyhd8ed1ab_0.conda
+    bleach: ==6.2.0
+    tinycss2: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
   hash:
-    md5: cf85c002319c15e9721934104aaa1137
-    sha256: 8ca3cd8f78d0607df28c9f76adb9800348f8f2dc8aa49d188a995a0acdc4477d
+    md5: a30e9406c873940383555af4c873220d
+    sha256: 0aba699344275b3972bd751f9403316edea2ceb942db12f9f493b63c74774a46
+  category: main
+  optional: false
+- name: blinker
+  version: 1.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+  hash:
+    md5: 42834439227a4551b939beeeb8a4b085
+    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
   category: main
   optional: false
 - name: blosc
@@ -1261,20 +1278,21 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
   hash:
-    md5: 54fe76ab3d0189acaef95156874db7f9
-    sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
+    md5: 2c2fae981fd2afd00812c92ac47d023d
+    sha256: e7af5d1183b06a206192ff440e08db1c4e8b2ca1f8376ee45fb2f3a85d4ee45d
   category: main
   optional: false
 - name: bokeh
-  version: 3.5.2
+  version: 3.6.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -1288,10 +1306,10 @@ package:
     pyyaml: '>=3.10'
     tornado: '>=6.2'
     xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 38d785787ec83d0431b3855328395113
-    sha256: 8af284264eb1cb9c08586ac8c212dcafc929ef1de3db9d0d7f8ca75190a30f4b
+    md5: 606498329a91bd9d5c0439fb2815816f
+    sha256: 6cc6841b1660cd3246890d4f601baf51367526afe6256dfd8a8d9a8f7db651fe
   category: main
   optional: false
 - name: boltons
@@ -1299,30 +1317,30 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: 2.7.*|>=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 61de176bd62041f9cd5bd4fcd09eb0ff
-    sha256: e44d07932306392372411ab1261670a552f96077f925af00c1559a18a73a1bdc
+    md5: d88c38e66d85ecc9c7e2c4110676bbf4
+    sha256: 4d6101f6a900c22495fbaa3c0ca713f1876d11f14aba3f7832bf6e6986ee5e64
   category: main
   optional: false
 - name: boto3
-  version: 1.35.23
+  version: 1.37.1
   manager: conda
   platform: linux-64
   dependencies:
-    botocore: '>=1.35.23,<1.36.0'
+    botocore: '>=1.37.1,<1.38.0'
     jmespath: '>=0.7.1,<2.0.0'
-    python: '>=3.8'
-    s3transfer: '>=0.10.0,<0.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.23-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    s3transfer: '>=0.11.0,<0.12.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.37.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5d644d9ab2fefa60752d3b89ee100360
-    sha256: cdf46f5fb3cca71155e4d3d36cacfe053917cd34cc892ab2851336eca710f615
+    md5: eb2c073da600ba16cd6a4714c5c73966
+    sha256: 9a61b39e929afb1ac2a44e7a35ad6c2700a89b00831c3a6056e230d0eb546ca3
   category: main
   optional: false
 - name: botocore
-  version: 1.35.23
+  version: 1.37.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -1330,10 +1348,10 @@ package:
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.23-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.37.1-pyge310_1234567_0.conda
   hash:
-    md5: 8bc6cc86e95ae59192bdf6d27bfffb37
-    sha256: 4af3e09e19d2858bdf05bcfdd07179772eb9580367b3f9453629453e533b0fe1
+    md5: 8c3c37279f889ee8507d43ab70558b6a
+    sha256: cfb900b68f4b298e7041b622abec950e0661524bcf0b9652d7e9a0044e2fb936
   category: main
   optional: false
 - name: bottleneck
@@ -1360,26 +1378,26 @@ package:
     ipywidgets: '>=7.6.0,<9'
     numpy: '>=1.10.4'
     pandas: '>=1.0.0,<3.0.0'
-    python: '>=3.6'
+    python: '>=3.9'
     traitlets: '>=4.3.0,<6.0'
     traittypes: '>=0.0.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.43-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.43-pyhd8ed1ab_1.conda
   hash:
-    md5: b9fe4be7c3abb5c473148feb9e8b7b02
-    sha256: e5a107d0c035331aef334d71f2aa3bdf09f8897e0cd645966ee9ee2c55f124b0
+    md5: 9e09d992eec43a6b6cefe514c07957e3
+    sha256: 8dc6e1206d02c747617d1ecb5c4f8be3b019b2578bda27eba83a184a4b1501a8
   category: main
   optional: false
 - name: branca
-  version: 0.7.2
+  version: 0.8.1
   manager: conda
   platform: linux-64
   dependencies:
     jinja2: '>=3'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5f1c719f1cac0aee5e6bd6ca7d54a7fa
-    sha256: 9f7df349cb5a8852804d5bb1f5f49e3076a55ac7229b9c114bb5f7461f497ba7
+    md5: 9f3937b768675ab4346f07e9ef723e4b
+    sha256: 38de10b8608ed962ad3e01d6ddc5cfa373221cfdc0faa96a46765d6defffc75f
   category: main
   optional: false
 - name: brotli
@@ -1457,58 +1475,58 @@ package:
   category: main
   optional: false
 - name: c-ares
-  version: 1.34.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
-  hash:
-    md5: 2b780c0338fc0ffa678ac82c54af51fd
-    sha256: c2a515e623ac3e17a56027c06098fbd5ab47afefefbd386b4c21289f2ec55139
-  category: main
-  optional: false
-- name: c-blosc2
-  version: 2.15.1
+  version: 1.34.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    zlib-ng: '>=2.2.1,<2.3.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.15.1-hc57e6cf_0.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.4-hb9d3cd8_0.conda
   hash:
-    md5: 5f84961d86d0ef78851cb34f9d5e31fe
-    sha256: 6b11cae208878fbf621fbc22135a7912fd0ef19301d0b654858ae16b972410dc
+    md5: e2775acf57efd5af15b8e3d1d74d72d3
+    sha256: d4f28d87b6339b94f74762c0076e29c8ef8ddfff51a564a92da2843573c18320
+  category: main
+  optional: false
+- name: c-blosc2
+  version: 2.15.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    zlib-ng: '>=2.2.2,<2.3.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.15.2-h3122c55_1.conda
+  hash:
+    md5: 2bc8d76acd818d7e79229f5157d5c156
+    sha256: 6c952a8aa5507c30cd80901cce5dfacfdaf54c999cf6b3e391322ca216f2593f
   category: main
   optional: false
 - name: c-compiler
-  version: 1.8.0
+  version: 1.9.0
   manager: conda
   platform: linux-64
   dependencies:
     binutils: ''
     gcc: ''
     gcc_linux-64: 13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.8.0-h2b85faf_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.9.0-h2b85faf_0.conda
   hash:
-    md5: fa7b3bf2965b9d74a81a0702d9bb49ee
-    sha256: 009fced27be14e5ac750a04111a07eda79d73f80009300c1538cb83d5da71879
+    md5: 3cb814f83f1f71ac1985013697f80cc1
+    sha256: 1e4b86b0f3d4ce9f3787b8f62e9f2c5683287f19593131640eed01cbdad38168
   category: main
   optional: false
 - name: ca-certificates
-  version: 2024.8.30
+  version: 2025.1.31
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2025.1.31-hbcca054_0.conda
   hash:
-    md5: c27d1c142233b5bc9ca570c6e2e0c244
-    sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
+    md5: 19f3a56f68d2fd06c516076bff482c52
+    sha256: bf832198976d559ab44d6cdb315642655547e26d826e34da67cbee6624cda189
   category: main
   optional: false
 - name: cached-property
@@ -1536,15 +1554,15 @@ package:
   category: main
   optional: false
 - name: cachetools
-  version: 5.5.0
+  version: 5.5.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.5.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 5bad039db72bd8f134a5cff3ebaa190d
-    sha256: 0abdbbfc2e9c21079a943f42a2dcd950b1a8093ec474fc017e83da0ec4e6cbf4
+    md5: bf9c1698e819fab31f67dbab4256f7ba
+    sha256: 1823dc939b2c2b5354b6add5921434f9b873209a99569b3a2f24dca6c596c0d6
   category: main
   optional: false
 - name: cachey
@@ -1561,32 +1579,48 @@ package:
   category: main
   optional: false
 - name: cairo
-  version: 1.18.0
+  version: 1.18.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    fontconfig: '>=2.14.2,<3.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     icu: '>=75.1,<76.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.3,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.16,<2.0.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.2,<3.0a0'
+    libpng: '>=1.6.47,<1.7.0a0'
+    libstdcxx: '>=13'
+    libxcb: '>=1.17.0,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    pixman: '>=0.43.2,<1.0a0'
-    xorg-libice: '>=1.1.1,<2.0a0'
-    xorg-libsm: '>=1.2.4,<2.0a0'
-    xorg-libx11: '>=1.8.9,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+    pixman: '>=0.44.2,<1.0a0'
+    xorg-libice: '>=1.1.2,<2.0a0'
+    xorg-libsm: '>=1.2.5,<2.0a0'
+    xorg-libx11: '>=1.8.11,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxrender: '>=0.9.12,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
   hash:
-    md5: fceaedf1cdbcb02df9699a0d9b005292
-    sha256: aee5b9e6ef71cdfb2aee9beae3ea91910ca761c01c0ef32052e3f94a252fa173
+    md5: 09262e66b19567aff4f592fb53b28760
+    sha256: 3bd6a391ad60e471de76c0e9db34986c4b5058587fbf2efa5a7f54645e28c2c7
+  category: main
+  optional: false
+- name: capnproto
+  version: 1.0.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.0.2-h766bdaa_3.conda
+  hash:
+    md5: 7ea5f8afe8041beee8bad281dee62414
+    sha256: fecb35e58b73a3dcb50725305964839ad08c0973592ba4d4ee0964360609fd12
   category: main
   optional: false
 - name: cartopy
@@ -1618,12 +1652,12 @@ package:
   dependencies:
     attrs: '>=23.1.0'
     exceptiongroup: '>=1.1.1'
-    python: '>=3.8'
+    python: '>=3.9'
     typing-extensions: '>=4.1.0,!=4.6.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/cattrs-24.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cattrs-24.1.2-pyhd8ed1ab_1.conda
   hash:
-    md5: ac582de2324988b79870b50c89c91c75
-    sha256: 51abcd19174028e3745ae7c16969ae66c321f047f20bc4383b9f6a692e770364
+    md5: 53eca64665361194ca4bbaf87c0ded99
+    sha256: 6561a73cb712d8972d64968d6de709fcb2c85cf77d06f996537e4f1768535d76
   category: main
   optional: false
 - name: cchardet
@@ -1642,15 +1676,15 @@ package:
   category: main
   optional: false
 - name: certifi
-  version: 2024.8.30
+  version: 2025.1.31
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.1.31-pyhd8ed1ab_0.conda
   hash:
-    md5: 12f7d00853807b0531775e9be891cb11
-    sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
+    md5: c207fa5ac7ea99b149344385a9c0880d
+    sha256: 42a78446da06a2568cb13e69be3355169fbd0ea424b00fc80b7d840f5baaacf3
   category: main
   optional: false
 - name: certipy
@@ -1659,24 +1693,24 @@ package:
   platform: linux-64
   dependencies:
     cryptography: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certipy-0.2.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/certipy-0.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 7566bb010833e59fb579ed520b9a7bc5
-    sha256: be226c66b57f28be62b019e175a6c7fd477d33bbbdc7bdc45559b786be2e82b1
+    md5: 40cc21890ee2e9eca7cbc795d233e118
+    sha256: c2ccd6295beb8c6b45b2f52a8d1c5a05b34fffd02c180f089a9e9c02e8dea9da
   category: main
   optional: false
 - name: cf_xarray
-  version: 0.10.0
+  version: 0.10.4
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-    xarray: '>=2022.03.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.0-pyhd8ed1ab_0.conda
+    xarray: '>=2023.09.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 9437cfe346eab83b011b4def99f0e879
-    sha256: 9733b1e42114f8f4be88005d89ecb39d56738750510601941e2197e1ba76efbc
+    md5: c0e4d140630d01713a6b3126788d7e85
+    sha256: 1bff85926960df159151f857c92aadc605171f2d9c777c987ecb7e3885b33c42
   category: main
   optional: false
 - name: cffi
@@ -1697,7 +1731,7 @@ package:
   category: main
   optional: false
 - name: cfgrib
-  version: 0.9.14.1
+  version: 0.9.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -1705,32 +1739,14 @@ package:
     click: ''
     numpy: ''
     packaging: ''
-    python: '>=3.7'
+    python: '>=3.9'
     python-eccodes: '>=0.9.8'
     setuptools: ''
     xarray: '>=0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/cfgrib-0.9.14.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cfgrib-0.9.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1870fe8c9bd8967429e227be28ab94d2
-    sha256: fca594ecc55659a47f03111d2a13a5a7b8d341465b01efedd529a68ccf183297
-  category: main
-  optional: false
-- name: cfitsio
-  version: 4.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
-    libgcc: '>=13'
-    libgfortran: ''
-    libgfortran5: '>=13.3.0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.1-ha728647_2.conda
-  hash:
-    md5: dab65ce7f9da0b25f53f0ec0d37ee09c
-    sha256: 985f6dd1346b3cdc6658ec9b17d794d8a5859f966e8e5b2a886a2bdc84c39975
+    md5: 211303621409d703235598be8c378b3c
+    sha256: 0864173af5c9a767b0ad49d10d5eb650d3fbd0372d9b782712c5c11749532381
   category: main
   optional: false
 - name: cftime
@@ -1755,13 +1771,13 @@ package:
   platform: linux-64
   dependencies:
     numpy: ''
-    python: '>=3.8'
+    python: '>=3.9'
     pytools: ''
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cgen-2020.1-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cgen-2020.1-pyhd8ed1ab_2.conda
   hash:
-    md5: df7c0886811b366401c3a7c300ce49af
-    sha256: 4d0369ef562504c496b8c61a5ab585e28fc3637282ca33023e23bad3b2e986bc
+    md5: 613c82247f8347eced8e1721ebffed9a
+    sha256: 922410122fc0a509a1e818566b862e648d4aedaa23c744e689811f62c9f384b2
   category: main
   optional: false
 - name: charls
@@ -1778,15 +1794,15 @@ package:
   category: main
   optional: false
 - name: charset-normalizer
-  version: 3.4.0
+  version: 3.4.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a374efa97290b8799046df7c5ca17164
-    sha256: 1873ac45ea61f95750cb0b4e5e675d1c5b3def937e80c7eebb19297f76810be8
+    md5: e83a31202d1c0a000fce3e9cf3825875
+    sha256: 4e0ee91b97e5de3e74567bdacea27f0139709fceca4db8adffbe24deffccb09b
   category: main
   optional: false
 - name: ciso
@@ -1806,7 +1822,7 @@ package:
   category: main
   optional: false
 - name: ciso8601
-  version: 2.3.1
+  version: 2.3.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -1814,23 +1830,23 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ciso8601-2.3.1-py310ha75aee5_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ciso8601-2.3.2-py310ha75aee5_0.conda
   hash:
-    md5: 74e23aea753172599cec77b600eb6336
-    sha256: 60c8b47b77fa18fd856d824c76758037158a789c678186d2fc952ca4b7346a83
+    md5: f9d17fccb801a3868cbc586d6d45bf05
+    sha256: 2cefdcc161215fe1f0a200613bd2c83f9bbd10d1bf1acbb5698bd731842312d2
   category: main
   optional: false
 - name: click
-  version: 8.1.7
+  version: 8.1.8
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
   hash:
-    md5: f3ad426304898027fc619827ff428eca
-    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+    md5: f22f4d4970e09d68a10b922cbb0408d3
+    sha256: c920d23cd1fcf565031c679adb62d848af60d6fbb0edc2d50ba475cea4f0d8ab
   category: main
   optional: false
 - name: click-plugins
@@ -1839,11 +1855,11 @@ package:
   platform: linux-64
   dependencies:
     click: '>=3.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
-    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+    md5: 82bea35e4dac4678ba623cf10e95e375
+    sha256: e7e2371a2561fbda9d50deb895d56fb16ccefe54f6d81b35ba8f1d33d3cc6957
   category: main
   optional: false
 - name: cligj
@@ -1852,23 +1868,23 @@ package:
   platform: linux-64
   dependencies:
     click: '>=4.0'
-    python: <4.0
-  url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
   hash:
-    md5: a29b7c141d6b2de4bb67788a5f107734
-    sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+    md5: 55c7804f428719241a90b152016085a1
+    sha256: 1a52ae1febfcfb8f56211d1483a1ac4419b0028b7c3e9e61960a298978a42396
   category: main
   optional: false
 - name: cloudpickle
-  version: 2.2.1
+  version: 3.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-2.2.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b325bfc4cff7d7f8a868f1f7ecc4ed16
-    sha256: f0c2fd0e842899a05ddd7b147fb26424adf58be0e8e54e5bc68b8f7e67d05dcd
+    md5: 364ba6c9fb03886ac979b482f39ebb92
+    sha256: 21ecead7268241007bf65691610cd7314da68c1f88113092af690203b5780db5
   category: main
   optional: false
 - name: cmocean
@@ -1880,15 +1896,15 @@ package:
     matplotlib-base: ''
     numpy: ''
     packaging: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cmocean-4.0.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cmocean-4.0.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 53df00540de0348ed1b2a62684dd912b
-    sha256: c32b9dddcfc5ce3aa2e4a84ff73b9eff67fe2cff64b5dc885ddd13e2bfab9978
+    md5: dd71e4ec2fbffe38c0359976505f816e
+    sha256: 70d3469d7a9b23a38526d7313ee10e7826f0245ffb5a7eeec15a134d90636a32
   category: main
   optional: false
 - name: color-operations
-  version: 0.1.5
+  version: 0.1.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -1897,10 +1913,10 @@ package:
     numpy: '>=1.19,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/color-operations-0.1.5-py310hf462985_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/color-operations-0.1.6-py310hf462985_0.conda
   hash:
-    md5: 79a25a5fa2cc6adfebc262a96a5257e5
-    sha256: 42815580184c250566a29d88d4884be0d9cca165cf7e456c38d96f17ca3ad04b
+    md5: 3768828e539ff0f746ab1fd366e1bcd6
+    sha256: 21b8a2b136c4aba67227f8842eb44d5ad96ddf66fc594e46fdb9ce17f0b84b7b
   category: main
   optional: false
 - name: colorama
@@ -1908,11 +1924,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+    md5: 962b9857ee8e7018c22f2776ffa0b2d7
+    sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   category: main
   optional: false
 - name: colorcet
@@ -1920,11 +1936,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.1.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 4d155b600b63bc6ba89d91fab74238f8
-    sha256: 79a6b4fff545e0b18f86ad93276a1797eb6ac3f7e1851e03f02d63b19655731b
+    md5: 91d7152c744dc0f18ef8beb3cbc9980a
+    sha256: 46055a0524ed3a48b23cd27a52246c89ac059ccce90a50b2eeb84d2f833ae827
   category: main
   optional: false
 - name: colorspacious
@@ -1933,11 +1949,11 @@ package:
   platform: linux-64
   dependencies:
     numpy: ''
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/colorspacious-1.1.2-pyh24bf2e0_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/colorspacious-1.1.2-pyhecae5ae_1.conda
   hash:
-    md5: b73afa0d009a51cabd3ec99c4d2ef4f3
-    sha256: f745cb501fbd4abaecf316ff1f6376246fd4e827b34c4a62fd0d3d06d2e5c102
+    md5: 04151bb8e351c6209caad045e4b1f4bd
+    sha256: 2c778b2a96946970a133852c8eba5e93512a3e3e6626a7983481cc16babcd16e
   category: main
   optional: false
 - name: colour
@@ -1945,11 +1961,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/colour-0.1.5-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/colour-0.1.5-pyhd8ed1ab_2.conda
   hash:
-    md5: de5ef3b303f625ac94939665ab85e996
-    sha256: 43fbcfc672a0b4947edfa94e60718211167297b64c699f3e7767e2c8814e8697
+    md5: 897ac24edd65c5a9948b51cb3327953c
+    sha256: 7571a828f68576502c124c3386f3868ac7b489874e188f63ab3a3ec89eebc537
   category: main
   optional: false
 - name: comm
@@ -1957,12 +1973,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 948d84721b578d426294e17a02e24cbb
-    sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+    md5: 74673132601ec2b7fc592755605f4c1b
+    sha256: 7e87ef7c91574d9fac19faedaaee328a70f718c9b4ddadfdc0ba9ac021bd64af
   category: main
   optional: false
 - name: configobj
@@ -1970,12 +1986,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.9-pyhd8ed1ab_1.conda
   hash:
-    md5: 0f20a9d96ded9cbd14b4cbfd18e45cfa
-    sha256: 97bf14ac9ec3ec203985edbc40e276dae6c4066173c81b8615087e1c8bd1f21a
+    md5: 5e1999cd1872c9d7f7d56bf3bf1141fa
+    sha256: c0e1b662a2f4288e07e57eeca8bf924cfb686d72cbb71720c6bb5aef1d517249
   category: main
   optional: false
 - name: contextily
@@ -1988,18 +2004,18 @@ package:
     matplotlib-base: ''
     mercantile: ''
     pillow: ''
-    python: '>=3.8'
+    python: '>=3.9'
     rasterio: ''
     requests: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 98e67488fd805cddb232a7246c915b4f
-    sha256: 8ea64368876654f4fe4ad6d39fd8df51462080e9647f8b9d42f5949600640c96
+    md5: 04c0d3c54ae90b9aedccebd30e09cab8
+    sha256: 3f0a1518e35e090070e7da76609d11ef8dafb655eda3ab9d4956fa85554e8513
   category: main
   optional: false
 - name: contourpy
-  version: 1.3.0
+  version: 1.3.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -2009,10 +2025,10 @@ package:
     numpy: '>=1.23'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.0-py310h3788b33_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py310h3788b33_0.conda
   hash:
-    md5: de92ea39a4d3afe19b6ee56701ebfa05
-    sha256: f38a4fed5060da3b91f172d1cace04a8ca1f65cb38d071c55f9a5afeed75f584
+    md5: f993b13665fc2bb262b30217c815d137
+    sha256: 1b18ebb72fb20b9ece47c582c6112b1d4f0f7deebaa056eada99e1f994e8a81f
   category: main
   optional: false
 - name: coolname
@@ -2027,48 +2043,18 @@ package:
     sha256: 1e1651c5e2a6ea6488c204f2310da3a281c872db1c9be4f879511790662dadcb
   category: main
   optional: false
-- name: cramjam
-  version: 2.8.4rc3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cramjam-2.8.4rc3-py310hed47299_2.conda
-  hash:
-    md5: 20c93ed393298b67e8a52c89b4a175cf
-    sha256: 87d5d5732a4d3ce4fbc4670242a50640214143426d92af1d21fda0519a35288d
-  category: main
-  optional: false
-- name: crcmod
-  version: '1.7'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/crcmod-1.7-py310ha75aee5_1011.conda
-  hash:
-    md5: 3a24e96318c7df73d8410fb62b130953
-    sha256: 3f61491bcada803d902e83ad6512abecab94542a406f809249168b2b3d0e1a12
-  category: main
-  optional: false
 - name: croniter
-  version: 1.4.1
+  version: 4.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=2.6'
+    python: '>=3.7'
     python-dateutil: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/croniter-1.4.1-pyhd8ed1ab_0.conda
+    pytz: '>2021.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/croniter-4.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7a4568626f8d6e7c63dcb25d5501a967
-    sha256: 15ee475c1e16c941def685d1160aced46030612cb22db93f0757233f63b0af54
+    md5: c549430fe4452a465207da7af4e93e82
+    sha256: 9e4929fcc700989168da0b9d3e1fb1bd7a5b31385eefab0b2c750b867ffc49c5
   category: main
   optional: false
 - name: cryptography
@@ -2093,11 +2079,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+    md5: 44600c4667a319d67dbe0681fc0bc833
+    sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
   category: main
   optional: false
 - name: cyrus-sasl
@@ -2117,7 +2103,7 @@ package:
   category: main
   optional: false
 - name: cytoolz
-  version: 1.0.0
+  version: 1.0.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -2126,10 +2112,10 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.0-py310ha75aee5_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.1-py310ha75aee5_0.conda
   hash:
-    md5: 81bbbb02f3664a012ce65c4fa8e8ca35
-    sha256: cfedba6ebe6b9b0cefdb074ca5696734e570f370e7f19c146333bf4e05863cad
+    md5: d0be1adaa04a03aed745f3d02afb59ce
+    sha256: b427689dfc24a6a297363122ce10d502ea00ddb3c43af6cff175ff563cc94eea
   category: main
   optional: false
 - name: dask
@@ -2163,11 +2149,11 @@ package:
     aiobotocore: '>=0.10.2'
     dask: '>=2.2.0'
     distributed: '>=2.3.1'
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-cloudprovider-2024.9.1-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-cloudprovider-2024.9.1-pyhd8ed1ab_1.conda
   hash:
-    md5: eaec51d42c61cbdff40e6185565448b0
-    sha256: 77b78ac32704483e514608f67a0581ad5d38701870b935072b16a3633fdf2d05
+    md5: abfd595fa514f39d322fe2bb720513fd
+    sha256: 33adc5c87dcaaa15eddadfc5601cd3eb6b599a5af403fd582875b02cfd7c9bdd
   category: main
   optional: false
 - name: dask-core
@@ -2217,26 +2203,29 @@ package:
     python: '>=3.9'
     pyyaml: ''
     tornado: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-gateway-2024.1.0-pyh8af1aa0_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-gateway-2024.1.0-pyh8af1aa0_2.conda
   hash:
-    md5: 8e8c5875b0bbdf9777ab6f02ae350ebd
-    sha256: 7d3c1916890afd26c36338a5244007115bec1b1f90c361af6ff9f2f558b6bfa6
+    md5: 96d83895f9a2cab6c6b40dea7d63f98e
+    sha256: c289476c4b873ef16db23000438bd1c3125be4adea6bdf86f77ae18ce098c4b7
   category: main
   optional: false
 - name: dask-geopandas
-  version: 0.4.2
+  version: 0.4.3
   manager: conda
   platform: linux-64
   dependencies:
     dask-core: '>=2022.06.0'
-    geopandas-base: '>=0.12'
+    geopandas-base: '>=0.14.3'
+    numpy: '>=1.24'
     packaging: ''
-    python: '>=3.9'
+    pandas: '>=2.0'
+    pyarrow: '>=14.0.1'
+    python: '>=3.10'
     shapely: '>=2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-geopandas-0.4.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-geopandas-0.4.3-pyhd8ed1ab_0.conda
   hash:
-    md5: c740384fd876fb385e8988ab446c332c
-    sha256: dd1bd2b7eb92307d0d392fcfb3c5b2f6bc9e29be2eea8b4ea51587599fdcb0a1
+    md5: 0e6a123a0d5600e6835fada0b9745586
+    sha256: 8405a7bc2dcd94e64bb4d1b7ea65872bc361251c90e3be4cdea321e9b82aa28f
   category: main
   optional: false
 - name: dask-glm
@@ -2276,7 +2265,7 @@ package:
   category: main
   optional: false
 - name: dask-kubernetes
-  version: 2024.9.0
+  version: 2025.1.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -2286,13 +2275,13 @@ package:
     kr8s: 0.17.*
     kubernetes_asyncio: '>=12.0.1'
     pykube-ng: '>=22.9.0'
-    python: '>=3.9'
+    python: '>=3.10'
     python-kubernetes: '>=12.0.1'
     rich: '>=12.5.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-kubernetes-2024.9.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-kubernetes-2025.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 1b495b6af8934e6fb7ec39990956bfaf
-    sha256: 06d14a64b167397f21ac8ca0a241bdfc6bbac8c96dfb1dc5e4d3a00e166af7e9
+    md5: addb302601428bdbb02a5a2d06a88bba
+    sha256: 04cdbb439e524c05a2eb9fb7d486ca6b6450c6ce5f47500b9ca9a60cb5268563
   category: main
   optional: false
 - name: dask-labextension
@@ -2304,11 +2293,11 @@ package:
     distributed: '>=1.24.1'
     jupyter-server-proxy: '>=1.3.2'
     jupyterlab: '>=4.0.0,<5'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-labextension-7.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-labextension-7.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: bccfda61b2c35a3cec53bd3417e3d783
-    sha256: bc30bf047145227c78e1082cc80d79a754f879eb74e664237dca1710ba727605
+    md5: 9aef5e5bebe4a054efd88c298beaeae8
+    sha256: a157787c6c524686d200d35f77ffc12e22d2bcd13e2de3d25c70842d9d3e0ac2
   category: main
   optional: false
 - name: dask-ml
@@ -2324,40 +2313,30 @@ package:
     numpy: '>=1.20.0'
     packaging: ''
     pandas: '>=0.24.2'
-    python: '>=3.8'
+    python: '>=3.9'
     scikit-learn: '>=1.2.0'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2024.4.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-ml-2024.4.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 5fc5ed918fa9a9f63001c06bdf21d53e
-    sha256: af9b810e3f4c0af06fdeaa6c76332bb768ff078832d3bc62ead022dd935d20ad
-  category: main
-  optional: false
-- name: dataclasses
-  version: '0.8'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2
-  hash:
-    md5: a362b2124b06aad102e2ee4581acee7d
-    sha256: 63a83e62e0939bc1ab32de4ec736f6403084198c4639638b354a352113809c92
+    md5: 3022ffd7e5fae31073ff7a6b4d106bbc
+    sha256: 74dc8c042ffa14f6797cf0e82dc8c6843ab755bdd81af35078dbf5a7044a6ae8
   category: main
   optional: false
 - name: datacube
-  version: 1.8.19
+  version: 1.9.2
   manager: conda
   platform: linux-64
   dependencies:
     affine: ''
-    attrs: ''
+    alembic: ''
+    antimeridian: ''
+    attrs: '>=18.1'
     boto3: ''
     botocore: ''
     cachetools: ''
     click: '>=5.0'
     cloudpickle: '>=0.4'
-    dask-core: ''
+    dask-core: <2024.11.0
     deprecat: ''
     distributed: ''
     geoalchemy2: ''
@@ -2365,49 +2344,48 @@ package:
     lark: ''
     netcdf4: ''
     numpy: ''
+    odc-geo: ''
     packaging: ''
     pandas: ''
     psycopg2: ''
     pyproj: '>=2.5'
-    python: '>=3.9'
+    python: '>=3.10'
     python-dateutil: ''
     pyyaml: ''
-    rasterio: '>=1.3.2'
+    rasterio: '>=1.3.11'
     ruamel.yaml: ''
     shapely: '>=2'
-    sqlalchemy: <2.0
+    sqlalchemy: '>=2.0'
     toolz: ''
     xarray: '>2022.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/datacube-1.8.19-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/datacube-1.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 108c0ca016e1f84928e348aca18e9fd6
-    sha256: 78ebd2c1111984083e9848794c89cfae4aceb8b400423ac250d7bf2d15c8e4da
+    md5: 868fbdb8789b73154da010c23f5eb365
+    sha256: 412284d3e94c2ac6e160a3731c7a54e67aed6fea4aa0c32bc94ea78377ebc9c2
   category: main
   optional: false
 - name: datashader
-  version: 0.16.3
+  version: 0.17.0
   manager: conda
   platform: linux-64
   dependencies:
     colorcet: ''
-    dask-core: ''
     multipledispatch: ''
     numba: ''
     numpy: ''
     packaging: ''
     pandas: ''
     param: ''
-    pillow: ''
     pyct: ''
-    python: '>=3.9'
+    python: '>=3.10'
     requests: ''
     scipy: ''
     toolz: ''
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/datashader-0.16.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/datashader-0.17.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1316959270592fbf8e2278a336de3ab9
-    sha256: 8f35e2d76173d300f5e5f504d67238097c16457267d421a8ab10d1e5bd9b734d
+    md5: e7511f05f4938cb0d988026507fed69a
+    sha256: 85b1ba89064501b4ae9695aeb819db4acfec74cd3acbb56df11c93b91ac0cbd4
   category: main
   optional: false
 - name: dateparser
@@ -2415,15 +2393,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     python-dateutil: ''
     pytz: ''
     regex: '!=2019.02.19,!=2021.8.27'
     tzlocal: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dateparser-1.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dateparser-1.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 7bdfb7b95b01e58834a478699215e371
-    sha256: 7f2d7288283df6ce2745f3f9f77ce3edb436d5ff12e5779dd5c2670610f2dfb7
+    md5: f008b2bd3dd6fa89d6beb5ad1d421d97
+    sha256: 8c2462b4ae71fd8e380dc96dbbd8a2b5e6943d4ca1b24dbe16f759ebd2178818
   category: main
   optional: false
 - name: dav1d
@@ -2438,8 +2416,22 @@ package:
     sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
   category: main
   optional: false
+- name: dbus
+  version: 1.13.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    expat: '>=2.4.2,<3.0a0'
+    libgcc-ng: '>=9.4.0'
+    libglib: '>=2.70.2,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+  hash:
+    md5: ecfff944ba3960ecb334b9a2663d708d
+    sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
+  category: main
+  optional: false
 - name: debugpy
-  version: 1.8.7
+  version: 1.8.13
   manager: conda
   platform: linux-64
   dependencies:
@@ -2448,22 +2440,22 @@ package:
     libstdcxx: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.7-py310hf71b8c6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.13-py310hf71b8c6_0.conda
   hash:
-    md5: 62f74768159cd1b97db23a4d6d05516e
-    sha256: 8ac9105a307992a8ba58a2d95c825d8ad60a7511fb51da8cfa8d2e3b8859ca82
+    md5: dc30b46d5b3ddccd3b3ac1b0bee17026
+    sha256: f02fb1862980595a310551f5cd35ddffa1f224e7d9c5aab6c3b9e37922a96e34
   category: main
   optional: false
 - name: decorator
-  version: 5.1.1
+  version: 5.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+    md5: 9ce473d1d1be1cc3810856a48b3fab32
+    sha256: c17c6b9937c08ad63cb20a26f403a3234088e57d4455600974a0ce865cb14017
   category: main
   optional: false
 - name: defusedxml
@@ -2479,21 +2471,21 @@ package:
   category: main
   optional: false
 - name: deltalake
-  version: 0.21.0
+  version: 0.24.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
+    liblzma: '>=5.6.3,<6.0a0'
     pyarrow: '>=16'
     pyarrow-hotfix: ''
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/deltalake-0.21.0-py310h8dcf605_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/deltalake-0.24.0-py310h7b8edb7_0.conda
   hash:
-    md5: 95edeeb295f840075d47f32e0376aace
-    sha256: e93323ad335b75f2712526a959d9ae0a2d528f3442308e1ca38fff787aaeeff6
+    md5: 5de4b1d63bc818fb5e35f4d6fc518167
+    sha256: 57bb80382025138d420335e5c65d1fd541e0de43433eda322dc247ca8a47166b
   category: main
   optional: false
 - name: deprecat
@@ -2501,25 +2493,25 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     wrapt: <2,>=1.10
-  url: https://conda.anaconda.org/conda-forge/noarch/deprecat-2.1.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/deprecat-2.1.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 92f2a15689a66879d5a7bbe2348faa9c
-    sha256: 195e351cd04f0061aab6d8affe2de18843723881ddf756f09740ed5b1a56f136
+    md5: c3acbfd8b45c1c81cce84eab456d5efa
+    sha256: 290a38e5b17ca0f53b03d28692cd405ee1ec6f541519f3e8fc3b225b8e81255d
   category: main
   optional: false
 - name: deprecated
-  version: 1.2.14
+  version: 1.2.18
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=2.7'
+    python: '>=3.9'
     wrapt: <2,>=1.10
-  url: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.14-pyh1a96a4e_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.18-pyhd8ed1ab_0.conda
   hash:
-    md5: 4e4c4236e1ca9bcd8816b921a4805882
-    sha256: 8f61539b00ea315c99f8b6f9e2408caa6894593617676741214cc0280e875ca0
+    md5: 0cef44b1754ae4d6924ac0eef6b9fdbe
+    sha256: d614bcff10696f1efc714df07651b50bf3808401fcc03814309ecec242cc8870
   category: main
   optional: false
 - name: descartes
@@ -2528,23 +2520,11 @@ package:
   platform: linux-64
   dependencies:
     matplotlib-base: ''
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/descartes-1.1.0-py_4.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/descartes-1.1.0-pyhd8ed1ab_5.conda
   hash:
-    md5: 32fa3526c15250ccf353f1ce905f50b3
-    sha256: b0b73c09a69e775f50541861622ea54e8342ae7c4b0ca7713967acb902263c74
-  category: main
-  optional: false
-- name: dill
-  version: 0.3.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.1.1-pyhd8ed1ab_2.tar.bz2
-  hash:
-    md5: dd31e651e9a38205c86447c1bb3a1607
-    sha256: 1efc782a99ab39d868a831ee7197f71cfb9edfcfa1c4daccd8549a4aa7ebca6b
+    md5: 4a25cae637029c5589135903aa15b3b6
+    sha256: af2f05a8c61e68a97d06f9bc35c63de6fd144ea1b6a1346dcc29a5e508033aa1
   category: main
   optional: false
 - name: distributed
@@ -2592,12 +2572,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9.0,<4.0.0'
+    python: '>=3.9,<4.0.0'
     sniffio: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.7.0-pyhff2d567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.7.0-pyhff2d567_1.conda
   hash:
-    md5: 0adf8f63d500d20418656289249533f9
-    sha256: 3e2ea1bfd90969e0e1f152bb1f969c56661278ad6bfaa3272027b1ff0d9a1a23
+    md5: 5fbd60d61d21b4bd2f9d7a48fe100418
+    sha256: 3ec40ccf63f2450c5e6c7dd579e42fc2e97caf0d8cd4ba24aa434e6fc264eda0
   category: main
   optional: false
 - name: docker-py
@@ -2606,27 +2586,15 @@ package:
   platform: linux-64
   dependencies:
     paramiko: '>=2.4.3'
-    python: '>=3.8'
+    python: '>=3.9'
     pywin32-on-windows: ''
     requests: '>=2.26.0'
     urllib3: '>=1.26.0'
     websocket-client: '>=0.32.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 3e547e36de765ca8f28a7623fb3f255a
-    sha256: eca0bf5605a6ce79021afa1cd234cc74093a239f86cd311872e4d9b0972b5a85
-  category: main
-  optional: false
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
+    md5: 07ce73ca6f6c1a1df5d498679fc52d9e
+    sha256: 909bad7898ef2933a7efe69a48200e2331a362b0a1edd2d592942cde1f130979
   category: main
   optional: false
 - name: docopt-ng
@@ -2634,11 +2602,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-ng-0.9.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/docopt-ng-0.9.0-pyhd8ed1ab_1.conda
   hash:
-    md5: d69e9163b8c89b27df532b988843c8de
-    sha256: e65fa4cb44aa41051bb48d90814f33593223daca0a8d2151e0d11f677550e5e0
+    md5: 7635e4907164a088d932f7d8965db7ab
+    sha256: fb8c1b918b3c28ff9cdf21279aad9a50a659dd3bcbdb95d687044fb35b58b2df
   category: main
   optional: false
 - name: docrep
@@ -2655,15 +2623,17 @@ package:
   category: main
   optional: false
 - name: docstring-to-markdown
-  version: '0.15'
+  version: '0.16'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/docstring-to-markdown-0.15-pyhd8ed1ab_0.conda
+    python: ''
+    importlib-metadata: '>=3.6'
+    typing_extensions: '>=4.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/docstring-to-markdown-0.16-pyh29332c3_1.conda
   hash:
-    md5: a3a1e6af2926a3affcd6f2072871f551
-    sha256: 0c640c23785f0fb41e4c3dd815cce22efd14230a6ebc08275ce1a484e480e476
+    md5: e9d0fc00255c0b153664b8e86950f65b
+    sha256: 4e335af4cad07d1d7e29b38dd345ac4535a885d7a5ce6ddc32bff23575584eb1
   category: main
   optional: false
 - name: docutils
@@ -2684,16 +2654,28 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     pyyaml: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
   hash:
-    md5: 8e4275fd4414d3f03cf5f19cb824bcd5
-    sha256: 93185f9494e4461c852ca4ad19059acc6b34e7ebbb28bd01a6d4fcc99d7dc26c
+    md5: c56a7fa5597ad78b62e1f5d21f7f8b8f
+    sha256: d58e97d418f71703e822c422af5b9c431e3621a0ecdc8b0334c1ca33e076dfe7
+  category: main
+  optional: false
+- name: durationpy
+  version: '0.9'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/durationpy-0.9-pyhd8ed1ab_1.conda
+  hash:
+    md5: f7e6b04ecc949a19de49cbcd3f14addf
+    sha256: 045055a25f47473759eea9c710cc4b6d27a4f4db8e34d96771a830435d2e9a27
   category: main
   optional: false
 - name: eccodes
-  version: 2.38.3
+  version: 2.40.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -2705,25 +2687,51 @@ package:
     libgfortran: ''
     libgfortran5: '>=13.3.0'
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.44,<1.7.0a0'
+    libpng: '>=1.6.46,<1.7.0a0'
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.38.3-h8bb6dbc_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.40.0-h8bb6dbc_0.conda
   hash:
-    md5: 73265d4acc551063cc5c5beab37f33c5
-    sha256: d1100e23310be460d5c8c8a67047af121e0b0295b97502173b213f2f0ba9f566
+    md5: 52c8d85ec289a75e7c731932f45c533d
+    sha256: f081aecd438a9069864078eb319c04d7a323112444bde6818bc52241882d1004
   category: main
   optional: false
 - name: elementpath
-  version: 4.5.0
+  version: 4.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/elementpath-4.5.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/elementpath-4.8.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 13a6a89b80473588d14cdba61773fc05
-    sha256: d6d1cd1c4024cd3df42ac956fdc9065c4889366f450ce4ccc290155dd7f16caa
+    md5: 2d8098f74d6693d983a968d421ef4f6e
+    sha256: 7c2ac4bd9a70a275ac64ec8d40223e4dfdc5e7a9aa4a1626e58aedc0db79e1c9
+  category: main
+  optional: false
+- name: email-validator
+  version: 2.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    dnspython: '>=2.0.0'
+    idna: '>=2.0.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.2.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: da16dd3b0b71339060cd44cb7110ddf9
+    sha256: b91a19eb78edfc2dbb36de9a67f74ee2416f1b5273dd7327abe53f2dbf864736
+  category: main
+  optional: false
+- name: email_validator
+  version: 2.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    email-validator: '>=2.2.0,<2.2.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.2.0-hd8ed1ab_1.conda
+  hash:
+    md5: 0794f8807ff2c6f020422cacb1bd7bfa
+    sha256: e0d0fdf587aa0ed0ff08b2bce3ab355f46687b87b0775bfba01cc80a859ee6a2
   category: main
   optional: false
 - name: entrypoints
@@ -2731,24 +2739,36 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 3cf04868fee0a029769bd41f4b2fbf2d
-    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
+    md5: 3366592d3c219f2731721f11bc93755c
+    sha256: 80f579bfc71b3dab5bef74114b89e26c85cb0df8caf4c27ab5ffc16363d57ee7
   category: main
   optional: false
 - name: eofs
-  version: 1.4.1
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
     numpy: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/eofs-1.4.1-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/eofs-2.0.0-pyhff2d567_0.conda
   hash:
-    md5: 5fc43108dee4106f23050acc7a101233
-    sha256: a19b44755b614e9df0eb24331fb0a01a921ecf72562bc638a22104a65d5436bc
+    md5: a3cce45423d73c3d4420b71351e71fef
+    sha256: a5ea05a972b8e795b75df94ff86d0a36b48ab1e93376a1552c99077736040e49
+  category: main
+  optional: false
+- name: epoxy
+  version: 1.5.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=10.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-h166bdaf_1.tar.bz2
+  hash:
+    md5: a089d06164afd2d511347d3f87214e0b
+    sha256: 1e58ee2ed0f4699be202f23d49b9644b499836230da7dd5b2f63e6766acff89e
   category: main
   optional: false
 - name: erddapy
@@ -2767,7 +2787,7 @@ package:
   category: main
   optional: false
 - name: esmf
-  version: 8.6.1
+  version: 8.8.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -2779,24 +2799,24 @@ package:
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
     libstdcxx: '>=13'
     netcdf-fortran: '>=4.6.1,<4.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.6.1-nompi_h4441c20_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.8.0-nompi_h4441c20_0.conda
   hash:
-    md5: 1afc1e85414e228916732df2b8c5d93b
-    sha256: 2e007ba0d94cb0a9e88306b346527e1233681833cfad13010ce653edda7cfeb1
+    md5: 34729c36214ff0b7834065bd5cacdc56
+    sha256: ecb364d8f5c8f53dcaf14921e0beb77922d47509fb6506c31417837576ac387b
   category: main
   optional: false
 - name: esmpy
-  version: 8.6.1
+  version: 8.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    esmf: 8.6.1.*
-    numpy: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/esmpy-8.6.1-pyhc1e730c_0.conda
+    esmf: 8.8.0.*
+    numpy: '>=1.19,<3'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/esmpy-8.8.0-pyhecae5ae_0.conda
   hash:
-    md5: 25a9661177fd68bfdb4314fd658e5c3b
-    sha256: 692d823ce05ff60cd9648a6f98b778a9944f79ecd0aaa20110fa368340ec4982
+    md5: 9d8320aa90c8e213002f9cdb5bb9f579
+    sha256: 298b2cb1fa84d13b0572fa9651c44a933b990ae1358d54b4309ece4527d44082
   category: main
   optional: false
 - name: exceptiongroup
@@ -2804,11 +2824,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
   hash:
-    md5: d02ae936e42063ca46af6cdad2dbd1e0
-    sha256: e0edd30c4b7144406bb4da975e6bb97d6bc9c0e999aa4efe66ae108cada5d5b5
+    md5: a16662747cdeb9abbac74d0057cc976e
+    sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
   category: main
   optional: false
 - name: executing
@@ -2816,53 +2836,73 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
   hash:
-    md5: d0441db20c827c11721889a241df1220
-    sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
+    md5: ef8b5fca76806159fc25b4f48d8737eb
+    sha256: 28d25ea375ebab4bf7479228f8430db20986187b04999136ff5c722ebd32eb60
   category: main
   optional: false
-- name: fastapi
-  version: 0.103.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    pydantic: '>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0'
-    python: '>=3.7'
-    starlette: '>=0.27.0,<0.28.0'
-    typing-extensions: '>=4.5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.103.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: c1db008f2554adcb1883d1e58c33529f
-    sha256: 657b7781ad340519ce6b5817c3c6cd62ac094363776095a62d131b0bb3ae39a5
-  category: main
-  optional: false
-- name: fastavro
-  version: 1.9.7
+- name: expat
+  version: 2.6.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    libexpat: 2.6.4
     libgcc: '>=13'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/fastavro-1.9.7-py310ha75aee5_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.4-h5888daf_0.conda
   hash:
-    md5: ca6fb5806dc7a1222edae47d9a6ba0d7
-    sha256: 32bd4ace3b5b26fcf03944fed0f591670396d112bfc8fae8ea90bab4fb8a8879
+    md5: 1d6afef758879ef5ee78127eb4cd2c4a
+    sha256: 1848c7db9e264e3b8036ee133d570dd880422983cd20dd9585a505289606d276
   category: main
   optional: false
-- name: fasteners
-  version: 0.17.3
+- name: fastapi
+  version: 0.115.12
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.17.3-pyhd8ed1ab_0.tar.bz2
+    python: ''
+    starlette: '>=0.40.0,<0.47.0'
+    typing_extensions: '>=4.8.0'
+    pydantic: '>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0'
+    email_validator: '>=2.0.0'
+    fastapi-cli: '>=0.0.5'
+    httpx: '>=0.23.0'
+    jinja2: '>=3.1.5'
+    python-multipart: '>=0.0.18'
+    uvicorn-standard: '>=0.12.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.115.12-pyh29332c3_0.conda
   hash:
-    md5: 348e27e78a5e39090031448c72f66d5e
-    sha256: 42be6ac8478051b26751d778490d6a71de12e5c6443e145ff3eddbc577d9bcda
+    md5: 4bc12ece07c8c717e19fd790bfec100d
+    sha256: d72da6ea523d80968f0cca4ba4fb6c31fc27450d07e419f039da9b99654a56e6
+  category: main
+  optional: false
+- name: fastapi-cli
+  version: 0.0.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    rich-toolkit: '>=0.11.1'
+    typer: '>=0.12.3'
+    uvicorn-standard: '>=0.15.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: d960e0ea9e1c561aa928f6c4439f04c7
+    sha256: 300683731013b7221922339cd40430bb3c2ddeeb658fd7e37f5099ffe64e4db0
+  category: main
+  optional: false
+- name: fasteners
+  version: '0.19'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/fasteners-0.19-pyhd8ed1ab_1.conda
+  hash:
+    md5: dbe9d42e94b5ff7af7b7893f4ce052e7
+    sha256: 42fb170778b47303e82eddfea9a6d1e1b8af00c927cd5a34595eaa882b903a16
   category: main
   optional: false
 - name: fastjmd95
@@ -2878,44 +2918,25 @@ package:
     sha256: 6f423bb9049ea2ad9ddf04815b4b82e9b87569670a86cbda44cf9c9dc91219f2
   category: main
   optional: false
-- name: fastparquet
-  version: 2024.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cramjam: '>=2.3'
-    fsspec: ''
-    libgcc: '>=13'
-    numpy: '>=1.20.3'
-    packaging: ''
-    pandas: '>=1.5.0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/fastparquet-2024.5.0-py310hf462985_2.conda
-  hash:
-    md5: ce15bde91eb49e58eb6774b82d6cf762
-    sha256: 8cb09a9095605a46d2a2006003425e9050313f7f049cc25434b9bdb798add112
-  category: main
-  optional: false
 - name: fastprogress
   version: 1.0.3
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.0.3-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.0.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 1690639d3647fde6edf4f00c8f87c263
-    sha256: d344107510764a791dc2a402cc1fed5097c0013fecaf36d4c3fd13ece3324d4d
+    md5: a1f997959ce49fe4d554a8ae6d3ef494
+    sha256: f8e8319c9fd9e11752c3efcd8ae98c07ea04afea389bb2e87414c8ed3bc73ff5
   category: main
   optional: false
 - name: ffmpeg
-  version: 7.1.0
+  version: 7.1.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    alsa-lib: '>=1.2.13,<1.3.0a0'
     aom: '>=3.9.1,<3.10.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     dav1d: '>=1.2.1,<1.2.2.0a0'
@@ -2923,56 +2944,59 @@ package:
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     gmp: '>=6.3.0,<7.0a0'
-    harfbuzz: '>=9.0.0,<10.0a0'
+    harfbuzz: '>=10.4.0,<11.0a0'
     lame: '>=3.100,<3.101.0a0'
     libass: '>=0.17.3,<0.17.4.0a0'
-    libexpat: '>=2.6.3,<3.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
     libgcc: '>=13'
-    libiconv: '>=1.17,<2.0a0'
-    libopenvino: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-auto-batch-plugin: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-auto-plugin: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-hetero-plugin: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-intel-cpu-plugin: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-intel-gpu-plugin: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-intel-npu-plugin: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-ir-frontend: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-onnx-frontend: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-paddle-frontend: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-pytorch-frontend: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-tensorflow-frontend: '>=2024.4.0,<2024.4.1.0a0'
-    libopenvino-tensorflow-lite-frontend: '>=2024.4.0,<2024.4.1.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.6.4,<6.0a0'
+    libopenvino: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-auto-batch-plugin: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-auto-plugin: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-hetero-plugin: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-intel-cpu-plugin: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-intel-gpu-plugin: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-intel-npu-plugin: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-ir-frontend: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-onnx-frontend: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-paddle-frontend: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-pytorch-frontend: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-tensorflow-frontend: '>=2025.0.0,<2025.0.1.0a0'
+    libopenvino-tensorflow-lite-frontend: '>=2025.0.0,<2025.0.1.0a0'
     libopus: '>=1.3.1,<2.0a0'
     librsvg: '>=2.58.4,<3.0a0'
     libstdcxx: '>=13'
     libva: '>=2.22.0,<3.0a0'
+    libvorbis: '>=1.3.7,<1.4.0a0'
     libvpx: '>=1.14.1,<1.15.0a0'
     libxcb: '>=1.17.0,<2.0a0'
-    libxml2: '>=2.13.4,<3.0a0'
+    libxml2: '>=2.13.6,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    openh264: '>=2.4.1,<2.4.2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-    svt-av1: '>=2.3.0,<2.3.1.0a0'
+    openh264: '>=2.6.0,<2.6.1.0a0'
+    openssl: '>=3.4.1,<4.0a0'
+    pulseaudio-client: '>=17.0,<17.1.0a0'
+    sdl2: '>=2.32.50,<3.0a0'
+    svt-av1: '>=3.0.1,<3.0.2.0a0'
     x264: '>=1!164.3095,<1!165'
     x265: '>=3.5,<3.6.0a0'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_hbb807a5_703.conda
+    xorg-libx11: '>=1.8.11,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h24e5c1d_701.conda
   hash:
-    md5: ebcb1e523d36a81af8f0910856c06946
-    sha256: b3c25c9eeee63f39ebff7dc1840734aab3e784a084a8352d5099aa9a9c07e42f
+    md5: d35de22d08aeb027b27fce13a2b2903b
+    sha256: 05ae7a8cb749daf1b350b0e0e6eb95e9a1e4669c55dee66927a882237f58ab61
   category: main
   optional: false
 - name: filelock
-  version: 3.16.1
+  version: 3.18.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.18.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 916f8ec5dd4128cd5f207a3c4c07b2c6
-    sha256: 1da766da9dba05091af87977922fe60dc7464091a9ccffb3765d403189d39be4
+    md5: 4547b39256e296bb758166893e909a7c
+    sha256: de7b6d4c4f865609ae88db6fa03c8b7544c2452a1aa5451eb7700aad16824570
   category: main
   optional: false
 - name: findlibs
@@ -2997,19 +3021,17 @@ package:
     click: '>=8.0,<9.dev0'
     click-plugins: '>=1.0'
     cligj: '>=0.5'
-    gdal: ''
     libgcc: '>=13'
-    libgdal: '>=3.9.2,<3.10.0a0'
-    libgdal-core: '>=3.9.2,<3.10.0a0'
+    libgdal-core: '>=3.10.0,<3.11.0a0'
     libstdcxx: '>=13'
     pyparsing: ''
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     shapely: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.10.1-py310hf7e30c6_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.10.1-py310h0aed7a2_3.conda
   hash:
-    md5: 02a1f2bc22f3830f31d13c05fb9224e5
-    sha256: 4c45307db67575650ce29075bf7f2bbdd4938ef28fc89dc75ed8254ffb161c96
+    md5: 159a16dee358df063730c205f7428993
+    sha256: 69d5f613a3002859784ba82259aa67a930bfe00de70551ba47e28c846ba610ec
   category: main
   optional: false
 - name: flexcache
@@ -3019,10 +3041,10 @@ package:
   dependencies:
     python: '>=3.9'
     typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 6ed8dc449e0da09c5aaa4e71eb91059a
-    sha256: 482edded5645290f1acd844dd05e5d51427f5ca8ada0b7a08cf0b6c7c7f1ce6b
+    md5: f1e618f2f783427019071b14a111b30d
+    sha256: acdb7b73d84268773fcc8192965994554411edc488ec3447925a62154e9d3baa
   category: main
   optional: false
 - name: flexparser
@@ -3033,14 +3055,14 @@ package:
     python: '>=3.9'
     typing-extensions: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
   hash:
-    md5: fa7030389ca7b33bd3430dd12d25e91b
-    sha256: 039dcda4a774523fc0edd9a3a07b6122b4c404f9f098b42427225d86dc0fad6f
+    md5: 6dc4e43174cd552452fdb8c423e90e69
+    sha256: 9bdad0cd9fb6d67e48798c03930d634ea2d33a894d30439d3d7bdffd3c21af7b
   category: main
   optional: false
 - name: flox
-  version: 0.9.14
+  version: 0.10.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -3051,41 +3073,41 @@ package:
     python: '>=3.10'
     scipy: '>=1.9'
     toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/flox-0.9.14-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/flox-0.10.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 2168f94c440ae4b6cae2de432598f394
-    sha256: 97806566f06f527f50d7167970444cb41981a04545bd9e61cedc4350fb9e982a
+    md5: 4228783fb257f356c6e408dff42309ee
+    sha256: c6b9827b685021ebf3e8600cdefdce6f394ab4472f93d19280d9954340fe78dd
   category: main
   optional: false
 - name: fmt
-  version: 11.0.2
+  version: 11.1.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h434a139_0.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.1.4-h07f6e7f_1.conda
   hash:
-    md5: 995f7e13598497691c1dc476d889bc04
-    sha256: c620e2ab084948985ae9b8848d841f603e8055655513340e04b6cf129099b5ca
+    md5: 288a90e722fd7377448b00b2cddcb90d
+    sha256: 2db2a6a1629bc2ac649b31fd990712446394ce35930025e960e1765a9249af5d
   category: main
   optional: false
 - name: folium
-  version: 0.18.0
+  version: 0.19.5
   manager: conda
   platform: linux-64
   dependencies:
     branca: '>=0.6.0'
     jinja2: '>=2.9'
     numpy: ''
-    python: '>=3.8'
+    python: '>=3.9'
     requests: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.18.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 26a1457f3e698dc0c9e656874cc6b623
-    sha256: b0692047888db2875cbdb3280aec69e9d88c229adf830c4f88357796d35ce006
+    md5: 4cb9e567a829a9083cc66eda88f2d330
+    sha256: 5536271960dbd1b030b7392ae9763d17c934f8aa09424d5e9fbba734771ad574
   category: main
   optional: false
 - name: font-ttf-dejavu-sans-mono
@@ -3177,7 +3199,7 @@ package:
   category: main
   optional: false
 - name: fonttools
-  version: 4.54.1
+  version: 4.56.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3188,10 +3210,10 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     unicodedata2: '>=15.1.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.54.1-py310h89163eb_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.56.0-py310h89163eb_0.conda
   hash:
-    md5: d30cf58ede43135249a18c5926a96d3f
-    sha256: 2bf67457397185ca039d7c1fa1f2984c8d22df74ac56197b59326d3038e82f41
+    md5: cd3125e1924bd8699dac9989652bca74
+    sha256: 751599162ba980477e9267b67d82e116465d0cf69efc52e016e8f72e7f9cdfcd
   category: main
   optional: false
 - name: fqdn
@@ -3200,11 +3222,11 @@ package:
   platform: linux-64
   dependencies:
     cached-property: '>=1.3.0'
-    python: '>=2.7,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9,<4'
+  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 642d35437078749ef23a5dca2c9bb1f3
-    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+    md5: d3549fd50d450b6d9e7dddff25dd2110
+    sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
   category: main
   optional: false
 - name: freeglut
@@ -3227,17 +3249,18 @@ package:
   category: main
   optional: false
 - name: freetype
-  version: 2.12.1
+  version: 2.13.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libpng: '>=1.6.47,<1.7.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.13.3-h48d6fc4_0.conda
   hash:
-    md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
-    sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+    md5: 9ecfd6f2ca17077dd9c2d24770bb9ccd
+    sha256: 7385577509a9c4730130f54bb6841b9b416249d5f4e9f74bf313e6378e313c57
   category: main
   optional: false
 - name: freexl
@@ -3245,14 +3268,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libexpat: '>=2.5.0,<3.0a0'
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
     libiconv: '>=1.17,<2.0a0'
-    minizip: '>=4.0.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
+    minizip: '>=4.0.7,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
   hash:
-    md5: 12e6988845706b2cfbc3bc35c9a61a95
-    sha256: 9213f60ba710ecfd3632ce47e036775c9f15ce80a6682ff63cbf12d9dddd5382
+    md5: ecb5d11305b8ba1801543002e69d2f2f
+    sha256: c8960e00a6db69b85c16c693ce05484facf20f1a80430552145f652a880e0d2a
   category: main
   optional: false
 - name: fribidi
@@ -3276,22 +3300,22 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.5.0-py310ha75aee5_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.5.0-py310h89163eb_1.conda
   hash:
-    md5: 8aac4068f272b6bdeb0aa0f29d8e516f
-    sha256: d7757d3e65682ee9bc04f43f50eb38e5ad48c92db976ea90ed84c53fd629bcac
+    md5: 4e8901e0c05f60897ca052a4991c57e4
+    sha256: 5a6142dddd42b3919ba2bd7ca9e2fd5af31516c180a7ec344d0f4795518fab6d
   category: main
   optional: false
 - name: fsspec
-  version: 2024.10.0
+  version: 2025.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 816dbc4679a64e4417cd1385d661bb31
-    sha256: 40bb76981dd49d5869b48925a8975bb7bbe4e33e1e40af4ec06f6bf4a62effd7
+    md5: 5ecafd654e33d1f2ecac5ec97057593b
+    sha256: 9cbba3b36d1e91e4806ba15141936872d44d20a4d1e3bb74f4aea0ebeb01b205
   category: main
   optional: false
 - name: future
@@ -3299,11 +3323,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_2.conda
   hash:
-    md5: 650a7807e689642dddd3590eb817beed
-    sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
+    md5: 1054c53c95d85e35b88143a3eda66373
+    sha256: 45dfd037889b7075c5eb46394f93172de0be0b1624c7f802dd3ecc94b814d8e0
   category: main
   optional: false
 - name: gcc
@@ -3312,10 +3336,10 @@ package:
   platform: linux-64
   dependencies:
     gcc_impl_linux-64: 13.3.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_2.conda
   hash:
-    md5: 606924335b5bcdf90e9aed9a2f5d22ed
-    sha256: d0161362430183cbdbc3db9cf95f9a1af1793027f3ab8755b3d3586deb28bf84
+    md5: d92e51bf4b6bdbfe45e5884fb0755afe
+    sha256: 300f077029e7626d69cc250a69acd6018c1fced3f5bf76adf37854f3370d2c45
   category: main
   optional: false
 - name: gcc_impl_linux-64
@@ -3330,10 +3354,10 @@ package:
     libsanitizer: 13.3.0
     libstdcxx: '>=13.3.0'
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-hfea6d02_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-h1e990d8_2.conda
   hash:
-    md5: 0d043dbc126b64f79d915a0e96d3a1d5
-    sha256: 998ade1d487e93fc8a7a16b90e2af69ebb227355bf4646488661f7ae5887873c
+    md5: f46cf0acdcb6019397d37df1e407ab91
+    sha256: c3e9f243ea8292eecad78bb200d8f5b590e0f82bf7e7452a3a7c8df4eea6f774
   category: main
   optional: false
 - name: gcc_linux-64
@@ -3344,49 +3368,50 @@ package:
     binutils_linux-64: ''
     gcc_impl_linux-64: 13.3.0.*
     sysroot_linux-64: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-hc28eda2_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-hc28eda2_8.conda
   hash:
-    md5: ffbadbbc3345d9a315ba31c8a9188d4c
-    sha256: 6778f93159cfd967320f60473447b19e320f303378d4c9da0784caa40073fafa
+    md5: 0c56ca4bfe2b04e71fe67652d5aa3079
+    sha256: 0294daf83875d475424f16eda49a17017f733bf565f9e8b3367d0374733f43f3
   category: main
   optional: false
 - name: gcsfs
-  version: 2024.10.0
+  version: 2025.3.0
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: ''
     decorator: '>4.1.2'
-    fsspec: 2024.10.0
+    fsspec: 2025.3.0
     google-auth: '>=1.2'
     google-auth-oauthlib: ''
     google-cloud-storage: '>1.40'
-    python: '>=3.7'
+    python: '>=3.9'
     requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/gcsfs-2024.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gcsfs-2025.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 955421eb32ce3fbeed9a83b20ecc76d3
-    sha256: 1a42711efffe728eb2f462a1c08dd749c86d91255fc7b993fdae420e4e2e2036
+    md5: f724b1c3730b5da7708bd5d926455426
+    sha256: 620ebd604a7052da3cf36e0893f7ac8a3f729facaac9f086e21bd2ad4675ffb8
   category: main
   optional: false
 - name: gdal
-  version: 3.9.2
+  version: 3.10.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libgdal-core: 3.9.2.*
+    libgdal-core: 3.10.2.*
     libkml: '>=1.3.0,<1.4.0a0'
+    liblzma: '>=5.6.4,<6.0a0'
     libstdcxx: '>=13'
-    libxml2: '>=2.12.7,<3.0a0'
+    libxml2: '>=2.13.6,<3.0a0'
     numpy: '>=1.19,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.2-py310h7209a21_7.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.2-py310h79127d3_5.conda
   hash:
-    md5: e5057e069c13f71988514a873c386153
-    sha256: 7903de151b1d2da462191c03431eff4817105f76e41ea635466960d2196a1c9a
+    md5: 7bfb6237ccf14f032ab035de8d08772d
+    sha256: a8d7dcffa51756a4fac455939b63c754a8e207b3e27ba14d55af0fb0061ced44
   category: main
   optional: false
 - name: gdk-pixbuf
@@ -3412,31 +3437,31 @@ package:
   dependencies:
     beautifulsoup4: ''
     filelock: ''
-    python: '>=3.8'
+    python: '>=3.9'
     requests: ''
     tqdm: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/gdown-5.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gdown-5.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 29903392720ea0d6162b772ff97235c3
-    sha256: 5a645ec883846558db8b6c3ea370602a7b2783e8c9d1c9b59f385a7f43f8f26c
+    md5: 0b2ab6adce98f0dcf1dfd3f11343e5cd
+    sha256: 556243e37e12cb99461e782b1713d24e0d134b2bcc66930ec8d7bfde10d52c3d
   category: main
   optional: false
 - name: geoalchemy2
-  version: 0.15.2
+  version: 0.17.1
   manager: conda
   platform: linux-64
   dependencies:
     packaging: ''
     python: '>=3.7'
     sqlalchemy: '>=1.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/geoalchemy2-0.15.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geoalchemy2-0.17.1-pyhd8ed1ab_0.conda
   hash:
-    md5: f0c41912cf8fef3dac8bfa6096b6ade0
-    sha256: 5b0b1230635ee2238d9897d23b2c8667b41cad8bf55e96acab24614c65c0928a
+    md5: bddd76591cbd1408a024a35490a2fdf4
+    sha256: f2b11e2af2bae8b77567e6a7178388351e05962029d2fd638b07a440441349c0
   category: main
   optional: false
 - name: geocube
-  version: 0.7.0
+  version: 0.7.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -3451,14 +3476,14 @@ package:
     rioxarray: '>=0.4'
     scipy: ''
     xarray: '>=0.17'
-  url: https://conda.anaconda.org/conda-forge/noarch/geocube-0.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geocube-0.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8887c687ee10662fbf1b22fc5b7e7dba
-    sha256: 88ac10e11363ecf99561ef4ff9260983b348a8845431aec125f14df0d174e96c
+    md5: 5d905eadd1a60abeb09fd636dedce3e2
+    sha256: 05f6b7163fb31778d99f9c57c7514460f29ed14cb35cf2a681aa0458230a0b4c
   category: main
   optional: false
 - name: geogif
-  version: '0.2'
+  version: '0.3'
   manager: conda
   platform: linux-64
   dependencies:
@@ -3466,13 +3491,13 @@ package:
     matplotlib-base: '>=3.4.1,<4.0.0'
     numpy: '>=1.20.2,<2.0.0'
     pillow: '>=10.1.0,<11.0.0'
-    python: '>=3.8.0,<4.0.0'
+    python: '>=3.9,<4.0.0'
     typing_extensions: ''
     xarray: '>=0.18'
-  url: https://conda.anaconda.org/conda-forge/noarch/geogif-0.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geogif-0.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 02b01f1e7aba0b1aaa1fe1fb2f9e9af0
-    sha256: 2da085947ad1c27ada14ae5fc2768ed4265552cd7e5f8a4600a8e37988fd22fd
+    md5: 136d08432ebcd31ef206f576fc3bd43d
+    sha256: 699862cefc9315ae67f701420f47436442258a6ec9cba18ef38446fd57eeced0
   category: main
   optional: false
 - name: geographiclib
@@ -3480,23 +3505,23 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 6b1f32359fc5d2ab7b491d0029bfffeb
-    sha256: a158e9430662daa29609da21f5d9f18d2093ef37b357c1b594c6f27545aaff3e
+    md5: 8b9328ab4aafb8fde493ab32c5eba731
+    sha256: 933064eaaac79ceadef948223873c433eb5375b8445264cbe569d34035ab4e20
   category: main
   optional: false
 - name: geojson
-  version: 3.1.0
+  version: 3.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/geojson-3.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/geojson-3.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d2297358b98129ef335c65dfdb67c311
-    sha256: 35dc57108acd1cb5e355d49b5ef2149508f6836445935548c3015eaa131fb16d
+    md5: 9f9840fb1c2e009fb0009a2f9461e64a
+    sha256: bfa3b5159e6696872586b2154ff9956e7e81d86d85a6a5601d25b26ca2bb916d
   category: main
   optional: false
 - name: geopandas
@@ -3512,10 +3537,10 @@ package:
     pyproj: '>=3.3.0'
     python: '>=3.9'
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_3.conda
   hash:
-    md5: 79a9a8d2fd39ecb4081c0df0c10135dc
-    sha256: ea0e200967b93a1342670bee137917e93d04742f3c3c626fe435ebb29462bbd7
+    md5: 1baca589eb35814a392eaad6d152447e
+    sha256: 04f7e616ebbf6352ff852b53c57901e43f14e2b3c92411f99b5547f106bc192e
   category: main
   optional: false
 - name: geopandas-base
@@ -3528,10 +3553,10 @@ package:
     pandas: '>=1.4.0'
     python: '>=3.9'
     shapely: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_3.conda
   hash:
-    md5: cad8d8e1583463e7642adc72a76dc3c5
-    sha256: 1b0853491a299e95d57ccf3f3c9053a1b7e49fc9b2ad959f321b0717e567e249
+    md5: e8343d1b635bf09dafdd362d7357f395
+    sha256: 2d031871b57c6d4e5e2d6cc23bd6d4e0084bb52ebca5c1b20bf06d03749e0f24
   category: main
   optional: false
 - name: geopy
@@ -3540,29 +3565,29 @@ package:
   platform: linux-64
   dependencies:
     geographiclib: '>=1.52'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
   hash:
-    md5: 358c17429c97883b2cb9ab5f64bc161b
-    sha256: 24fce5e30307da0e7961a1e37f64eea4bc060b1496e7a84d1c44ba9ad7c4bfb6
+    md5: 40182a8d62a61d147ec7d3e4c5c36ac2
+    sha256: ac453c9558c48febe452c79281c632b3749baef7c04ed4b62f871709aee2aa03
   category: main
   optional: false
 - name: geos
-  version: 3.13.0
+  version: 3.13.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.1-h97f6797_0.conda
   hash:
-    md5: 40b4ab956c90390e407bb177f8a58bab
-    sha256: 5c70d6d16e044859edca85feb9d4f1c3c6062aaf88d650826f5ccdf8c44336de
+    md5: 5bc18c66111bc94532b0d2df00731c66
+    sha256: 3a9c854fa8cf1165015b6ee994d003c3d6a8b0f532ca22b6b29cd6e8d03942ed
   category: main
   optional: false
 - name: geotiff
-  version: 1.7.3
+  version: 1.7.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -3570,36 +3595,68 @@ package:
     libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libstdcxx: '>=13'
-    libtiff: '>=4.6.0,<4.8.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    proj: '>=9.5.0,<9.6.0a0'
+    proj: '>=9.6.0,<9.7.0a0'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.4-h239500f_2.conda
   hash:
-    md5: 4eb52aecb43e7c72f8e4fca0c386354e
-    sha256: 94c7d002c70a4802a78ac2925ad6b36327cff85e0af6af2825b11a968c81ec20
+    md5: b0c42bce162a38b1aa2f6dfb5c412bc4
+    sha256: 0cd4454921ac0dfbf9d092d7383ba9717e223f9e506bc1ac862c99f98d2a953c
   category: main
   optional: false
 - name: geoviews-core
-  version: 1.13.0
+  version: 1.14.0
   manager: conda
   platform: linux-64
   dependencies:
-    bokeh: '>=3.5.0,<3.6.0'
+    bokeh: '>=3.6.0'
     cartopy: '>=0.18.0'
     holoviews: '>=1.16.0'
     numpy: '>=1.0'
     packaging: ''
     panel: '>=1.0.0'
-    param: '>=1.9.3'
+    param: '>=1.9.3,<3.0'
     pyproj: ''
     python: '>=3.10'
     shapely: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.13.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.14.0-pyha770c72_0.conda
   hash:
-    md5: e59925a00efb42c08cf0fef58f779bb4
-    sha256: a2453b6df701d38c5d141247946e0d21814fa1f056c6e85aa4003ede2f20d82e
+    md5: 7363b7d4fc02240b69c81ad96af5611e
+    sha256: 34af4b5a1ef9360418ddb45ccf06b093b5d222909816432a889f327107209789
+  category: main
+  optional: false
+- name: gettext
+  version: 0.23.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    gettext-tools: 0.23.1
+    libasprintf: 0.23.1
+    libasprintf-devel: 0.23.1
+    libgcc: '>=13'
+    libgettextpo: 0.23.1
+    libgettextpo-devel: 0.23.1
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.23.1-h5888daf_0.conda
+  hash:
+    md5: 0754038c806eae440582da1c3af85577
+    sha256: 9d93e75a63a8ca8f86d1be09f68f1211754e6f1e9ee4fa6d90b9d46ee0f1dabb
+  category: main
+  optional: false
+- name: gettext-tools
+  version: 0.23.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.23.1-h5888daf_0.conda
+  hash:
+    md5: 2f659535feef3cfb782f7053c8775a32
+    sha256: dd2b54a823ea994c2a7908fcce40e1e612ca00cb9944f2382624ff2d3aa8db03
   category: main
   optional: false
 - name: gflags
@@ -3629,30 +3686,44 @@ package:
   category: main
   optional: false
 - name: gitdb
-  version: 4.0.11
+  version: 4.0.12
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     smmap: '>=3.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
   hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+    md5: 7c14f3706e099f8fcd47af2d494616cc
+    sha256: dbbec21a369872c8ebe23cb9a3b9d63638479ee30face165aa0fccc96e93eec3
   category: main
   optional: false
 - name: gitpython
-  version: 3.1.43
+  version: 3.1.44
   manager: conda
   platform: linux-64
   dependencies:
     gitdb: '>=4.0.1,<5'
-    python: '>=3.7'
+    python: '>=3.9'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.44-pyhff2d567_0.conda
   hash:
-    md5: 0b2154c1818111e17381b1df5b4b0176
-    sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
+    md5: 140a4e944f7488467872e562a2a52789
+    sha256: b996e717ca693e4e831d3d3143aca3abb47536561306195002b226fe4dde53c3
+  category: main
+  optional: false
+- name: glib-tools
+  version: 2.82.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libglib: 2.82.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_1.conda
+  hash:
+    md5: e2e44caeaef6e4b107577aa46c95eb12
+    sha256: 5d8a48abdb1bc2b54f1380d2805cb9cd6cd9609ed0e5c3ed272aef92ab53b190
   category: main
   optional: false
 - name: glog
@@ -3683,24 +3754,24 @@ package:
   category: main
   optional: false
 - name: google-api-core
-  version: 2.22.0
+  version: 2.24.2
   manager: conda
   platform: linux-64
   dependencies:
-    google-auth: '>=2.14.1,<3.0.dev0'
-    googleapis-common-protos: '>=1.56.2,<2.0.dev0'
-    proto-plus: '>=1.25.0,<2.0.0dev'
-    protobuf: '>=3.19.5,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
-    python: '>=3.7'
-    requests: '>=2.18.0,<3.0.0.dev0'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.22.0-pyhd8ed1ab_0.conda
+    google-auth: '>=2.14.1,<3.0.0'
+    googleapis-common-protos: '>=1.56.2,<2.0.0'
+    proto-plus: '>=1.25.0,<2.0.0'
+    protobuf: '>=3.19.5,<7.0.0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    python: '>=3.9'
+    requests: '>=2.18.0,<3.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.24.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 43ac2eb76299f388c89a360e9a23fb5a
-    sha256: 0fb95fb51d25645d412150f25fb37e2cb6aac5d9fcedf6a2750cbe40ff816ef8
+    md5: 05a11e28a8e55c7ef1f727c2a25e77c1
+    sha256: 356dfadc342013b2835250337476d1cb0f4bc01c6f8ffedb7bb412098ddf3412
   category: main
   optional: false
 - name: google-auth
-  version: 2.36.0
+  version: 2.38.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3713,10 +3784,10 @@ package:
     pyu2f: '>=0.1.5'
     requests: '>=2.20.0,<3.0.0'
     rsa: '>=3.1.4,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.36.0-pyhff2d567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.38.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ca4e5c994526c3a5bb863ef6d41a2612
-    sha256: 1d770915840311c7f50512c294930095e0819581f840f8155e1b25592a182ce0
+    md5: c48abda87ffa7a0cc9f819cb8a384a9a
+    sha256: 0bbff264a2a50af0e2a61a4445c1b2353c6f44d87b83ffb36c95cca5d8fd4aaa
   category: main
   optional: false
 - name: google-auth-oauthlib
@@ -3726,64 +3797,62 @@ package:
   dependencies:
     click: '>=6.0.0'
     google-auth: '>=2.15.0'
-    python: '>=3.6'
+    python: '>=3.9'
     requests-oauthlib: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.2.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: b252850143cd2080d87060f891d3b288
-    sha256: 2eadaa93ef72136b872ee2d4775f0bc193e411a1b46b7af4e25805aed7f2e1e8
+    md5: 0fd0e6681f01076477c713ff70dbdf75
+    sha256: bc24ca2adc93a827a20e076e6ac0b9c0beaa1eb8d3cd6c5f6cf027f53113a93c
   category: main
   optional: false
 - name: google-cloud-core
-  version: 2.4.1
+  version: 2.4.3
   manager: conda
   platform: linux-64
   dependencies:
     google-api-core: '>=1.31.6,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0'
     google-auth: '>=1.25.0,<3.0dev'
     grpcio: '>=1.38.0,<2.0.0dev'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-core-2.4.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-core-2.4.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 1853cdebbfe25fb6ee253855a44945a6
-    sha256: d01b787bad2ec4da9536ce2cedb3e53ed092fe6a4a596c043ab358bb9b2fbcdd
+    md5: 7a191cc7d8d50e6dd565f15c1b92170b
+    sha256: 3e674119e8ff016a0ddd6128c3709a7a449b1dc02088e242b5df349d120ca466
   category: main
   optional: false
 - name: google-cloud-storage
-  version: 2.18.2
+  version: 3.1.0
   manager: conda
   platform: linux-64
   dependencies:
     google-api-core: '>=2.15.0,<3.0.0dev'
     google-auth: '>=2.26.1,<3.0dev'
-    google-cloud-core: '>=2.3.0,<3.0dev'
+    google-cloud-core: '>=2.4.2,<3.0dev'
     google-crc32c: '>=1.0,<2.0dev'
     google-resumable-media: '>=2.7.2'
     protobuf: <6.0.0dev
-    python: '>=3.7'
+    python: '>=3.9'
     requests: '>=2.18.0,<3.0.0dev'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-2.18.2-pyhff2d567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-3.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 75a712b2dad63711cbc1133232b469ae
-    sha256: cfb493c7771a82ea57ad66a2e8589eee45c21480dafe0613012ef7834eb60f02
+    md5: bb3983e0a57d882b74cdae28419656f2
+    sha256: 026ab32697801d01025e4dfb55acec524090eb8a11370bc281191a62e014f838
   category: main
   optional: false
 - name: google-crc32c
-  version: 1.1.2
+  version: 1.7.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    cffi: '>=1.0.0'
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.1.2-py310hd027165_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.7.0-py310hd027165_0.conda
   hash:
-    md5: 277b9122ab595ffb4775e85f2358125f
-    sha256: 7da1a0fb33056118cc7e0c3364b58cb5d5f334b720dbb01146828b48a4fe127f
+    md5: 47d9501e1ede05becaeddcbc3d25ddaa
+    sha256: 316e03ddbb90e9955eb084e0974f7d7ad695ee42456fb2af332ad1393d2509d4
   category: main
   optional: false
 - name: google-resumable-media
@@ -3792,24 +3861,24 @@ package:
   platform: linux-64
   dependencies:
     google-crc32c: '>=1.0,<2.0dev'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/google-resumable-media-2.7.2-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/google-resumable-media-2.7.2-pyhd8ed1ab_2.conda
   hash:
-    md5: 357cb6c361778650356349769e4c834b
-    sha256: 2ff33f5e48df03d86c2ca839afc3168b641106fa57603f7b39431524a595b661
+    md5: 1792ca195c71d1304b3f7c783a3d7419
+    sha256: 53f613ff22203c9d8a81ac9eb2351d0b9dea44e92922e62cdd2d45a676582cc7
   category: main
   optional: false
 - name: googleapis-common-protos
-  version: 1.65.0
+  version: 1.69.2
   manager: conda
   platform: linux-64
   dependencies:
-    protobuf: '>=3.20.2,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.65.0-pyhd8ed1ab_0.conda
+    protobuf: '>=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.69.2-pyhd8ed1ab_0.conda
   hash:
-    md5: f5bdd5dd4ad1fd075a6f25670bdda1b6
-    sha256: 093e899196b6bedb761c707677a3bc7161a04371084eb26f489327e8aa8d6f25
+    md5: f68727c208418c7abae573cbecec682b
+    sha256: a80fd47f3689c3cf0f7f3f3fa77cb354571cd07b0e307674bf99537bc68f217d
   category: main
   optional: false
 - name: graphite2
@@ -3826,29 +3895,30 @@ package:
   category: main
   optional: false
 - name: graphviz
-  version: 12.0.0
+  version: 12.2.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.0,<2.0a0'
+    adwaita-icon-theme: ''
+    cairo: '>=1.18.2,<2.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.42.12,<3.0a0'
-    gtk2: ''
+    gtk3: '>=3.24.43,<4.0a0'
     gts: '>=0.7.6,<0.8.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
-    libgcc-ng: '>=12'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
     libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.80.3,<3.0a0'
-    librsvg: '>=2.58.2,<3.0a0'
-    libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.4.0,<2.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    librsvg: '>=2.58.4,<3.0a0'
+    libstdcxx: '>=13'
+    libwebp-base: '>=1.5.0,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.0.0-hba01fac_0.conda
+    pango: '>=1.56.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.2.1-h5ae0cbf_1.conda
   hash:
-    md5: 953e31ea00d46beb7e64a79fc291ec44
-    sha256: 2eb794ae1de42b688f89811113ae3dcb63698272ee8f87029abce5f77c742c2a
+    md5: df7835d2c73cd1889d377cfd6694ada4
+    sha256: e6866409ba03df392ac5ec6f0d6ff9751a685ed917bfbcd8a73f550c5fe83c2b
   category: main
   optional: false
 - name: greenlet
@@ -3861,40 +3931,41 @@ package:
     libstdcxx: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.1.1-py310hf71b8c6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.1.1-py310hf71b8c6_1.conda
   hash:
-    md5: 76323cdee8093d5c214c35a114ef950c
-    sha256: 6720cc42d899a42fd096bc20f466d86951fa47b31483be64df2f35cc419d1a85
+    md5: 973d74c46d37ed8bbdbe721fb64a4357
+    sha256: 5a03a750d23a26a2660799f60a4cce4e951f5a5ee70db97216ae306b82401c61
   category: main
   optional: false
 - name: griffe
-  version: 1.5.1
+  version: 1.6.2
   manager: conda
   platform: linux-64
   dependencies:
     colorama: '>=0.4'
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/griffe-1.5.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/griffe-1.6.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 87db2aa0738c4acc5f565388d519fb25
-    sha256: 591bf3247a0872b76e2cf57cbdb71762913568390f5a745fe0f3f779a16459a9
+    md5: 87f05efa3df95c3bf7d6031c33db4bd5
+    sha256: bad2179b07df4cc1263337586b4f667e8df7745ceeadf0e1eed1528d17cf52b2
   category: main
   optional: false
 - name: grpcio
-  version: 1.62.2
+  version: 1.67.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libgrpc: 1.62.2
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgrpc: 1.67.1
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.62.2-py310h1b8f574_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.67.1-py310h56e06c5_2.conda
   hash:
-    md5: 21caec4bb6765fe65adc364b71a57aa6
-    sha256: e09a98015bc215b02507f5af0499602ea9eaaf104d5cf0135305857eb13cb928
+    md5: 3437789a892c80177c781a3c5d83fcbc
+    sha256: e2009605444c1114829870d5a52a5ce0fa3bb4aa7243dfe8e6ec71001be03c86
   category: main
   optional: false
 - name: gsw
@@ -3913,29 +3984,60 @@ package:
     sha256: 7944ea0c945aef30fc37e98205f0381ecbe2ba56b9c33d31407fe24a1b43f75d
   category: main
   optional: false
-- name: gtk2
-  version: 2.24.33
+- name: gtest
+  version: 1.16.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    atk-1.0: '>=2.38.0'
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    harfbuzz: '>=9.0.0,<10.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.3,<3.0a0'
-    pango: '>=1.54.0,<2.0a0'
-    xorg-libx11: '>=1.8.9,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h6470451_5.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.16.0-h84d6215_0.conda
   hash:
-    md5: 1483ba046164be27df7f6eddbcec3a12
-    sha256: 16644d036321b32635369c183502974c8b989fa516c313bd379f9aa4adcdf642
+    md5: 964fa3cb8fd0f35754535c78d966159e
+    sha256: 8ea9220055740d5ab90d81cd28a3c5450fc66410f03f63c38cf33a0e7fb8411f
+  category: main
+  optional: false
+- name: gtk3
+  version: 3.24.43
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    at-spi2-atk: '>=2.38.0,<3.0a0'
+    atk-1.0: '>=2.38.0'
+    cairo: '>=1.18.4,<2.0a0'
+    epoxy: '>=1.5.10,<1.6.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
+    fonts-conda-ecosystem: ''
+    fribidi: '>=1.0.10,<2.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    glib-tools: ''
+    harfbuzz: '>=10.4.0,<11.0a0'
+    hicolor-icon-theme: ''
+    libcups: '>=2.3.3,<3.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.2,<3.0a0'
+    liblzma: '>=5.6.4,<6.0a0'
+    libxkbcommon: '>=1.8.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pango: '>=1.56.1,<2.0a0'
+    wayland: '>=1.23.1,<2.0a0'
+    xorg-libx11: '>=1.8.11,<2.0a0'
+    xorg-libxcomposite: '>=0.4.6,<1.0a0'
+    xorg-libxcursor: '>=1.2.3,<2.0a0'
+    xorg-libxdamage: '>=1.1.6,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+    xorg-libxi: '>=1.8.2,<2.0a0'
+    xorg-libxinerama: '>=1.1.5,<1.2.0a0'
+    xorg-libxrandr: '>=1.5.4,<2.0a0'
+    xorg-libxrender: '>=0.9.12,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_4.conda
+  hash:
+    md5: a891e341072432fafb853b3762957cbf
+    sha256: fc8abccb4b0d454891847bdd8163332ff8607aa33ea9cf1e43b3828fc88c42ce
   category: main
   optional: false
 - name: gts
@@ -3957,44 +4059,44 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3'
+    python: '>=3.9'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: b21ed0883505ba1910994f1df031a428
-    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+    md5: 7ee49e89531c0dcbba9466f6d115d585
+    sha256: 622516185a7c740d5c7f27016d0c15b45782c1501e5611deec63fd70344ce7c8
   category: main
   optional: false
 - name: h2
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    hpack: '>=4.0,<5'
-    hyperframe: '>=6.0,<7'
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+    hpack: '>=4.1,<5'
+    hyperframe: '>=6.1,<7'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: b748fbf7060927a6e82df7cb5ee8f097
-    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+    md5: b4754fb1bdcb70c8fd54f918301582c6
+    sha256: 0aa1cdc67a9fe75ea95b5644b734a756200d6ec9d0dff66530aec3d1c1e9df75
   category: main
   optional: false
 - name: h5netcdf
-  version: 1.4.0
+  version: 1.6.1
   manager: conda
   platform: linux-64
   dependencies:
     h5py: ''
     packaging: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 09654b6e08a38977b2ccab5136673871
-    sha256: 313bcfe1d25da44d82c3ffa1d2d4addacab1e7ad12d9c21be63ad056398e9cc4
+    md5: fa1eb98e45a257b9a90228b57760a35f
+    sha256: e360e8eabf18796b1b32029193ee7e7c8a1cee463933d9592e2071a20c947f54
   category: main
   optional: false
 - name: h5py
-  version: 3.12.1
+  version: 3.13.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4005,29 +4107,31 @@ package:
     numpy: '>=1.19,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.12.1-nompi_py310h60e0fe6_102.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.13.0-nompi_py310h60e0fe6_100.conda
   hash:
-    md5: bbd9033531b34e220e3ff09312e91137
-    sha256: 15b07c1a1daf1a39ca9f6a7ceaef55b160ce20a9464b368eb093c31b4d538b9a
+    md5: 262cb7007454532e0cdf88c34c0c8f41
+    sha256: 5907cd4f8a57d899a7319b2668321bda8a91b375b0a5e69a8729160b64600d67
   category: main
   optional: false
 - name: harfbuzz
-  version: 9.0.0
+  version: 10.4.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.0,<2.0a0'
+    cairo: '>=1.18.2,<2.0a0'
     freetype: '>=2.12.1,<3.0a0'
     graphite2: ''
     icu: '>=75.1,<76.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.3,<3.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.2,<3.0a0'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-10.4.0-h76408a6_0.conda
   hash:
-    md5: 76b32dcf243444aea9c6b804bcfa40b8
-    sha256: 973afa37840b4e55e2540018902255cfb0d953aaed6353bb83a4d120f5256767
+    md5: 81f137b4153cf111ff8e3188b6fb8e73
+    sha256: 3b4ccabf170e1bf98c593f724cc4defe286d64cb19288751a50c63809ca32d5f
   category: main
   optional: false
 - name: hdf4
@@ -4050,18 +4154,19 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libaec: '>=1.1.3,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
+    libcurl: '>=8.11.1,<9.0a0'
+    libgcc: '>=13'
+    libgfortran: ''
+    libgfortran5: '>=13.3.0'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h2d575fe_109.conda
   hash:
-    md5: 7e1729554e209627636a0f6fabcdd115
-    sha256: 2278fa07da6f96e807d402cd55480624d67d2dee202191aaaf278ce5ab23605a
+    md5: e7a7a6e6f70553a31e6e79c65768d089
+    sha256: e8669a6d76d415f4fdbe682507ac3a3b39e8f493d2f2bdc520817f80b7cc0753
   category: main
   optional: false
 - name: heapdict
@@ -4069,15 +4174,26 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-pyhd8ed1ab_2.conda
   hash:
-    md5: 6543d34623a84f005528d73adae8535a
-    sha256: 06128b641132ea40b479371f8b1334d006e171910414031e8690ffe030bdbb17
+    md5: 9f203f36c466edeced192b7c5694c480
+    sha256: 028d035e09e5119e2defee4e8387460b0e31429616aa0999392ec0ad20da6181
+  category: main
+  optional: false
+- name: hicolor-icon-theme
+  version: '0.17'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
+  hash:
+    md5: bbf6f174dcd3254e19a2f5d2295ce808
+    sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
   category: main
   optional: false
 - name: holoviews
-  version: 1.20.0
+  version: 1.20.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -4091,56 +4207,58 @@ package:
     param: '>=2.0,<3.0'
     python: '>=3.9'
     pyviz_comms: '>=2.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.20.2-pyhd8ed1ab_0.conda
   hash:
-    md5: a765e03fa67caf58525b08bbbd5b4f76
-    sha256: 369d234fb83fb37e0e8abe7a78981a533cec37053c5c15177ad6caade729118d
+    md5: 937f8a9ea68628fb68290ca9d20a6497
+    sha256: fe74faa69e9958fbb2d66a05d6b4ac91702d93c38c79ea43cdf6e6f1ac59b569
   category: main
   optional: false
 - name: hpack
-  version: 4.0.0
+  version: 4.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 914d6646c4dbb1fd3ff539830a12fd71
-    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+    md5: 0a802cb9888dd14eeefc611f05c40b6e
+    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
   category: main
   optional: false
 - name: httpcore
-  version: 1.0.6
+  version: 1.0.7
   manager: conda
   platform: linux-64
   dependencies:
-    anyio: '>=3.0,<5.0'
-    certifi: ''
+    python: '>=3.8'
     h11: '>=0.13,<0.15'
     h2: '>=3,<5'
-    python: '>=3.8'
     sniffio: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
+    anyio: '>=3.0,<5.0'
+    certifi: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
   hash:
-    md5: b8e1901ef9a215fc41ecfb6bef7e0943
-    sha256: 8952c3f1eb18bf4d7e813176c3b23e0af4e863e8b05087e73f74f371d73077ca
+    md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
+    sha256: c84d012a245171f3ed666a8bf9319580c269b7843ffa79f26468842da3abd5df
   category: main
   optional: false
-- name: httplib2
-  version: 0.22.0
+- name: httptools
+  version: 0.6.4
   manager: conda
   platform: linux-64
   dependencies:
-    pyparsing: '>=2.4.2,<4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/httplib2-0.22.0-pyhd8ed1ab_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.6.4-py310ha75aee5_0.conda
   hash:
-    md5: 75362ef538813bab1cfec370bb09e41f
-    sha256: b3b4205aa0f5017c58a9468e443a187b5c73a3b9f18bae146feceed6c0d4a81a
+    md5: 33f0fb2d3851f38bd3feddbebfa8e76d
+    sha256: dc62022f9fb5ee82eb3274e44ce842f4842ab7ecc38375b38ace065df7bbaf13
   category: main
   optional: false
 - name: httpx
-  version: 0.27.2
+  version: 0.28.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -4148,28 +4266,27 @@ package:
     certifi: ''
     httpcore: 1.*
     idna: ''
-    python: '>=3.8'
-    sniffio: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 7e9ac3faeebdbd7b53b462c41891e7f7
-    sha256: 1a33f160548bf447e15c0273899d27e4473f1d5b7ca1441232ec2d9d07c56d03
+    md5: d6989ead454181f4f9bc987d3dc4e285
+    sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
   category: main
   optional: false
 - name: httpx-ws
-  version: 0.6.2
+  version: 0.7.1
   manager: conda
   platform: linux-64
   dependencies:
     anyio: '>=4'
     httpcore: '>=1.0.4'
     httpx: '>=0.23.1'
-    python: '>=3.8'
+    python: '>=3.9'
     wsproto: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-ws-0.6.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-ws-0.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: dc4d538daf367fbf39026a6c882c8413
-    sha256: 66ed8a57c5fa34f6c9b7c274a48e0153d630364c22d24c043b2443da1ef04d76
+    md5: 768dc4879cab7a2f8d0191a9b1cfca65
+    sha256: 59c95d01f5fe43cf0b95502fa385b5e3409c20ecf38a7c75312471d84ccec4ff
   category: main
   optional: false
 - name: humanfriendly
@@ -4178,27 +4295,27 @@ package:
   platform: linux-64
   dependencies:
     __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyhd8ed1ab_6.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
   hash:
-    md5: 2ed1fe4b9079da97c44cfe9c2e5078fd
-    sha256: cd93d5d4b1d98f7ce76a8658c35de9c63e17b3a40e52f40fa2f459e0da83d0b1
+    md5: 7fe569c10905402ed47024fc481bb371
+    sha256: fa2071da7fab758c669e78227e6094f6b3608228740808a6de5d6bce83d9e52d
   category: main
   optional: false
 - name: humanize
-  version: 4.11.0
+  version: 4.12.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/humanize-4.11.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/humanize-4.12.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 85b19c6cf705a85845172ade61e05a43
-    sha256: aeb87c0a422f5f68930041330ab34a784425e13933ba9fa25b0a9771a704ff66
+    md5: 81fa1a5709ae052dc8339109e01e71d9
+    sha256: d76e82921860441e4a860a1cfb97042cab4ebf437a767e083e86244c886141ab
   category: main
   optional: false
 - name: hvplot
-  version: 0.11.1
+  version: 0.11.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -4211,22 +4328,22 @@ package:
     panel: '>=1.0'
     param: '>=1.12.0,<3.0'
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.11.2-pyhd8ed1ab_0.conda
   hash:
-    md5: dbc57da07daee81a9cd76586217c7cbb
-    sha256: a0fb47776b6816990b94eab6e1a27025f643fa94646b845277d3aa8bce8fb2f1
+    md5: a8143fe7133f43b62a96a77455c30ffe
+    sha256: cc4367490e9f159d4fc91a2aecb12e37621fe38c0a9c244d3086f11a35a3186b
   category: main
   optional: false
 - name: hyperframe
-  version: 6.0.1
+  version: 6.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 9f765cbfab6870c8435b9eefecd7a1f4
-    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+    md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
+    sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
   category: main
   optional: false
 - name: icu
@@ -4248,15 +4365,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
   hash:
-    md5: 7ba2ede0e7c795ff95088daf0dc59753
-    sha256: 8c57fd68e6be5eecba4462e983aed7e85761a519aab80e834bbd7794d4b545b2
+    md5: 39a4f67be3286c86d696df570b1201b7
+    sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
   category: main
   optional: false
 - name: imagecodecs
-  version: 2024.9.22
+  version: 2024.12.30
   manager: conda
   platform: linux-64
   dependencies:
@@ -4264,7 +4381,7 @@ package:
     blosc: '>=1.21.6,<2.0a0'
     brunsli: '>=0.1,<1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    c-blosc2: '>=2.15.1,<2.16.0a0'
+    c-blosc2: '>=2.15.2,<2.16.0a0'
     charls: '>=2.4.2,<2.5.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
     jxrlib: '>=1.1,<1.2.0a0'
@@ -4275,95 +4392,107 @@ package:
     libbrotlicommon: '>=1.1.0,<1.2.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libdeflate: '>=1.22,<1.23.0a0'
+    libdeflate: '>=1.23,<1.24.0a0'
     libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libjxl: '>=0.11,<0.12.0a0'
-    libpng: '>=1.6.44,<1.7.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libpng: '>=1.6.45,<1.7.0a0'
     libstdcxx: '>=13'
     libtiff: '>=4.7.0,<4.8.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     libzopfli: '>=1.0.3,<1.1.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     numpy: '>=1.19,<3'
-    openjpeg: '>=2.5.2,<3.0a0'
+    openjpeg: '>=2.5.3,<3.0a0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     snappy: '>=1.2.1,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
     zfp: '>=1.0.1,<2.0a0'
-    zlib-ng: '>=2.2.2,<2.3.0a0'
+    zlib-ng: '>=2.2.3,<2.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2024.9.22-py310hdbe5077_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2024.12.30-py310h78a9a29_0.conda
   hash:
-    md5: 0c8d18531fa038323d9312e810b484b5
-    sha256: 21da76d133bc03f08e76589828337f9a54101fd46fff05f2c52800d320d6617d
+    md5: e0c50079904122427bcf52e1afcd1cdb
+    sha256: 13da21dfa6428f709d836703b2654e52aa96d7a1581afa37352982915e570add
   category: main
   optional: false
 - name: imageio
-  version: 2.36.0
+  version: 2.37.0
   manager: conda
   platform: linux-64
   dependencies:
     numpy: ''
     pillow: '>=8.3.2'
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/imageio-2.36.0-pyh12aca89_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
   hash:
-    md5: 36349844ff73fcd0140ee7f30745f0bf
-    sha256: 1fbe1bdbef2c19643c6f4e2c216305d8d54860db80968fecfa7566277518132f
+    md5: b5577bc2212219566578fd5af9993af6
+    sha256: 8ef69fa00c68fad34a3b7b260ea774fda9bd9274fd706d3baffb9519fd0063fe
+  category: main
+  optional: false
+- name: immutabledict
+  version: 4.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/immutabledict-4.2.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 16b5a86b36deff70f73019b43b9cd655
+    sha256: b313ffd7ae5934357b693b2ce7c04ba65368ea7267996bfe581eddca8c73f461
   category: main
   optional: false
 - name: importlib-metadata
-  version: 8.5.0
+  version: 8.6.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
   hash:
-    md5: 54198435fce4d64d8a89af22573012a8
-    sha256: 7194700ce1a5ad2621fd68e894dd8c1ceaff9a38723e6e0e5298fdef13017b1c
+    md5: f4b39bf00c69f56ac01e020ebfac066c
+    sha256: 598951ebdb23e25e4cec4bbff0ae369cec65ead80b50bc08b441d8e54de5cf03
   category: main
   optional: false
 - name: importlib-resources
-  version: 6.4.5
+  version: 6.5.2
   manager: conda
   platform: linux-64
   dependencies:
-    importlib_resources: '>=6.4.5,<6.4.6.0a0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.5-pyhd8ed1ab_0.conda
+    importlib_resources: '>=6.5.2,<6.5.3.0a0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 67f4772681cf86652f3e2261794cf045
-    sha256: b5a63a3e2bc2c8d3e5978a6ef4efaf2d6b02803c1bce3c2eb42e238dd91afe0b
+    md5: e376ea42e9ae40f3278b0f79c9bf9826
+    sha256: a99a3dafdfff2bb648d2b10637c704400295cb2ba6dc929e2d814870cf9f6ae5
   category: main
   optional: false
 - name: importlib_metadata
-  version: 8.5.0
+  version: 8.6.1
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: '>=8.5.0,<8.5.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.5.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.6.1,<8.6.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.6.1-hd8ed1ab_0.conda
   hash:
-    md5: 2a92e152208121afadf85a5e1f3a5f4d
-    sha256: 313b8a05211bacd6b15ab2621cb73d7f41ea5c6cae98db53367d47833f03fef1
+    md5: 7f46575a91b1307441abc235d01cab66
+    sha256: 1e3eb9d65c4d7b87c7347553ef9eef6f994996f90a2299e19b35f5997d3a3e79
   category: main
   optional: false
 - name: importlib_resources
-  version: 6.4.5
+  version: 6.5.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: c808991d29b9838fb4d96ce8267ec9ec
-    sha256: 2cb9db3e40033c3df72d3defc678a012840378fd55a67e4351363d4b321a0dc1
+    md5: c85c76dc67d75619a92f51dfbce06992
+    sha256: acc1d991837c0afb67c75b77fdc72b4bf022aac71fedd8b9ea45918ac9b08a80
   category: main
   optional: false
 - name: iniconfig
@@ -4371,27 +4500,27 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+    md5: 6837f3eff7dcea42ecd714ce1ac2b108
+    sha256: 0ec8f4d02053cd03b0f3e63168316530949484f80e16f5e2fb199a1d117a89ca
   category: main
   optional: false
 - name: intake
-  version: 2.0.7
+  version: 2.0.8
   manager: conda
   platform: linux-64
   dependencies:
     fsspec: '>=2023.0.0'
     networkx: ''
     platformdirs: ''
-    python: '>=3.8'
+    python: '>=3.9'
     pyyaml: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/intake-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-2.0.8-pyhd8ed1ab_0.conda
   hash:
-    md5: 60d4141073985bace34703a9de4c9b24
-    sha256: 7fe91841c9aee259b10f41cf239577ebe2c471d1fb3ffc360e2ade8b327574d6
+    md5: bcd8513a2f3b9b8d83fc7f04302cf800
+    sha256: 54b81550dbacdedb8aa272859233f7455bdd89e89fcb154beb7022f61af3af4a
   category: main
   optional: false
 - name: intake-esm
@@ -4423,31 +4552,31 @@ package:
   dependencies:
     geopandas: ''
     intake: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/intake-geopandas-0.4.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-geopandas-0.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 5d6429a927d1ef3c0d26d81f5d7b31f0
-    sha256: 7fd5b9cfec19d20364248202f9960553eab156bd4aab57c48eaa3e7dc1b345d9
+    md5: b1e2b5665d15c2d62d99bec8aedda0da
+    sha256: 4e19ddbaf3a318c9a050ca31f4a73e6825672dbe10aee9edf2f5e8c874ac6fdf
   category: main
   optional: false
 - name: intake-xarray
-  version: 0.7.0
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
     dask: '>=2.2'
     fsspec: '>=2022'
-    intake: '>=0.6.6'
+    intake: '>=2.0'
     msgpack-python: ''
     netcdf4: ''
-    python: '>=3.5'
+    python: '>=3.9'
     requests: ''
     xarray: '>=2022'
     zarr: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-0.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-xarray-2.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: d6471673fac9fa8f13a2517315ffcf6b
-    sha256: ceb8cf5761c29467684cb860f1c73fce396ed412a3b54f69cdd314b96ef736b6
+    md5: 9ff534be39502e636cb4d25dc6696c66
+    sha256: e8e7a165a2b8387ff23c85ea06380ab3bf9ff458513581a697286fb72c22eea5
   category: main
   optional: false
 - name: ipyevents
@@ -4456,11 +4585,11 @@ package:
   platform: linux-64
   dependencies:
     ipywidgets: '>=7.6'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipyevents-2.0.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipyevents-2.0.2-pyh80e38bb_1.conda
   hash:
-    md5: 95f2b3a86abaa1b19eebfcf33f46e761
-    sha256: 4be01788d825d9248ff8a73f30078140fdd7541264e29b0832df21bb894543ad
+    md5: 7d0c533f412ea8a758674f1e8425a9e5
+    sha256: 805f1032ec773352d6ae2773e6d79bacaca2fc332526e43f084fc9075ad7c20e
   category: main
   optional: false
 - name: ipyfilechooser
@@ -4509,13 +4638,13 @@ package:
     branca: '>=0.5.0'
     ipywidgets: '>=7.6.0,<9'
     jupyter_leaflet: ''
-    python: '>=3.8'
+    python: '>=3.9'
     traittypes: '>=0.2.1,<0.3.0'
     xyzservices: '>=2021.8.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipyleaflet-0.19.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipyleaflet-0.19.2-pyhd8ed1ab_1.conda
   hash:
-    md5: afbe890e677f76d347730edcb60167fa
-    sha256: 503c3de87d5803b63244c2b2e9905a770fa15f26f7c1ac9d2728d4a292a26fa9
+    md5: 924fbd260c4635501494850337b70925
+    sha256: fc9e7f42b80191bc5cb170b8d2c65001c3e319cee61ea64198dcb0d23499b98d
   category: main
   optional: false
 - name: ipysheet
@@ -4562,38 +4691,38 @@ package:
   platform: linux-64
   dependencies:
     ipywidgets: '>=7.6.0,<9'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipytree-0.2.2-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipytree-0.2.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 5cc19cec6c4598183f4a8278e2142810
-    sha256: 5045747a2d02ef8595dc2fa9f8e74c6702da41bb656e35f8ca794570dcf2aa93
+    md5: 05e0e5f1ce90b8ef275fc1cbdc8f6cd3
+    sha256: 4e7c2f1037a2e9f0dc49a3fecd681a937b48a244b946c5a7a37432bb98436071
   category: main
   optional: false
 - name: ipyvue
-  version: 1.11.0
+  version: 1.11.2
   manager: conda
   platform: linux-64
   dependencies:
     ipywidgets: '>=7.0.0'
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipyvue-1.11.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipyvue-1.11.2-pyhd8ed1ab_0.conda
   hash:
-    md5: e0c654ff60f028f281db145e8a9a2d20
-    sha256: 209c0dbd73f13712daed69474af7b9d0c7809766718938cb70d96a186dbaaaad
+    md5: bdcd3fe0e72a6335ba5a30068f135375
+    sha256: 8cc751f06301d1fc23f791085353875a6b6fb52da9251fb995a371b0b9643832
   category: main
   optional: false
 - name: ipyvuetify
-  version: 1.10.0
+  version: 1.11.0
   manager: conda
   platform: linux-64
   dependencies:
     ipyvue: '>=1.5,<2'
     ipywidgets: '>=7.0.0'
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipyvuetify-1.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipyvuetify-1.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a29a71d67465f289802fcea4c9b4b945
-    sha256: f26c7218dbcffdb2724f9b45da9fc0f2d5f45a6e1a22d48c77d71738f9adddb2
+    md5: 9aadf7bd573ecd3ab6a953ab6464ad31
+    sha256: 64343bab6dd374b81241af4652c71454dbabf361a4ec4e3047fd48454015bb05
   category: main
   optional: false
 - name: ipywidgets
@@ -4604,13 +4733,13 @@ package:
     comm: '>=0.1.3'
     ipython: '>=6.1.0'
     jupyterlab_widgets: '>=3.0.13,<3.1.0'
-    python: '>=3.7'
+    python: '>=3.9'
     traitlets: '>=4.3.1'
     widgetsnbextension: '>=4.0.13,<4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.5-pyhd8ed1ab_1.conda
   hash:
-    md5: a022d34163147d16b27de86dc53e93fc
-    sha256: ae27447f300c85a184d5d4fa08674eaa93931c12275daca981eb986f5d7795b3
+    md5: bb19ad65196475ab6d0bb3532d7f8d96
+    sha256: f419657566e3d9bea85b288a0ce3a8e42d76cd82ac1697c6917891df3ae149ab
   category: main
   optional: false
 - name: iso8601
@@ -4618,11 +4747,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/iso8601-2.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.9,<4'
+  url: https://conda.anaconda.org/conda-forge/noarch/iso8601-2.1.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 2f8af18d4f486f8a37de7f1fa5d39612
-    sha256: 53c7b7c13bc690d26fabb50edec46d37c4ec7fabb11de33c41914f55c4887a57
+    md5: 29370dfa863fe2b6af79888a35f2da0d
+    sha256: bdfd0191d791f1b55d89ddafbec80a7ac9b5526e9a79053246996ecf1dc3e8f6
   category: main
   optional: false
 - name: isodate
@@ -4630,11 +4759,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_1.conda
   hash:
-    md5: d68d25aca67d1a06bf6f5b43aea9430d
-    sha256: 5bf70eb750654eba73d0624a21dccbda982fb77070b3ff457dc2abd67c4e0a27
+    md5: 14c42a6334f38c412449f5a5e4043a5a
+    sha256: 845fc87dfaf3f96245ad6ad69c5e5b31b084979f64f9e32157888ee0a08f39ba
   category: main
   optional: false
 - name: isoduration
@@ -4643,11 +4772,39 @@ package:
   platform: linux-64
   dependencies:
     arrow: '>=0.15.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 4cb68948e0b8429534380243d063a27a
-    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
+    md5: 0b0154421989637d424ccf0f104be51a
+    sha256: 08e838d29c134a7684bca0468401d26840f41c92267c4126d7b43a6b533b0aed
+  category: main
+  optional: false
+- name: itsdangerous
+  version: 2.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 7ac5f795c15f288984e32add616cdc59
+    sha256: 1684b7b16eec08efef5302ce298c606b163c18272b69a62b666fbaa61516f170
+  category: main
+  optional: false
+- name: jack
+  version: 1.9.22
+  manager: conda
+  platform: linux-64
+  dependencies:
+    alsa-lib: '>=1.2.10,<1.3.0.0a0'
+    libdb: '>=6.2.32,<6.3.0a0'
+    libgcc-ng: '>=12'
+    libopus: '>=1.3.1,<2.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/jack-1.9.22-h7c63dc7_2.conda
+  hash:
+    md5: f56277b7f079f1b13cbf7fb9b4f194c4
+    sha256: 5e44a3a4b9791d1268636811628555ad40d4a8dd5c3be3334062df75580ae25b
   category: main
   optional: false
 - name: jasper
@@ -4678,47 +4835,47 @@ package:
   category: main
   optional: false
 - name: jedi
-  version: 0.19.1
+  version: 0.19.2
   manager: conda
   platform: linux-64
   dependencies:
     parso: '>=0.8.3,<0.9.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
+    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
   category: main
   optional: false
 - name: jedi-language-server
-  version: 0.41.4
+  version: 0.44.0
   manager: conda
   platform: linux-64
   dependencies:
-    cattrs: '>=23.1.2'
     docstring-to-markdown: '>=0.4,<1.0'
-    jedi: '>=0.19.1,<0.20.0'
+    cattrs: '>=23.1.2'
+    jedi: '>=0.19.2,<0.20.0'
     lsprotocol: '>=2023.0.1'
     pygls: '>=1.1.0,<2.0.0'
-    python: '>=3.8'
+    python: ''
     typing_extensions: '>=4.5.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-language-server-0.41.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-language-server-0.44.0-pyh29332c3_0.conda
   hash:
-    md5: ee3e8f555cbcb3cf1d456e7cc8d86894
-    sha256: 300801accbaa421d8240a3d61319a42b68d7b2f3015eff2cacc9676e7a5922aa
+    md5: fd2aa39a0c00ccec5cde95f70383ecec
+    sha256: 0f69dda25db72f5d9ae491ca5b9440104ead372800e72a1f5f4d50efb834ec5e
   category: main
   optional: false
 - name: jinja2
-  version: 3.1.4
+  version: 3.1.6
   manager: conda
   platform: linux-64
   dependencies:
     markupsafe: '>=2.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b86ecb7d3557821c649b3c31e3eb9f2
-    sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
+    md5: 446bd6c8cb26050d528881df495ce646
+    sha256: f1ac18b11637ddadc05642e8185a851c7fab5998c6f5470d716812fae943b2af
   category: main
   optional: false
 - name: jinja2-humanize-extension
@@ -4728,11 +4885,11 @@ package:
   dependencies:
     humanize: '>=3.14.0'
     jinja2: ''
-    python: '>=3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-humanize-extension-0.4.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-humanize-extension-0.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: a97d26d0c873821fccaa41a74b58774c
-    sha256: abe466cbb753037708de2c72db17cf72e5098affd71746c2ed1e7e3d80e32033
+    md5: 2b6ca58776c9acbde08833f9d020a842
+    sha256: 22d5e9ef7712d9f1d913ba5ed73954867d84419e1d17190e975e242319dc736f
   category: main
   optional: false
 - name: jmespath
@@ -4740,11 +4897,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
-    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
   category: main
   optional: false
 - name: joblib
@@ -4752,12 +4909,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 25df261d4523d9f9783bcdb7208d872f
-    sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
+    md5: bf8243ee348f3a10a14ed0cae323e0c1
+    sha256: 51cc2dc491668af0c4d9299b0ab750f16ccf413ec5e2391b924108c1fbacae9b
   category: main
   optional: false
 - name: json-c
@@ -4774,15 +4931,15 @@ package:
   category: main
   optional: false
 - name: json5
-  version: 0.9.25
+  version: 0.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.25-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.10.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 5d8c241a9261e720a34a07a3e1ac4109
-    sha256: 0c75e428970e8bb72ba1dd3a6dc32b8d68f6534b4fe16b38e53364963fdc8e38
+    md5: cd170f82d8e5b355dfdea6adab23e4af
+    sha256: 61bca2dac194c44603446944745566d7b4e55407280f6f6cea8bbe4de26b558f
   category: main
   optional: false
 - name: jsonpatch
@@ -4791,11 +4948,11 @@ package:
   platform: linux-64
   dependencies:
     jsonpointer: '>=1.9'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
   hash:
-    md5: bfdb7c5c6ad1077c82a69a8642c87aff
-    sha256: fbb17e33ace3225c6416d1604637c1058906b8223da968cc015128985336b2b4
+    md5: cb60ae9cf02b9fcb8004dec4089e5691
+    sha256: 304955757d1fedbe344af43b12b5467cca072f83cce6109361ba942e186b3993
   category: main
   optional: false
 - name: jsonpath-ng
@@ -4805,25 +4962,24 @@ package:
   dependencies:
     decorator: ''
     ply: ''
-    python: '>=3.6'
+    python: '>=3.9'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpath-ng-1.6.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpath-ng-1.6.1-pyhd8ed1ab_1.conda
   hash:
-    md5: a698a41f5b52fe96049fd8c926ac3086
-    sha256: 9bfe839073ba18c5619d533a9c9a8d299f6b37ab70c5a982162c4f0f006198d5
+    md5: 5c21e268b3020ff115372b797336793e
+    sha256: be0fbac0976f82997ef56cab9197dbab3240c58ac05c35f02f4a0d62c097d835
   category: main
   optional: false
 - name: jsonpickle
-  version: 3.4.2
+  version: 4.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-3.4.2-pyhff2d567_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-4.0.0-pyh29332c3_0.conda
   hash:
-    md5: 857174a73a5adb08d9cfc3e567d94b11
-    sha256: 19c26f7fc99a43641f0f76620e52b90458a6ab8dd9a15ad78013197910323f14
+    md5: 326318b423a787eec6cb842fac0158c0
+    sha256: f0b69d1c43ae01c7494020bd800b4791909690b2b12b92c1d9760f2c9af1d5c8
   category: main
   optional: false
 - name: jsonpointer
@@ -4848,13 +5004,13 @@ package:
     importlib_resources: '>=1.4.0'
     jsonschema-specifications: '>=2023.03.6'
     pkgutil-resolve-name: '>=1.3.10'
-    python: '>=3.8'
+    python: '>=3.9'
     referencing: '>=0.28.4'
     rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
   hash:
-    md5: da304c192ad59975202859b367d0f6a2
-    sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
+    md5: a3cead9264b331b32fe8f0aabc967522
+    sha256: be992a99e589146f229c58fe5083e0b60551d774511c494f91fe011931bd7893
   category: main
   optional: false
 - name: jsonschema-specifications
@@ -4862,12 +5018,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     referencing: '>=0.31.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 720745920222587ef942acfbc578b584
-    sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
+    md5: 3b519bc21bc80e60b456f1e62962a766
+    sha256: 37127133837444cf0e6d1a95ff5a505f8214ed4e89e8e9343284840e674c6891
   category: main
   optional: false
 - name: jsonschema-with-format-nongpl
@@ -4884,10 +5040,10 @@ package:
     rfc3986-validator: '>0.1.0'
     uri-template: ''
     webcolors: '>=24.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
   hash:
-    md5: 16b37612b3a2fd77f409329e213b530c
-    sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
+    md5: a5b1a8065857cc4bd8b7a38d063bb728
+    sha256: 6e0184530011961a0802fda100ecdfd4b0eca634ed94c37e553b72e21c26627d
   category: main
   optional: false
 - name: jupyter-lsp
@@ -4897,11 +5053,11 @@ package:
   dependencies:
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_1.conda
   hash:
-    md5: 885867f6adab3d7ecdf8ab6ca0785f51
-    sha256: 2151c2c63e0442a4c69ee0ad8a634195eedab10b7b74c0ec8266471842239a93
+    md5: 0b4c3908e5a38ea22ebb98ee5888c768
+    sha256: 1565c8b1423a37fca00fe0ab2a17cd8992c2ecf23e7867a1c9f6f86a9831c196
   category: main
   optional: false
 - name: jupyter-panel-proxy
@@ -4911,26 +5067,26 @@ package:
   dependencies:
     jupyter-server-proxy: ''
     panel: ''
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-panel-proxy-0.1.0-py_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-panel-proxy-0.1.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 80c21feab6100e287707c371c752adea
-    sha256: 2fb87368ff1e44e24b177c1786dc4227135efbc5bd54bceab5c0f7b85c39ed72
+    md5: 736ba9f0c55b2e66ce0b6f5848010abe
+    sha256: 1293841e194261af08abdd7db81acc0349485533091379a25ca82e18523bdd45
   category: main
   optional: false
 - name: jupyter-resource-usage
-  version: 1.1.0
+  version: 1.1.1
   manager: conda
   platform: linux-64
   dependencies:
     jupyter_server: '>=2.0.0,<3'
     psutil: '>=5.6.0,<6'
-    python: '>=3.8'
+    python: '>=3.9'
     pyzmq: '>=19'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-resource-usage-1.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-resource-usage-1.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c64f9b9f15a79239b864c455cc0a67d4
-    sha256: 163a265b237d1896539b75e79288c117bdc9e7eec47aac5087c3b0a737b5511f
+    md5: 2d7371814049db8228fb4d945d2b455e
+    sha256: 93df25a9cda37db4c62c3aa2da070af4d721dc02508b0011c41a61ff9c7394ed
   category: main
   optional: false
 - name: jupyter-server-mathjax
@@ -4939,11 +5095,11 @@ package:
   platform: linux-64
   dependencies:
     jupyter_server: '>=1.1,<3'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-server-mathjax-0.2.6-pyh5bfe37b_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-server-mathjax-0.2.6-pyhbbac1ac_2.conda
   hash:
-    md5: 11ca195fc8a16770661a387bcce27c36
-    sha256: 46f6c3b76d9f03e8eb31e1c178083efb7de94447b8b14d378493073666a791a1
+    md5: a575ab1d71583644de23e7a9bef9bd27
+    sha256: f59a97ee617a711dafc5cd39c53dc526de35bb8e43b2dbc780c7b5c672a661be
   category: main
   optional: false
 - name: jupyter-server-proxy
@@ -4954,14 +5110,14 @@ package:
     aiohttp: ''
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.24.0'
-    python: '>=3.8'
+    python: '>=3.9'
     simpervisor: '>=1.0.0'
     tornado: '>=6.1.0'
     traitlets: '>=5.1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-server-proxy-4.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-server-proxy-4.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: f84c359ab53d51c125319b25bd09a887
-    sha256: 51955e791d7cb60ad1efabf0802cb9f55905bab74709ec0f096d3b5bc9e9815e
+    md5: 4696e23d86b32957ff469870e74c8c97
+    sha256: 51006cf07d38c410890a8ae42d5e85fc806c3fb0740a7d7749afe48bff0e5580
   category: main
   optional: false
 - name: jupyter-vscode-proxy
@@ -4970,12 +5126,12 @@ package:
   platform: linux-64
   dependencies:
     jupyter-server-proxy: ''
-    python: '>=3'
+    python: '>=3.9'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-vscode-proxy-0.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-vscode-proxy-0.6-pyhd8ed1ab_1.conda
   hash:
-    md5: 15af47d9ba08dc87c4dcb09eb5000b05
-    sha256: 160a692440d8310efbe65f375e46b59b54ef03609017585f5e25b6a4c30b6dd1
+    md5: b137c99126a6fb68c36ed6a8e640eb01
+    sha256: ded1833ed2c86fb4a1d2e18962b4c1945598b3a0e08c78f1d2f4c74c3faed0ef
   category: main
   optional: false
 - name: jupyter_client
@@ -4985,15 +5141,15 @@ package:
   dependencies:
     importlib-metadata: '>=4.8.3'
     jupyter_core: '>=4.12,!=5.0.*'
-    python: '>=3.8'
+    python: '>=3.9'
     python-dateutil: '>=2.8.2'
     pyzmq: '>=23.0'
     tornado: '>=6.2'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
   hash:
-    md5: a14218cfb29662b4a19ceb04e93e298e
-    sha256: 4419c85e209a715f551a5c9bead746f29ee9d0fc41e772a76db3868622795671
+    md5: 4ebae00eae9705b0c3d6d1018a81d047
+    sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
   category: main
   optional: false
 - name: jupyter_core
@@ -5012,22 +5168,23 @@ package:
   category: main
   optional: false
 - name: jupyter_events
-  version: 0.10.0
+  version: 0.12.0
   manager: conda
   platform: linux-64
   dependencies:
     jsonschema-with-format-nongpl: '>=4.18.0'
-    python: '>=3.8'
+    packaging: ''
+    python: ''
     python-json-logger: '>=2.0.4'
     pyyaml: '>=5.3'
     referencing: ''
     rfc3339-validator: ''
     rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
   hash:
-    md5: ed45423c41b3da15ea1df39b1f80c2ca
-    sha256: cd3f41dc093162a41d4bae171e40a1b9b115c4d488e9bb837a8fa9d084931fb9
+    md5: f56000b36f09ab7533877e695e4e8cb0
+    sha256: 37e6ac3ccf7afcc730c3b93cb91a13b9ae827fd306f35dd28f958a74a14878b5
   category: main
   optional: false
 - name: jupyter_leaflet
@@ -5036,14 +5193,14 @@ package:
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_leaflet-0.19.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_leaflet-0.19.2-pyhd8ed1ab_1.conda
   hash:
-    md5: aafc37674dd1409e2e218f89a9020291
-    sha256: ab1b7f0cb32790dedb502deb2000ef1f28e158f25fea1a5d5c0ee73d22ceb8e0
+    md5: 54176d4d376c155a3940ac567729d5a7
+    sha256: 66f9c8d109d280d35154aee5374d683663d547bc846a564ce1088f0681d06e63
   category: main
   optional: false
 - name: jupyter_server
-  version: 2.14.2
+  version: 2.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5052,24 +5209,24 @@ package:
     jinja2: '>=3.0.3'
     jupyter_client: '>=7.4.4'
     jupyter_core: '>=4.12,!=5.0.*'
-    jupyter_events: '>=0.9.0'
+    jupyter_events: '>=0.11.0'
     jupyter_server_terminals: '>=0.4.4'
     nbconvert-core: '>=6.4.4'
     nbformat: '>=5.3.0'
     overrides: '>=5.0'
     packaging: '>=22.0'
     prometheus_client: '>=0.9'
-    python: '>=3.8'
+    python: '>=3.9'
     pyzmq: '>=24'
     send2trash: '>=1.8.2'
     terminado: '>=0.8.3'
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ca23c71f70a7c7935b3d03f0f1a5801d
-    sha256: edab71a05feceac54bdb90e755a257545af7832b9911607c1a70f09be44ba985
+    md5: 6ba8c206b5c6f52b82435056cf74ee46
+    sha256: be5f9774065d94c4a988f53812b83b67618bec33fcaaa005a98067d506613f8a
   category: main
   optional: false
 - name: jupyter_server_terminals
@@ -5077,12 +5234,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     terminado: '>=0.8.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 219b3833aa8ed91d47d1be6ca03f30be
-    sha256: 038efbc7e4b2e72d49ed193cfb2bbbe9fbab2459786ce9350301f466a32567db
+    md5: 2d983ff1b82a1ccb6f2e9d8784bdd6bd
+    sha256: 0890fc79422191bc29edf17d7b42cff44ba254aa225d31eb30819f8772b775b8
   category: main
   optional: false
 - name: jupyter_telemetry
@@ -5176,15 +5333,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-geojson-3.4.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-geojson-3.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: a98e9b2a8648b246b9aec4a67cfea5f7
-    sha256: c51c056cba96296509b81f2885d36f7ae6b99fdcca99b1b1cc8175dd560fbffd
+    md5: 52330b4c11577d4eca2405150867aeb7
+    sha256: 59857222b7a7c071135f6a3b15309974867709a864b4569c9e691a8bb14ec9b8
   category: main
   optional: false
 - name: jupyterlab-git
-  version: 0.50.2
+  version: 0.51.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5193,12 +5350,12 @@ package:
     nbformat: ''
     packaging: ''
     pexpect: ''
-    python: '>=3.6,<4.0'
+    python: '>=3.9,<4.0'
     traitlets: '>=5.0,<6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-git-0.50.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-git-0.51.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ceef639ca7744eae72138fb5cff033ad
-    sha256: d436cb217a2367b3122169e276ed6f73912e3c2c66381f45683391f78ba342bc
+    md5: 053d26baf17b58d8d945d9a1bedbe441
+    sha256: 35f573ef65d1b58554f8577205f13b5a25695dfdc9297fb01c2ee55b4cd475b7
   category: main
   optional: false
 - name: jupyterlab_code_formatter
@@ -5207,11 +5364,11 @@ package:
   platform: linux-64
   dependencies:
     jupyter_server: '>=1.21,<3'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_code_formatter-3.0.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_code_formatter-3.0.2-pyhd8ed1ab_1.conda
   hash:
-    md5: bd108b7352ce3f9ec42bb9518df10629
-    sha256: 3b8e956697bd3b8135f3b4a669b2961b38ece7bae272746f8ea6bee61644d0e1
+    md5: f41368c2e6ca4338e6d8a05eaeda35cf
+    sha256: 43f2eab266e856785b4554681eb03561872a37aaee2688f4f8a389ed66d04ce3
   category: main
   optional: false
 - name: jupyterlab_pygments
@@ -5220,11 +5377,11 @@ package:
   platform: linux-64
   dependencies:
     pygments: '>=2.4.1,<3'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
   hash:
-    md5: afcd1b53bcac8844540358e33f33d28f
-    sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
+    md5: fd312693df06da3578383232528c468d
+    sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
   category: main
   optional: false
 - name: jupyterlab_server
@@ -5239,12 +5396,12 @@ package:
     jsonschema: '>=4.18'
     jupyter_server: '>=1.21,<3'
     packaging: '>=21.3'
-    python: '>=3.8'
+    python: '>=3.9'
     requests: '>=2.31'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
   hash:
-    md5: af8239bf1ba7e8c69b689f780f653488
-    sha256: a23b26d1a35bccdb91b9232119e5f402624e1e1a252b0e64cc20c6eb5b87cefb
+    md5: 9dc4b2b0f41f0de41d27f3293e319357
+    sha256: d03d0b7e23fa56d322993bc9786b3a43b88ccc26e58b77c756619a921ab30e86
   category: main
   optional: false
 - name: jupyterlab_widgets
@@ -5252,11 +5409,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.13-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.13-pyhd8ed1ab_1.conda
   hash:
-    md5: ccea946e6dce9f330fbf7fca97fe8de7
-    sha256: 0e7ec7936d766f39d5a0a8eafc63f5543f488883ad3645246bc22db6d632566e
+    md5: b26e487434032d7f486277beb0cead3a
+    sha256: 206489e417408d2ffc2a7b245008b4735a8beb59df6c9109d4f77e7bc5969d5d
   category: main
   optional: false
 - name: jxrlib
@@ -5271,35 +5428,20 @@ package:
     sha256: 2057ca87b313bde5b74b93b0e696f8faab69acd4cb0edebb78469f3f388040c0
   category: main
   optional: false
-- name: kealib
-  version: 1.5.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-hf8d3e68_2.conda
-  hash:
-    md5: ffe68c611ae0ccfda4e7a605195e22b3
-    sha256: a45cb038fce2b6fa154cf0c71485a75b59cb1d8d6b0465bdcb23736aca6bf2ac
-  category: main
-  optional: false
 - name: kerchunk
-  version: 0.2.6
+  version: 0.2.7
   manager: conda
   platform: linux-64
   dependencies:
     fsspec: ''
     numcodecs: ''
-    python: '>=3.7'
+    python: '>=3.9'
     ujson: ''
     zarr: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.7-pyhd8ed1ab_0.conda
   hash:
-    md5: 1e8d30ede5a3b9146551532091dc23cd
-    sha256: 3d988302b89dec9419c72158ae9545c3caa1034fdaf1a699f11279ab8c168fa4
+    md5: 411253f16f2de8232c94483a46d2f08a
+    sha256: 624e14d7c4787ba683ebc80962d63054d9793267a93dbb1a501ad83c46046762
   category: main
   optional: false
 - name: kernel-headers_linux-64
@@ -5342,26 +5484,25 @@ package:
   category: main
   optional: false
 - name: knack
-  version: 0.5.1
+  version: 0.12.0
   manager: conda
   platform: linux-64
   dependencies:
     argcomplete: ''
-    colorama: ''
     jmespath: ''
+    packaging: ''
     pygments: ''
-    python: ''
+    python: '>=3.9'
     pyyaml: ''
-    six: ''
     tabulate: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/knack-0.5.1-py_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/knack-0.12.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 6f93c69448d2c5a3f423f6c64cb14a52
-    sha256: 36ca5c658aca9c3ef3b5421ab371fef1b2d75ad20265a828d6c2776422a79cbc
+    md5: a8334270c095de8290771b858a99d99b
+    sha256: 6cee36390d3c6f6cfdf65f4c7dfb7be7e360468875739c8b02bf7d5b8ac88f1d
   category: main
   optional: false
 - name: kopf
-  version: 1.37.2
+  version: 1.37.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -5370,14 +5511,14 @@ package:
     iso8601: ''
     kubernetes: ''
     pykube-ng: ''
-    python: '>=3.7'
+    python: '>=3.9'
     python-json-logger: ''
     pyyaml: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/kopf-1.37.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kopf-1.37.5-pyhd8ed1ab_0.conda
   hash:
-    md5: c14f5c7dab8c72f4fb01ce6c8622f4e7
-    sha256: f067301001928d856071c972c5951ac156eda58e92e4043400a00bf1c0be898c
+    md5: 4db408765d9d67d0267fb1f7ff5b40c4
+    sha256: e818cc5ea3420935c2a457e1510d3427a71e1d1596f4d056ea0c9126ded8091e
   category: main
   optional: false
 - name: kr8s
@@ -5418,76 +5559,76 @@ package:
   category: main
   optional: false
 - name: kubernetes
-  version: 1.31.2
+  version: 1.32.3
   manager: conda
   platform: linux-64
   dependencies:
-    kubernetes-client: 1.31.2
-    kubernetes-node: 1.31.2
-    kubernetes-server: 1.31.2
-  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-1.31.2-ha770c72_0.conda
+    kubernetes-client: 1.32.3
+    kubernetes-node: 1.32.3
+    kubernetes-server: 1.32.3
+  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-1.32.3-ha770c72_0.conda
   hash:
-    md5: bccd3efc98845486828fe4d136a5ebd0
-    sha256: 040d454954ea1864a6fd2d673dbb1a2027e02a714c1cfd5622a101264af8bc79
+    md5: 395a51333b80352320822131714845d2
+    sha256: b446816914b2c9051515c0f31827296161c4a815ae942504dbd4ad745712cbf8
   category: main
   optional: false
 - name: kubernetes-client
-  version: 1.31.2
+  version: 1.32.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-client-1.31.2-h6d84b8b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-client-1.32.3-h6d84b8b_0.conda
   hash:
-    md5: 1e1cb15ed7882b4fb991c7d93b4cfd28
-    sha256: 95d60c817bf3a37edd9ff2bb686738933a4e4dd6438b65d420ec060d510a86fc
+    md5: d18a296104f9aa5c335c3627e09809fa
+    sha256: 387729132844fb0c71fce73adeb1502a05d52b1ec94299d3794b7d842e96cc0c
   category: main
   optional: false
 - name: kubernetes-node
-  version: 1.31.2
+  version: 1.32.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-node-1.31.2-h6d84b8b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-node-1.32.3-h6d84b8b_0.conda
   hash:
-    md5: 1db263fc25e8b0acca27ffcdb7260add
-    sha256: 751748a7b613dd5baa56fa82af64f6f8f26f19c6d34842a7f561b477b6984bee
+    md5: b855f23b06dca474a8d471a8a6bdbbe3
+    sha256: 063ee1d817ee574d52bc037651c96b7dcb7c832fc228fb705bc52a88fec86786
   category: main
   optional: false
 - name: kubernetes-server
-  version: 1.31.2
+  version: 1.32.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    kubernetes-node: 1.31.2
+    kubernetes-node: 1.32.3
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-server-1.31.2-h6d84b8b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/kubernetes-server-1.32.3-h6d84b8b_0.conda
   hash:
-    md5: 513b8ebfd4cb36ae1a0494ef6aafc318
-    sha256: 2666fc468113cb23c8676ac1cb318650375b9d70877b00fd433a98d5033960e3
+    md5: b33045cbab592b7e53b08b8532bc312e
+    sha256: 2eef4c59ad4505b7b42c3e5aff72bb62fffa1d1c58f8ed8c90a339ff5f58cf6d
   category: main
   optional: false
 - name: kubernetes_asyncio
-  version: 31.1.0
+  version: 32.0.0
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: '>=3.7.0,<4.0.0'
     certifi: '>=14.05.14'
-    python: '>=3.6'
+    python: '>=3.9'
     python-dateutil: '>=2.5.3'
     pyyaml: '>=3.12'
     setuptools: '>=21.0.0'
     six: '>=1.9.0'
     urllib3: '>=1.24.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/kubernetes_asyncio-31.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kubernetes_asyncio-32.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: dac971db6b739fd41302dede1fe5e801
-    sha256: c207aba82e0afb60b2e8b68d06ece266d4fd44818f87d8b0aaa6af10ba78566e
+    md5: ab0535d56a6e588418ba279f4d9001b2
+    sha256: 049b93aa9e9094247a94e2a6ef2ebdeffec2bff57da5fb9a5e7b1e2f347270b8
   category: main
   optional: false
 - name: lame
@@ -5507,11 +5648,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/lark-1.2.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/lark-1.2.2-pyhd8ed1ab_1.conda
   hash:
-    md5: e69ddc63e66565bc5283b169b350a851
-    sha256: a71d0e5c0975803b43c93df9b4e92850fc291c6fc3dd6c6e38aeacc64cc43737
+    md5: 3a8063b25e603999188ed4bbf3485404
+    sha256: 637a9c32e15a4333f1f9c91e0a506dbab4a6dab7ee83e126951159c916c81c99
   category: main
   optional: false
 - name: lazy-loader
@@ -5521,11 +5662,11 @@ package:
   dependencies:
     importlib-metadata: ''
     packaging: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
   hash:
-    md5: 4809b9f4c6ce106d443c3f90b8e10db2
-    sha256: c1ca8dc910d7c32d431d8ef4acdea8da2e876c62f096b99591f712fd62cf7269
+    md5: d10d9393680734a8febc4b362a4c94f2
+    sha256: d7ea986507090fff801604867ef8e79c8fda8ec21314ba27c032ab18df9c3411
   category: main
   optional: false
 - name: lazy_loader
@@ -5534,25 +5675,26 @@ package:
   platform: linux-64
   dependencies:
     lazy-loader: '0.4'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.4-pyhd8ed1ab_2.conda
   hash:
-    md5: ec6f70b8a5242936567d4f886726a372
-    sha256: bf5a563f4e7d2bd5d3ec0644c0cb452b1e9e4ee68a221f6c9718872a22d4fa7a
+    md5: bb0230917e2473c77d615104dbe8a49d
+    sha256: e26803188a54cd90df9ce1983af70b287c4918c0fd178a9aabd9f1580f657a2b
   category: main
   optional: false
 - name: lcms2
-  version: '2.16'
+  version: '2.17'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+    libtiff: '>=4.7.0,<4.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
   hash:
-    md5: 51bb7010fc86f70eee639b4bb7a894f5
-    sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+    md5: 000e85703f0fd9594c81710dd5066471
+    sha256: d6a61830a354da022eae93fa896d0991385a875c6bba53c82263a289deda9db8
   category: main
   optional: false
 - name: ld_impl_linux-64
@@ -5561,14 +5703,14 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
   hash:
-    md5: 048b02e3962f066da18efe3a21b77672
-    sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
+    md5: 01f8d123c96816249efd255a31ad7712
+    sha256: db73f38155d901a610b2320525b9dd3b31e4949215c870685fd92ea61b5ce472
   category: main
   optional: false
 - name: leafmap
-  version: 0.38.16
+  version: 0.42.13
   manager: conda
   platform: linux-64
   dependencies:
@@ -5601,22 +5743,22 @@ package:
     scooby: ''
     whiteboxgui: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/leafmap-0.38.16-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/leafmap-0.42.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 2f4167dd305186e0d49633e17cb5372d
-    sha256: 85ce712be2e23b8b8d336cce71daee0cfbddf2270df508f15c73efb87bdac011
+    md5: cf869aeeb76201d951345f5e65b883bc
+    sha256: b002a2885854a6afa8246646b9cdd006bf965599314ed95ed4e1d9646141e0ed
   category: main
   optional: false
 - name: legacy-cgi
-  version: 2.6.1
+  version: 2.6.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/legacy-cgi-2.6.1-pyh5b84bb0_3.conda
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/legacy-cgi-2.6.2-pyh41aed27_1.conda
   hash:
-    md5: f258b7f54b5d9ddd02441f10c4dca2ac
-    sha256: 4e46bf5a8f7d3bbe89f2884539b31877c367e09d63fbe54979319f4bb9e62c1b
+    md5: 097b37f4503a319a9631020ecfe0e845
+    sha256: aca06fc1d0cdbb342951c5d1187569c5fcfaa6fc10310a7ca88e5e44520f398d
   category: main
   optional: false
 - name: lerc
@@ -5632,18 +5774,32 @@ package:
     sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
   category: main
   optional: false
-- name: libabseil
-  version: '20240116.2'
+- name: level-zero
+  version: 1.21.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_he02047a_1.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.21.6-h84d6215_0.conda
   hash:
-    md5: c48fc56ec03229f294176923c3265c05
-    sha256: 945396726cadae174a661ce006e3f74d71dbd719219faf7cc74696b267f7b0b5
+    md5: a5f844bb4a579da14f93901296f51439
+    sha256: c42db00f9db9cc79acf434deb988c52097a1999c7e3295eba8496b3e5f87b44a
+  category: main
+  optional: false
+- name: libabseil
+  version: '20240722.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_hbbce691_4.conda
+  hash:
+    md5: 488f260ccda0afaf08acb286db439c2f
+    sha256: 143a586aa67d50622ef703de57b9d43f44945836d6568e0e7aa174bd8c45e0d4
   category: main
   optional: false
 - name: libaec
@@ -5660,110 +5816,140 @@ package:
   category: main
   optional: false
 - name: libarchive
-  version: 3.7.4
+  version: 3.7.7
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libgcc-ng: '>=12'
-    libxml2: '>=2.12.7,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    libgcc: '>=13'
+    liblzma: '>=5.6.3,<6.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.3.0,<4.0a0'
-    xz: '>=5.2.6,<6.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-h4585015_3.conda
   hash:
-    md5: 32ddb97f897740641d8d46a829ce1704
-    sha256: c30970e5e6515c662d00bb74e7c1b09ebe0c8c92c772b952a41a5725e2dcc936
+    md5: a28808eae584c7f519943719b2a2b386
+    sha256: 2466803e26ae9dbd2263de3a102b572b741c056549875c04b6ec10830bd5d338
   category: main
   optional: false
 - name: libarrow
-  version: 16.1.0
+  version: 19.0.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.28.3,<0.28.4.0a0'
-    aws-sdk-cpp: '>=1.11.407,<1.11.408.0a0'
-    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
-    azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
-    azure-storage-blobs-cpp: '>=12.12.0,<12.12.1.0a0'
-    azure-storage-files-datalake-cpp: '>=12.11.0,<12.11.1.0a0'
+    aws-crt-cpp: '>=0.29.9,<0.29.10.0a0'
+    aws-sdk-cpp: '>=1.11.489,<1.11.490.0a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-identity-cpp: '>=1.10.0,<1.10.1.0a0'
+    azure-storage-blobs-cpp: '>=12.13.0,<12.13.1.0a0'
+    azure-storage-files-datalake-cpp: '>=12.12.0,<12.12.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    gflags: '>=2.2.2,<2.3.0a0'
     glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
     libgcc: '>=13'
-    libgoogle-cloud: '>=2.29.0,<2.30.0a0'
-    libgoogle-cloud-storage: '>=2.29.0,<2.30.0a0'
-    libre2-11: '>=2023.9.1'
+    libgoogle-cloud: '>=2.35.0,<2.36.0a0'
+    libgoogle-cloud-storage: '>=2.35.0,<2.36.0a0'
+    libopentelemetry-cpp: '>=1.18.0,<1.19.0a0'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+    libre2-11: '>=2024.7.2'
     libstdcxx: '>=13'
-    libutf8proc: '>=2.8.0,<3.0a0'
+    libutf8proc: '>=2.10.0,<2.11.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.2,<2.0.3.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    orc: '>=2.0.3,<2.0.4.0a0'
     re2: ''
     snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-16.1.0-had3b6fe_29_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-19.0.1-hfa2a6e7_0_cpu.conda
   hash:
-    md5: 10aaea548b6f3460d407c6f84c16568d
-    sha256: b254c7c02771eaa5f85d2f40353ce77a6181e9908dea2cd75a1de80d80906ba1
+    md5: 11b712ed1316c98592f6bae7ccfaa86c
+    sha256: 7b1f61045b37266989023a007d6331875062bb658068a6e6ab49720495ca3543
   category: main
   optional: false
 - name: libarrow-acero
-  version: 16.1.0
+  version: 19.0.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libarrow: 16.1.0
+    libarrow: 19.0.1
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-16.1.0-h5888daf_29_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-19.0.1-hcb10f89_0_cpu.conda
   hash:
-    md5: a394dfa5772ed993426baf95eb535bcc
-    sha256: f39aa8f5d529652cd44f402482eb1b3c4be526e0faffd7f2b6c0d993eaf62b06
+    md5: 0d63e2dea06c44c9d2c8be3e7e38eea9
+    sha256: 9a3c38a8f1516fe5b7801d0407ff704efd53955ebd63f7fbc439ec3b563d19cc
   category: main
   optional: false
 - name: libarrow-dataset
-  version: 16.1.0
+  version: 19.0.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libarrow: 16.1.0
-    libarrow-acero: 16.1.0
+    libarrow: 19.0.1
+    libarrow-acero: 19.0.1
     libgcc: '>=13'
-    libparquet: 16.1.0
+    libparquet: 19.0.1
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-16.1.0-h5888daf_29_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-19.0.1-hcb10f89_0_cpu.conda
   hash:
-    md5: d9a344c5277c71d7cf875ace13fb0bca
-    sha256: 64209a090c15e83ec928ace2e34f4836d381ee929f1c9739aedf60dd5123a2fb
+    md5: ec52b3b990be399f4267a9acabb73070
+    sha256: f756208d787db50b6be68210cb9eec3644b8291a8a353bb2071ea4451bfc1412
   category: main
   optional: false
 - name: libarrow-substrait
-  version: 16.1.0
+  version: 19.0.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libarrow: 16.1.0
-    libarrow-acero: 16.1.0
-    libarrow-dataset: 16.1.0
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libarrow: 19.0.1
+    libarrow-acero: 19.0.1
+    libarrow-dataset: 19.0.1
     libgcc: '>=13'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-16.1.0-hf54134d_29_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-19.0.1-h08228c5_0_cpu.conda
   hash:
-    md5: 2ca2bab8b89c7f5e2f61b2202f1e744c
-    sha256: c2006aa62e7e41bc6085941b8cf9e7fa9a063df4ddd2add58893fcce01add1ed
+    md5: 792e2359bb93513324326cbe3ee4ebdd
+    sha256: e0b3ed06ce74c6a083dab59fb3059fdbc40fc71ff94ce470ca0a7c7ffe8d0317
+  category: main
+  optional: false
+- name: libasprintf
+  version: 0.23.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.23.1-h8e693c7_0.conda
+  hash:
+    md5: 988f4937281a66ca19d1adb3b5e3f859
+    sha256: 13b863584fccbb9089de73a2442e540703ce4873e4719c9d98c98e4a8e12f9d1
+  category: main
+  optional: false
+- name: libasprintf-devel
+  version: 0.23.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libasprintf: 0.23.1
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.23.1-h8e693c7_0.conda
+  hash:
+    md5: 2827e722a963b779ce878ef9b5474534
+    sha256: b05a859fe5a2b43574f3a5d93552061232b92d17017b27ecab1eccca1dbb2fe4
   category: main
   optional: false
 - name: libass
@@ -5771,23 +5957,22 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    libgcc: '>=13'
     __glibc: '>=2.17,<3.0.a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
+    harfbuzz: '>=10.1.0,<11.0a0'
     freetype: '>=2.12.1,<3.0a0'
     fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=9.0.0,<10.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
-    libgcc-ng: '>=12'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
+    fontconfig: '>=2.15.0,<3.0a0'
+    fonts-conda-ecosystem: ''
+    libiconv: '>=1.17,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-hba53ac1_1.conda
   hash:
-    md5: 2a66267ba586dadd110cc991063cfff7
-    sha256: 52afd5e79681185ea33da0e7548aa3721be7e9a153a90f004c5adc33d61f7a14
+    md5: f5e75fe79d446bf4975b41d375314605
+    sha256: aaf38bcb9b78963f4eb58d882a9a6a350f500cfa162bd8a80f7f215d3831afa2
   category: main
   optional: false
 - name: libavif16
-  version: 1.1.1
+  version: 1.2.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -5796,11 +5981,11 @@ package:
     dav1d: '>=1.2.1,<1.2.2.0a0'
     libgcc: '>=13'
     rav1e: '>=0.6.6,<1.0a0'
-    svt-av1: '>=2.3.0,<2.3.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-h1909e37_2.conda
+    svt-av1: '>=3.0.1,<3.0.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.2.1-h63b8bd6_0.conda
   hash:
-    md5: 21e468ed3786ebcb2124b123aa2484b7
-    sha256: e06da844b007a64a9ac35d4e3dc4dbc66583f79b57d08166cf58f2f08723a6e8
+    md5: edeb4cf51435b3db35a3d5449752b248
+    sha256: ba14be65b69790c625bef9cc858f4945e59373ef4d568be253886830a92bdfd9
   category: main
   optional: false
 - name: libblas
@@ -5808,11 +5993,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.28,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
+    mkl: '>=2024.2.2,<2025.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-31_hfdb39a5_mkl.conda
   hash:
-    md5: 8ea26d42ca88ec5258802715fe1ee10b
-    sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
+    md5: bdf4a57254e8248222cb631db4393ff1
+    sha256: 862289f2cfb84bb6001d0e3569e908b8c42d66b881bd5b03f730a3924628b978
   category: main
   optional: false
 - name: libbrotlicommon
@@ -5856,16 +6041,30 @@ package:
     sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
   category: main
   optional: false
+- name: libcap
+  version: '2.75'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    attr: '>=2.5.1,<2.6.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.75-h39aace5_0.conda
+  hash:
+    md5: c44c16d6976d2aebbd65894d7741e67e
+    sha256: 9c84448305e7c9cc44ccec7757cf5afcb5a021f4579aa750a1fa6ea398783950
+  category: main
+  optional: false
 - name: libcblas
   version: 3.9.0
   manager: conda
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-31_h372d94f_mkl.conda
   hash:
-    md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
-    sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
+    md5: 2a06a6c16b45bd3d10002927ca204b67
+    sha256: 2ee3ab2b6eeb59f2d3c6f933fa0db28f1b56f0bc543ed2c0f6ec04060e4b6ec0
   category: main
   optional: false
 - name: libcrc32c
@@ -5881,63 +6080,105 @@ package:
     sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
   category: main
   optional: false
+- name: libcups
+  version: 2.3.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    krb5: '>=1.21.1,<1.22.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<2.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+  hash:
+    md5: d4529f4dff3057982a7617c7ac58fde3
+    sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
+  category: main
+  optional: false
 - name: libcurl
-  version: 8.10.1
+  version: 8.12.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     krb5: '>=1.21.3,<1.22.0a0'
     libgcc: '>=13'
-    libnghttp2: '>=1.58.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
+    libnghttp2: '>=1.64.0,<2.0a0'
+    libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
+    openssl: '>=3.4.1,<4.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.12.1-h332b0f4_0.conda
   hash:
-    md5: 6e801c50a40301f6978c53976917b277
-    sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
+    md5: 45e9dc4e7b25e2841deb392be085500e
+    sha256: 2ebc3039af29269e4cdb858fca36265e5e400c1125a4bcd84ae73a596e0e76ca
+  category: main
+  optional: false
+- name: libdb
+  version: 6.2.32
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.3.0'
+    libstdcxx-ng: '>=9.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdb-6.2.32-h9c3ff4c_0.tar.bz2
+  hash:
+    md5: 3f3258d8f841fbac63b36b75bdac1afd
+    sha256: 21fac1012ff05b131d4b5d284003dbbe7b5c4c652aa9e401b46279ed5a784372
+  category: main
+  optional: false
+- name: libde265
+  version: 1.0.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libde265-1.0.15-h00ab1b0_0.conda
+  hash:
+    md5: 407fee7a5d7ab2dca12c9ca7f62310ad
+    sha256: 7cf7e294e1a7c8219065885e186d8f52002fb900bf384d815f159b5874204e3d
   category: main
   optional: false
 - name: libdeflate
-  version: '1.22'
+  version: '1.23'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.23-h4ddbbb0_0.conda
   hash:
-    md5: b422943d5d772b7cc858b36ad2a92db5
-    sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+    md5: 8dfae1d2e74767e9ce36d5fa0d8605db
+    sha256: 511d801626d02f4247a04fff957cc6e9ec4cc7e8622bd9acd076bcdc5de5fe66
   category: main
   optional: false
 - name: libdrm
-  version: 2.4.123
+  version: 2.4.124
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=13'
+    libgcc: '>=13'
     libpciaccess: '>=0.18,<0.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.124-hb9d3cd8_0.conda
   hash:
-    md5: ee605e794bdc14e2b7f84c4faa0d8c2c
-    sha256: 5f274243fc7480b721a4ed6623c72d07b86a508a1363a85f0f16451ab655ace8
+    md5: 8bc89311041d7fcb510238cf0848ccae
+    sha256: f0d5ffbdf3903a7840184d14c14154b503e1a96767c328f61d99ad24b6963e52
   category: main
   optional: false
 - name: libedit
-  version: 3.1.20191231
+  version: 3.1.20250104
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    ncurses: '>=6.2,<7.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+    ncurses: '>=6.5,<7.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   hash:
-    md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
-    sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+    md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+    sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   category: main
   optional: false
 - name: libegl
@@ -5947,10 +6188,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libglvnd: 1.7.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
   hash:
-    md5: 38a5cd3be5fb620b48069e27285f1a44
-    sha256: e64388e983cf14354b70fe908ca3943f2481ea63df8a4de5e4d418dc2addd38e
+    md5: c151d5eb730e9b7480e6d48c0fc44048
+    sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
   category: main
   optional: false
 - name: libev
@@ -5992,15 +6233,31 @@ package:
   category: main
   optional: false
 - name: libffi
-  version: 3.4.2
+  version: 3.4.6
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_0.conda
   hash:
-    md5: d645c6d2ac96843a2bfaccd2d62b3ac3
-    sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+    md5: e3eb7806380bc8bcecba6d749ad5f026
+    sha256: 67a6c95e33ebc763c1adc3455b9a9ecde901850eb2fceb8e646cc05ef3a663da
+  category: main
+  optional: false
+- name: libflac
+  version: 1.4.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gettext: '>=0.21.1,<1.0a0'
+    libgcc-ng: '>=12'
+    libogg: '>=1.3.4,<1.4.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+  hash:
+    md5: ee48bf17cc83a00f59ca1494d5646869
+    sha256: 65908b75fa7003167b8a8f0001e11e58ed5b1ef5e98b96ab2ba66d7c1b822c7d
   category: main
   optional: false
 - name: libgcc
@@ -6008,12 +6265,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    _libgcc_mutex: '0.1'
+    __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h767d61c_2.conda
   hash:
-    md5: 3cb76c3f10d3bc7f1105b2fc9db984df
-    sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+    md5: ef504d1acbd74b7cc6849ef8af47dd03
+    sha256: 3a572d031cb86deb541d15c1875aaa097baefc0c580b54dc61f5edab99215792
   category: main
   optional: false
 - name: libgcc-devel_linux-64
@@ -6022,10 +6279,10 @@ package:
   platform: linux-64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-h84ea5a7_101.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-hc03c837_102.conda
   hash:
-    md5: 0ce69d40c142915ac9734bc6134e514a
-    sha256: 027cfb011328a108bc44f512a2dec6d954db85709e0b79b748c3392f85de0c64
+    md5: 4c1d6961a6a54f602ae510d9bf31fa60
+    sha256: 538544a2e0651bfeb0348ca6469b6b608606f6080a0b5a531af3a3852fec0215
   category: main
   optional: false
 - name: libgcc-ng
@@ -6034,10 +6291,24 @@ package:
   platform: linux-64
   dependencies:
     libgcc: 14.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_2.conda
   hash:
-    md5: e39480b9ca41323497b05492a63bc35b
-    sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+    md5: a2222a6ada71fb478682efe483ce0f92
+    sha256: fb7558c328b38b2f9d2e412c48da7890e7721ba018d733ebdfea57280df01904
+  category: main
+  optional: false
+- name: libgcrypt-lib
+  version: 1.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgpg-error: '>=1.51,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.0-hb9d3cd8_2.conda
+  hash:
+    md5: e55712ff40a054134d51b89afca57dbc
+    sha256: ffc3602f9298da248786f46b00d0594d26a18feeb1b07ce88f3d7d61075e39e6
   category: main
   optional: false
 - name: libgd
@@ -6046,300 +6317,91 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    fontconfig: '>=2.14.2,<3.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     icu: '>=75.1,<76.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
-    libgcc-ng: '>=12'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.8.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
+    libpng: '>=1.6.45,<1.7.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-hd3e95f3_10.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
   hash:
-    md5: 30ee3a29c84cf7b842a8c5828c4b7c13
-    sha256: b0fa27d4d09fb24750c04e89dbd0aee898dc028bde99e62621065a9bde43efe8
-  category: main
-  optional: false
-- name: libgdal
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgdal-core: 3.9.2.*
-    libgdal-fits: 3.9.2.*
-    libgdal-grib: 3.9.2.*
-    libgdal-hdf4: 3.9.2.*
-    libgdal-hdf5: 3.9.2.*
-    libgdal-jp2openjpeg: 3.9.2.*
-    libgdal-kea: 3.9.2.*
-    libgdal-netcdf: 3.9.2.*
-    libgdal-pdf: 3.9.2.*
-    libgdal-pg: 3.9.2.*
-    libgdal-postgisraster: 3.9.2.*
-    libgdal-tiledb: 3.9.2.*
-    libgdal-xls: 3.9.2.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.2-ha770c72_7.conda
-  hash:
-    md5: 63779711c7afd4fcf9cea67538baa67a
-    sha256: 33ae5aed64c19e3e7e50f0d1bbbd7abfe814687b2a350444c4b2867f81fca9b4
+    md5: 68fc66282364981589ef36868b1a7c78
+    sha256: 19e5be91445db119152217e8e8eec4fd0499d854acc7d8062044fb55a70971cd
   category: main
   optional: false
 - name: libgdal-core
-  version: 3.9.2
+  version: 3.10.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     blosc: '>=1.21.6,<2.0a0'
-    geos: '>=3.13.0,<3.13.1.0a0'
-    geotiff: '>=1.7.3,<1.8.0a0'
+    geos: '>=3.13.1,<3.13.2.0a0'
+    geotiff: '>=1.7.4,<1.8.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
     json-c: '>=0.18,<0.19.0a0'
     lerc: '>=4.0.0,<5.0a0'
-    libarchive: '>=3.7.4,<3.8.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
-    libdeflate: '>=1.22,<1.23.0a0'
-    libexpat: '>=2.6.3,<3.0a0'
+    libarchive: '>=3.7.7,<3.8.0a0'
+    libcurl: '>=8.12.1,<9.0a0'
+    libdeflate: '>=1.23,<1.24.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
     libgcc: '>=13'
-    libiconv: '>=1.17,<2.0a0'
+    libheif: '>=1.19.7,<1.20.0a0'
+    libiconv: '>=1.18,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
-    libpng: '>=1.6.44,<1.7.0a0'
+    liblzma: '>=5.6.4,<6.0a0'
+    libpng: '>=1.6.47,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.46.1,<4.0a0'
+    libsqlite: '>=3.49.1,<4.0a0'
     libstdcxx: '>=13'
     libtiff: '>=4.7.0,<4.8.0a0'
     libuuid: '>=2.38.1,<3.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
+    libxml2: '>=2.13.6,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.3.2,<4.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    openssl: '>=3.4.1,<4.0a0'
     pcre2: '>=10.44,<10.45.0a0'
-    proj: '>=9.5.0,<9.6.0a0'
+    proj: '>=9.6.0,<9.7.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.2-hd5b9bfb_7.conda
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.2-hae73b24_5.conda
   hash:
-    md5: a23eb349d023a8543752566be00b6d88
-    sha256: afff658dece6c8f4dbff2fc459bc834f8491e7ed1a491397e23280cf0917aa19
+    md5: 6e264c86c2e964cdcaa20ec4d10d474c
+    sha256: 43163198406574562e1df59a3289d30033e05cd2f6905c4f2ed81352919e756f
   category: main
   optional: false
-- name: libgdal-fits
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cfitsio: '>=4.4.1,<4.4.2.0a0'
-    libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.2-h2db6552_7.conda
-  hash:
-    md5: 524e64f1aa0ebc87230109e684f392f4
-    sha256: 156ae6b968301cc0ce51c96b60df594569a6df0caab0ac936d2532d09619e2fc
-  category: main
-  optional: false
-- name: libgdal-grib
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libaec: '>=1.1.3,<2.0a0'
-    libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.2-hc3b29a1_7.conda
-  hash:
-    md5: 56a7436a66a1a4636001ce4b621a3a33
-    sha256: 54937f8f0b85b941321324f350a9e1895b772153b70be64539689466899dd9b1
-  category: main
-  optional: false
-- name: libgdal-hdf4
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    libaec: '>=1.1.3,<2.0a0'
-    libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.2-hd5ecb85_7.conda
-  hash:
-    md5: 9c8431dc0b83d5fe9c12a2c0b6861a72
-    sha256: 0b8b77e609b72a51e9548e63c4423222515cd833ab5321eb7f283cf250bb00b5
-  category: main
-  optional: false
-- name: libgdal-hdf5
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.2-h6283f77_7.conda
-  hash:
-    md5: c8c82df3aece4e23804d178a8a8b308a
-    sha256: 0998f51e51086a56871538c803eb4e87eb404862a38ab0109e1dc78705491db2
-  category: main
-  optional: false
-- name: libgdal-jp2openjpeg
-  version: 3.9.2
+- name: libgettextpo
+  version: 0.23.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libstdcxx: '>=13'
-    openjpeg: '>=2.5.2,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.2-h1b2c38e_7.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.23.1-h5888daf_0.conda
   hash:
-    md5: f0f86f8cb8835bb91acb8c7fa2c350b0
-    sha256: 27068921e22565c71cca415211f0185154db3f1d070680790f5c3cc59bb376c7
+    md5: a09ce5decdef385bcce78c32809fa794
+    sha256: 190097140d9c16637aa516757d8087f17e8c22cc844c87288da64404b81ef43c
   category: main
   optional: false
-- name: libgdal-kea
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    kealib: '>=1.5.3,<1.6.0a0'
-    libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libgdal-hdf5: 3.9.2.*
-    libkml: '>=1.3.0,<1.4.0a0'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.2-h1df15e4_7.conda
-  hash:
-    md5: c693e703649051ee9db0fabd4fcd0483
-    sha256: 252d6f9cc3bb2fa2788e73ce5c8a4587f653f9b1f1dc34ecc022ef4aa1b53bf0
-  category: main
-  optional: false
-- name: libgdal-netcdf
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libgdal-hdf4: 3.9.2.*
-    libgdal-hdf5: 3.9.2.*
-    libkml: '>=1.3.0,<1.4.0a0'
-    libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.2-hf2d2f32_7.conda
-  hash:
-    md5: 4015ef020928219acc0b5c9edbce8d30
-    sha256: 58155b0df43b090ed55341c9b24e07047db9b4bd8889309a02180e99c4e69558
-  category: main
-  optional: false
-- name: libgdal-pdf
-  version: 3.9.2
+- name: libgettextpo-devel
+  version: 0.23.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libstdcxx: '>=13'
-    poppler: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.2-h600f43f_7.conda
+    libgettextpo: 0.23.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.23.1-h5888daf_0.conda
   hash:
-    md5: 567066db0820f4983a6741e429c651d1
-    sha256: 10ebe0047d4300152185c095a74a3159fcc3b3d2b0e0bb111381dc7d018cbf65
-  category: main
-  optional: false
-- name: libgdal-pg
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libpq: '>=17.0,<18.0a0'
-    libstdcxx: '>=13'
-    postgresql: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.2-h5e77dd0_7.conda
-  hash:
-    md5: e86b26f53ae868565e95fde5b10753d3
-    sha256: 24bebc7b479dc2373739655a4e8e4142d47d64b37dd5529fdf87dfc2e7586cc4
-  category: main
-  optional: false
-- name: libgdal-postgisraster
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libpq: '>=17.0,<18.0a0'
-    libstdcxx: '>=13'
-    postgresql: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.2-h5e77dd0_7.conda
-  hash:
-    md5: 3392965ffc4e8b7c66a532750ce0e91f
-    sha256: cfa1968d15e1e4ab94c74a426c55795bd2b702bd9e99767cb74633dfba77afbc
-  category: main
-  optional: false
-- name: libgdal-tiledb
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libstdcxx: '>=13'
-    tiledb: '>=2.26.1,<2.27.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.2-h4a3bace_5.conda
-  hash:
-    md5: 4361660d9babee02d729bff61eb50cbe
-    sha256: 87cd6b33baf87a46096d8c03edeb4e93d742a1367c7bfb361198bcf87b627ee8
-  category: main
-  optional: false
-- name: libgdal-xls
-  version: 3.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    freexl: '>=2.0.0,<3.0a0'
-    libgcc: '>=13'
-    libgdal-core: '>=3.9'
-    libkml: '>=1.3.0,<1.4.0a0'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.2-h03c987c_7.conda
-  hash:
-    md5: 165f12373452e8d17889e9c877431acf
-    sha256: 363f00ff7b5295a65e918c5f96bcd8fd3daba09fd8d6563de7b7d266144f86e5
+    md5: 7a5d5c245a6807deab87558e9efd3ef0
+    sha256: 90f29ec7a7e2d758cb61459e643dcb54933dcf92194be6c29b0a1591fcbb163e
   category: main
   optional: false
 - name: libgfortran
@@ -6348,10 +6410,10 @@ package:
   platform: linux-64
   dependencies:
     libgfortran5: 14.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_2.conda
   hash:
-    md5: f1fd30127802683586f768875127a987
-    sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
+    md5: fb54c4ea68b460c278d26eea89cfbcc3
+    sha256: e05263e8960da03c341650f2a3ffa4ccae4e111cb198e8933a2908125459e5a6
   category: main
   optional: false
 - name: libgfortran-ng
@@ -6360,10 +6422,10 @@ package:
   platform: linux-64
   dependencies:
     libgfortran: 14.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_2.conda
   hash:
-    md5: 0a7f4cd238267c88e5d69f7826a407eb
-    sha256: 423f1e2403f0c665748e42d335e421e53fd03c08d457cfb6f360d329d9459851
+    md5: 4056c857af1a99ee50589a941059ec55
+    sha256: 688a5968852e677d2a64974c8869ffb120eac21997ced7d15c599f152ef6857e
   category: main
   optional: false
 - name: libgfortran5
@@ -6371,11 +6433,28 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hf1ad2bd_2.conda
   hash:
-    md5: 9822b874ea29af082e5d36098d25427d
-    sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
+    md5: 556a4fdfac7287d349b8f09aba899693
+    sha256: c17b7cf3073a1f4e1f34d50872934fa326346e104d3c445abc1e62481ad6085c
+  category: main
+  optional: false
+- name: libgirepository
+  version: 1.82.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.0,<2.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.1,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgirepository-1.82.0-h0dcfedc_0.conda
+  hash:
+    md5: 6fa896ca28ec44313f1e2438dcc2fded
+    sha256: 1d3a95887a8ac570f10d6d814723de40d025b73542dcaa52443681e4e5ecd45d
   category: main
   optional: false
 - name: libgl
@@ -6386,10 +6465,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libglvnd: 1.7.0
     libglx: 1.7.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
   hash:
-    md5: 204892bce2e44252b5cf272712f10bdd
-    sha256: 2de573a2231d0ffa13242e274d33b7bae88fb0a178392fd4a03cf803a47e4051
+    md5: 928b8be80851f5d8ffb016f9c81dae7a
+    sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
   category: main
   optional: false
 - name: libglib
@@ -6403,27 +6482,32 @@ package:
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     pcre2: '>=10.44,<10.45.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_1.conda
   hash:
-    md5: 13e8e54035ddd2b91875ba399f0f7c04
-    sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
+    md5: 37d1af619d999ee8f1f73cf5a06f4e2f
+    sha256: f0804a9e46ae7b32ca698d26c1c95aa82a91f71b6051883d4a46bea725be9ea4
   category: main
   optional: false
 - name: libglu
-  version: 9.0.0
+  version: 9.0.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.16,<2.0.0a0'
-    xorg-libx11: '>=1.8.9,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-xextproto: '>=7.3.0,<8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libdrm: '>=2.4.123,<2.5.0a0'
+    libegl: '>=1.7.0,<2.0a0'
+    libgcc: '>=13'
+    libgl: '>=1.7.0,<2.0a0'
+    libstdcxx: '>=13'
+    libxcb: '>=1.17.0,<2.0a0'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxdamage: '>=1.1.6,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxxf86vm: '>=1.1.5,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h03adeef_0.conda
   hash:
-    md5: df069bea331c8486ac21814969301c1f
-    sha256: c4a14878c2be8c18b7e89a19917f0f6c964dd962c91a079fe5e0c6e8b8b1bbd4
+    md5: b1df5affe904efe82ef890826b68881d
+    sha256: cabd78b5ede1f3f161037d3a6cfb6b8a262ec474f9408859c364ef55ba778097
   category: main
   optional: false
 - name: libglvnd
@@ -6432,10 +6516,10 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
   hash:
-    md5: 1ece2ccb1dc8c68639712b05e0fae070
-    sha256: 67942c2b6e4ddb705640b5db962e678f17d8305df5c1633e939cef1158a95058
+    md5: 434ca7e50e40f4918ab701e3facd59a0
+    sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
   category: main
   optional: false
 - name: libglx
@@ -6446,10 +6530,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libglvnd: 1.7.0
     xorg-libx11: '>=1.8.10,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
   hash:
-    md5: 80a57756c545ad11f9847835aa21e6b2
-    sha256: facc239145719034f7b8815d9630032e701d26534dae28303cdbae8b19590a82
+    md5: c8013e438185f33b13814c5c488acd5c
+    sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
   category: main
   optional: false
 - name: libgomp
@@ -6457,34 +6541,34 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    _libgcc_mutex: '0.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
   hash:
-    md5: cc3573974587f12dda90d96e3e55a702
-    sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
+    md5: 06d02030237f4d5b3d9a7e7d348fe3c6
+    sha256: 1a3130e0b9267e781b89399580f3163632d59fe5b0142900d63052ab1a53490e
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.29.0
+  version: 2.35.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libcurl: '>=8.9.1,<9.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
     libgcc: '>=13'
-    libgrpc: '>=1.62.2,<1.63.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libstdcxx: '>=13'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.29.0-h435de7b_0.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.35.0-h2b5623c_0.conda
   hash:
-    md5: 5d95d9040c4319997644f68e9aefbe70
-    sha256: c8ee42a4acce5227d220ec6500f6872d52d82e478c76648b9ff57dd2d86429bd
+    md5: 1040ab07d7af9f23cf2466ffe4e58db1
+    sha256: d747d14c69da512d8993a995dc2df90e857778b0a8542f12fb751544128af685
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 2.29.0
+  version: 2.35.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -6493,34 +6577,68 @@ package:
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
     libgcc: '>=13'
-    libgoogle-cloud: 2.29.0
+    libgoogle-cloud: 2.35.0
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.29.0-h0121fbd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.35.0-h0121fbd_0.conda
   hash:
-    md5: 06dfd5208170b56eee943d9ac674a533
-    sha256: 2847c9e940b742275a7068e0a742bdabf211bf0b2bbb1453592d6afb47c7e17e
+    md5: 34e2243e0428aac6b3e903ef99b6d57d
+    sha256: cb1ef70e55d2c1defbfd8413dbe85b5550782470dda4f8d393f28d41b6d9b007
   category: main
   optional: false
-- name: libgrpc
-  version: 1.62.2
+- name: libgpg-error
+  version: '1.51'
   manager: conda
   platform: linux-64
   dependencies:
-    c-ares: '>=1.28.1,<2.0a0'
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libre2-11: '>=2023.9.1'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.2-h15f2491_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.51-hbd13f7d_1.conda
   hash:
-    md5: 8dabe607748cb3d7002ad73cd06f1325
-    sha256: 28241ed89335871db33cb6010e9ccb2d9e9b6bb444ddf6884f02f0857363c06a
+    md5: 168cc19c031482f83b23c4eebbb94e26
+    sha256: 9e0c09c1faf2151ade3ccb64e52d3c1f2dde85c00e37c6a3e6a8bced2aba68be
+  category: main
+  optional: false
+- name: libgrpc
+  version: 1.67.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    c-ares: '>=1.34.4,<2.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libgcc: '>=13'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+    libre2-11: '>=2024.7.2'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.1,<4.0a0'
+    re2: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-h25350d4_2.conda
+  hash:
+    md5: bfcedaf5f9b003029cc6abe9431f66bf
+    sha256: 675ab892e51614d511317f704564c8c0a8b85e7620948f733eff99800ad25570
+  category: main
+  optional: false
+- name: libheif
+  version: 1.19.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aom: '>=3.9.1,<3.10.0a0'
+    dav1d: '>=1.2.1,<1.2.2.0a0'
+    libavif16: '>=1.2.0,<2.0a0'
+    libde265: '>=1.0.15,<1.0.16.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    x265: '>=3.5,<3.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.19.7-gpl_hc18d805_100.conda
+  hash:
+    md5: 1db2693fa6a50bef58da2df97c5204cb
+    sha256: ec9797d57088aeed7ca4905777d4f3e70a4dbe90853590eef7006b0ab337af3f
   category: main
   optional: false
 - name: libhwloc
@@ -6531,11 +6649,11 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-    libxml2: '>=2.12.7,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_he43201b_1000.conda
+    libxml2: '>=2.13.4,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
   hash:
-    md5: 36247217c4e1018085bd9db41eb3526a
-    sha256: 75be8732e6f94ff2faa129f44ec4970275e1d977559b0c2fb75b7baa5347e16b
+    md5: 804ca9e91bcaea0824a341d55b1684f2
+    sha256: d14c016482e1409ae1c50109a9ff933460a50940d2682e745ab1c172b5282a69
   category: main
   optional: false
 - name: libhwy
@@ -6552,15 +6670,16 @@ package:
   category: main
   optional: false
 - name: libiconv
-  version: '1.17'
+  version: '1.18'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
   hash:
-    md5: d66573916ffcf376178462f1b61c941e
-    sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+    md5: e796ff8ddc598affdf7c173d6145f087
+    sha256: 18a4afe14f731bfb9cf388659994263904d20111e42f841e9eea1bb6f91f4ab4
   category: main
   optional: false
 - name: libjpeg-turbo
@@ -6576,7 +6695,7 @@ package:
   category: main
   optional: false
 - name: libjxl
-  version: 0.11.0
+  version: 0.11.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -6586,10 +6705,10 @@ package:
     libgcc: '>=13'
     libhwy: '>=1.1.0,<1.2.0a0'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.0-hdb8da77_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-hdb8da77_0.conda
   hash:
-    md5: 9c4554fafc94db681543804037e65de2
-    sha256: ea50bc2d3cb87c667decdde55100faca6a9b7c59bd6792690c53950660bbce57
+    md5: 32b23f3487beae7e81495fbc1099ae9e
+    sha256: 0c7c921e182900d65206bef27ef9de491d2b5efe17a5b7a8e200227e123cd826
   category: main
   optional: false
 - name: libkml
@@ -6615,24 +6734,37 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-31_hc41d3b0_mkl.conda
   hash:
-    md5: 4dc03a53fc69371a6158d0ed37214cd3
-    sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
+    md5: 10d012ddd7cc1c7ff9093d4974a34e53
+    sha256: a2d20845d916ac8fba09376cd791136a9b4547afb2131bc315178adfc87bb4ca
   category: main
   optional: false
-- name: libllvm14
-  version: 14.0.6
+- name: liblzma
+  version: 5.6.4
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.4-hb9d3cd8_0.conda
   hash:
-    md5: 73301c133ded2bf71906aa2104edae8b
-    sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
+    md5: 42d5b6a0f30d3c10cd88cb8584fda1cb
+    sha256: cad52e10319ca4585bc37f0bc7cce99ec7c15dc9168e42ccb96b741b0a27db3f
+  category: main
+  optional: false
+- name: liblzma-devel
+  version: 5.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.6.4-hb9d3cd8_0.conda
+  hash:
+    md5: 5ab1a0df19c8f3ec00d5e63458e0a420
+    sha256: 34928b36a3946902196a6786db80c8a4a97f6c9418838d67be90a1388479a682
   category: main
   optional: false
 - name: libnetcdf
@@ -6640,24 +6772,25 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    blosc: '>=1.21.5,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    blosc: '>=1.21.6,<2.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     hdf4: '>=4.2.15,<4.2.16.0a0'
     hdf5: '>=1.14.3,<1.14.4.0a0'
     libaec: '>=1.1.3,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.7,<3.0a0'
-    libzip: '>=1.10.1,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libxml2: '>=2.13.5,<3.0a0'
+    libzip: '>=1.11.2,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     zlib: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h135f659_114.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h00e09a9_116.conda
   hash:
-    md5: a908e463c710bd6b10a9eaa89fdf003c
-    sha256: 055572a4c8a1c3f9ac60071ee678f5ea49cfd7ac60a636d817988a6f9d6de6ae
+    md5: 417864857bdb6c2be2e923e89bffd2e8
+    sha256: 8c389b867452b13e7a2e0cf9c8120e0124a4ac1ab419fab23a565e2659084840
   category: main
   optional: false
 - name: libnghttp2
@@ -6691,242 +6824,273 @@ package:
   category: main
   optional: false
 - name: libntlm
-  version: '1.4'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.4-h7f98852_1002.tar.bz2
-  hash:
-    md5: e728e874159b042d92b90238a3cb0dc2
-    sha256: 63244b73156033ea3b7c2a1581526e79b4670349d64b15f645dcdb12de441d1a
-  category: main
-  optional: false
-- name: libopenblas
-  version: 0.3.28
+  version: '1.8'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libgfortran: ''
-    libgfortran5: '>=14.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
   hash:
-    md5: 62857b389e42b36b686331bec0922050
-    sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
+    md5: 7c7927b404672409d9917d49bff5f2d6
+    sha256: 3b3f19ced060013c2dd99d9d46403be6d319d4601814c772a3472fe2955612b0
+  category: main
+  optional: false
+- name: libogg
+  version: 1.3.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
+  hash:
+    md5: 601bfb4b3c6f0b844443bb81a56651e0
+    sha256: 5eda3fe92b99b25dd4737226a9485078ab405672d9f621be75edcb68f1e9026d
+  category: main
+  optional: false
+- name: libopentelemetry-cpp
+  version: 1.18.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libopentelemetry-cpp-headers: 1.18.0
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    nlohmann_json: ''
+    prometheus-cpp: '>=1.3.0,<1.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.18.0-hfcad708_1.conda
+  hash:
+    md5: 1f5a5d66e77a39dc5bd639ec953705cf
+    sha256: 4ea235e08676f16b0d3c3380befe1478c0fa0141512ee709b011005c55c9619f
+  category: main
+  optional: false
+- name: libopentelemetry-cpp-headers
+  version: 1.18.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.18.0-ha770c72_1.conda
+  hash:
+    md5: 4fb055f57404920a43b147031471e03b
+    sha256: aa1f7dea79ea8513ff77339ba7c6e9cf10dfa537143e7718b1cfb3af52b649f2
   category: main
   optional: false
 - name: libopenvino
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-    pugixml: '>=1.14,<1.15.0a0'
+    pugixml: '>=1.15,<1.16.0a0'
     tbb: '>=2021.13.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.0.0-hdc3f47d_2.conda
   hash:
-    md5: a9048b1af0374fe0b5fa4c25bb8d22ca
-    sha256: 34579cc1ce59efe1560d17e6ec86fe07936b10858d2883f3a66f2bb496163a1b
+    md5: 477a9a5ea9a9c1e74d8ced47f82c3cd8
+    sha256: 2adfd873271fe7399c97861724af5626e566b12cf4d1a3bac0ca91729f18561b
   category: main
   optional: false
 - name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
+    libopenvino: 2025.0.0
     libstdcxx: '>=13'
     tbb: '>=2021.13.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.0.0-h4d9b6c2_2.conda
   hash:
-    md5: 52c847d170f613afb0841c5ec1f87b78
-    sha256: 976a5e703d2d3f94daa3aa9c00a8f47c28b038d20f421bf21114abfd8e0cbf58
+    md5: f97b2fd990ebaa73a613e8c845ac2f6a
+    sha256: 8fe3146d85f3599996b378fc82687921ece07640c610da9cc456ff4d939132af
   category: main
   optional: false
 - name: libopenvino-auto-plugin
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
+    libopenvino: 2025.0.0
     libstdcxx: '>=13'
     tbb: '>=2021.13.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.0.0-h4d9b6c2_2.conda
   hash:
-    md5: f6335f9d947ba550ada90cf101b6232c
-    sha256: 605faab60844c8e044005dc80a4e18e3d6ca98c905d4e6065606a34220bcce0c
+    md5: edbdd0917593321cedd8a232eaab565e
+    sha256: 5730f0350723984a51f19994674d37c133b149f0446361cbce40b4547852b774
   category: main
   optional: false
 - name: libopenvino-hetero-plugin
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
+    libopenvino: 2025.0.0
     libstdcxx: '>=13'
-    pugixml: '>=1.14,<1.15.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_0.conda
+    pugixml: '>=1.15,<1.16.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.0.0-h981d57b_2.conda
   hash:
-    md5: cc7f76fdcc00ecb9aab668b8c956cc8d
-    sha256: af9c55da6c25f921973c9001c8893d643ddad399c8da81342ff2033a297055be
+    md5: 3b1dd8be3f9b8be475771064d94739d4
+    sha256: bc251a8058913e03b401eef72923d158cff056c0f1c58b73ae6e159a906b7c89
   category: main
   optional: false
 - name: libopenvino-intel-cpu-plugin
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
+    libopenvino: 2025.0.0
     libstdcxx: '>=13'
-    pugixml: '>=1.14,<1.15.0a0'
+    pugixml: '>=1.15,<1.16.0a0'
     tbb: '>=2021.13.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.0.0-hdc3f47d_2.conda
   hash:
-    md5: 9b47c0e151ce7e2b6169ab8e3d18f9d8
-    sha256: c8676331577475bd2602a898fed2d4855695723fbb602fa554b34873b694a7ed
+    md5: 9273d8c26337da4dd7e574ce6bea1b79
+    sha256: 28df5321a7e37ea4f290a51c5c9537395798648dfa8eb6cf8ddf5aa062ac0c99
   category: main
   optional: false
 - name: libopenvino-intel-gpu-plugin
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
+    libopenvino: 2025.0.0
     libstdcxx: '>=13'
     ocl-icd: '>=2.3.2,<3.0a0'
-    pugixml: '>=1.14,<1.15.0a0'
+    pugixml: '>=1.15,<1.16.0a0'
     tbb: '>=2021.13.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.0.0-hdc3f47d_2.conda
   hash:
-    md5: 5b85313c114e1e681b5878c4fbf640b3
-    sha256: d37210cbcb345b95ffd246c9b04669beaa31740c57bf1e9ff131588dec2bbafa
+    md5: 64a5bb85f87ca50bcd5d4e405a281a7f
+    sha256: 616d04cab6dc96815fd0e0f41b2341bc372dfb078efce02c4399e82460335878
   category: main
   optional: false
 - name: libopenvino-intel-npu-plugin
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    level-zero: '>=1.21.2,<2.0a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
+    libopenvino: 2025.0.0
     libstdcxx: '>=13'
-    pugixml: '>=1.14,<1.15.0a0'
+    pugixml: '>=1.15,<1.16.0a0'
     tbb: '>=2021.13.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.0.0-hdc3f47d_2.conda
   hash:
-    md5: 2f4a881f43dd916fe71be85848440584
-    sha256: bf74978afa331b27079f0973081c2a1cd3e12ebcee0cc1545b7e400770130879
+    md5: 5013ef62ab2375e7de213a22bd54ff7f
+    sha256: bf0e551566b8ad44f1f9fd2c20c80b5686a6b00a32940bf0abfcabe925260909
   category: main
   optional: false
 - name: libopenvino-ir-frontend
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
+    libopenvino: 2025.0.0
     libstdcxx: '>=13'
-    pugixml: '>=1.14,<1.15.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_0.conda
+    pugixml: '>=1.15,<1.16.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.0.0-h981d57b_2.conda
   hash:
-    md5: e58bb393b3e13eae8c472a962748750f
-    sha256: 4e3391075bb992d6ac686ec276952677b0d176b2ed07a583042eff64dd2976a3
+    md5: e87fa6147e191af584df6a7f8a2727e5
+    sha256: 1c524b913ae568290ffadc079d264f9fe99f3cbbc3454255149b22a61276e9b3
   category: main
   optional: false
 - name: libopenvino-onnx-frontend
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libopenvino: 2025.0.0
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h56242b0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.0.0-h6363af5_2.conda
   hash:
-    md5: bc2d0913d22b2f30e441036542dfc5e9
-    sha256: a119277dff41843d9967c77756d1fcba7e17f7fa65977762d6c32d71214da917
+    md5: 17c9dddf4827e51ea2a63070b40c31ee
+    sha256: a6a623f0ff2083eb6420a948dd76b73007ef47a51855bb72e7b64eb7ebbfd201
   category: main
   optional: false
 - name: libopenvino-paddle-frontend
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libopenvino: 2025.0.0
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h56242b0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.0.0-h6363af5_2.conda
   hash:
-    md5: 9b97741337ad0c7df240498c5bc3e69f
-    sha256: 3c984a74c06720f9eed0cb4e7c4370470f635c8c5e148aac1517cb51b074ac54
+    md5: dd22be48afd66a261010915198d21ebf
+    sha256: 3b0dff7744fe8ba82c3abfc1b690819e84219766d4545effd3629593d0a84b61
   category: main
   optional: false
 - name: libopenvino-pytorch-frontend
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
+    libopenvino: 2025.0.0
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.0.0-h5888daf_2.conda
   hash:
-    md5: 4188f0bb601163c25ed8cd515324358c
-    sha256: 314b476ded8c7de2e42911ad6a5a0957e0ceb8b4d99a99caf552f18e69973dde
+    md5: ee8a2d76a90abe1ecd8cd67bc64c4114
+    sha256: f4c5f5e0fe477785ec6f133ee922ed8bf7887be2d86993cb3945e73ccd566b9b
   category: main
   optional: false
 - name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libopenvino: 2025.0.0
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libstdcxx: '>=13'
     snappy: '>=1.2.1,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h358ae18_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.0.0-h630ec5c_2.conda
   hash:
-    md5: 5fbd3f499da9d147ed5417a6f7e24d83
-    sha256: f348f0d569dfba6c8e7b9bfff16f244da1f26b1f7ce1001245e1fb8b0af1dc6b
+    md5: 9c379f714c3ad449d713296130775838
+    sha256: b46f64ee4067e010882d1bc0d2d914c82daea382c639c170deba02a006077f86
   category: main
   optional: false
 - name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
+  version: 2025.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libopenvino: 2024.4.0
+    libopenvino: 2025.0.0
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.0.0-h5888daf_2.conda
   hash:
-    md5: bffe380c0f0d813bdf7e35445cf11f2a
-    sha256: 6990ea69c92e0f48f3628b753f42919d6201ca1d53c2434750d46b0f7af7b3dd
+    md5: 191d6387b7116a0b07b857b035125f93
+    sha256: ff1c4685fd7f417b8035516dd6002e86451fba5194eee3c321bbdb16a2bc8b10
   category: main
   optional: false
 - name: libopus
@@ -6942,20 +7106,20 @@ package:
   category: main
   optional: false
 - name: libparquet
-  version: 16.1.0
+  version: 19.0.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libarrow: 16.1.0
+    libarrow: 19.0.1
     libgcc: '>=13'
     libstdcxx: '>=13'
-    libthrift: '>=0.20.0,<0.20.1.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-16.1.0-h39682fd_29_cpu.conda
+    libthrift: '>=0.21.0,<0.21.1.0a0'
+    openssl: '>=3.4.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-19.0.1-h081d1f1_0_cpu.conda
   hash:
-    md5: 3fc2cb985cf9b5c3931e907f65bd8926
-    sha256: b02f94949b47df47f1521384ca999a77b94dcfaefbabb8ee63615923b00cdde7
+    md5: 8b58c378d65b213c001f04a174a2a70e
+    sha256: e9c4a07e79886963bfcd05894a15b5d4c7137c1122273de68845315c35d6505d
   category: main
   optional: false
 - name: libpciaccess
@@ -6971,43 +7135,44 @@ package:
   category: main
   optional: false
 - name: libpdal-core
-  version: 2.8.0
+  version: 2.8.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    geotiff: '>=1.7.3,<1.8.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    geotiff: '>=1.7.4,<1.8.0a0'
+    icu: '*'
+    libcurl: '>=8.12.1,<9.0a0'
     libgcc: '>=13'
-    libgdal-core: '>=3.9.2,<3.10.0a0'
+    libgdal-core: '>=3.10.2,<3.11.0a0'
     libstdcxx: '>=13'
-    libxml2: '>=2.12.7,<3.0a0'
+    libxml2: '>=2.13.6,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-    proj: '>=9.5.0,<9.6.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpdal-core-2.8.0-h8f62525_3.conda
+    openssl: '>=3.4.1,<4.0a0'
+    proj: '>=9.6.0,<9.7.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpdal-core-2.8.4-hb03d00e_2.conda
   hash:
-    md5: a9b58e36eee9eda99300339ecfc157d2
-    sha256: d87228b0a5f1de21d15a2e27e2ddcf0ab710d431470784d827c3659732f55200
+    md5: 7dd148d27706d50e075c8822466e3dfc
+    sha256: 8329457b8190220ffa5e7b53e1c5a9824f73f69a8f14b3c9eedbb03ad04c54bc
   category: main
   optional: false
 - name: libpng
-  version: 1.6.44
+  version: 1.6.47
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.47-h943b412_0.conda
   hash:
-    md5: f4cc49d7aa68316213e4b12be35308d1
-    sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+    md5: 55199e2ae2c3651f6f9b2a447b47bdc9
+    sha256: 23367d71da58c9a61c8cbd963fcffb92768d4ae5ffbef9a47cdf1f54f98c5c36
   category: main
   optional: false
 - name: libpq
-  version: '17.0'
+  version: '17.4'
   manager: conda
   platform: linux-64
   dependencies:
@@ -7015,42 +7180,43 @@ package:
     icu: '>=75.1,<76.0a0'
     krb5: '>=1.21.3,<1.22.0a0'
     libgcc: '>=13'
-    openldap: '>=2.6.8,<2.7.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.0-h04577a9_4.conda
+    openldap: '>=2.6.9,<2.7.0a0'
+    openssl: '>=3.4.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.4-h27ae623_0.conda
   hash:
-    md5: 392cae2a58fbcb9db8c2147c6d6d1620
-    sha256: 2f7e72e32f495cfb0492b8091d97dbe1c0700428fe167f3a781bb46e88dee4e5
+    md5: d67f3f3c33344ff3e9ef5270001e9011
+    sha256: 9fe3b323116a47631a9492f33f4d2c147a7f925bcd48c3fe986fdd2cc9ad3a6a
   category: main
   optional: false
 - name: libprotobuf
-  version: 4.25.3
+  version: 5.28.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-hd5b35b9_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
   hash:
-    md5: 06def97690ef90781a91b786cb48a0a9
-    sha256: 8b5e4e31ed93bf36fd14e9cf10cd3af78bb9184d0f1f87878b8d28c0374aa4dc
+    md5: d8703f1ffe5a06356f06467f1d0b9464
+    sha256: 51125ebb8b7152e4a4e69fd2398489c4ec8473195c27cde3cbdf1cb6d18c5493
   category: main
   optional: false
 - name: libre2-11
-  version: 2023.09.01
+  version: 2024.07.02
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_2.conda
   hash:
-    md5: 41c69fba59d495e8cf5ffda48a607e35
-    sha256: 3f3c65fe0e9e328b4c1ebc2b622727cef3e5b81b18228cfa6cf0955bc1ed8eff
+    md5: b2fede24428726dd867611664fb372e8
+    sha256: 4420f8362c71251892ba1eeb957c5e445e4e1596c0c651c28d0d8b415fe120c7
   category: main
   optional: false
 - name: librsvg
@@ -7059,19 +7225,19 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.0,<2.0a0'
+    cairo: '>=1.18.2,<2.0a0'
     freetype: '>=2.12.1,<3.0a0'
     gdk-pixbuf: '>=2.42.12,<3.0a0'
-    harfbuzz: '>=9.0.0,<10.0a0'
+    harfbuzz: '>=10.1.0,<11.0a0'
     libgcc: '>=13'
-    libglib: '>=2.80.3,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    libpng: '>=1.6.44,<1.7.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
     pango: '>=1.54.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
   hash:
-    md5: 83f045969988f5c7a65f3950b95a8b35
-    sha256: fda3197ffb24512e719d55defa02f9f70286038e56cad8c1d580ed6460f417fa
+    md5: b9846db0abffb09847e2cb0fec4b4db6
+    sha256: 475013475a3209c24a82f9e80c545d56ccca2fa04df85952852f3d73caa38ff9
   category: main
   optional: false
 - name: librttopo
@@ -7080,13 +7246,13 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    geos: '>=3.13.0,<3.13.1.0a0'
+    geos: '>=3.13.1,<3.13.2.0a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hd718a1a_18.conda
   hash:
-    md5: e16e9b1333385c502bf915195f421934
-    sha256: 1fb8a71bdbc236b8e74f0475887786735d5fa6f5d76d9a4135021279c7ff54b8
+    md5: 4f40dea96ff9935e7bd48893c24891b9
+    sha256: 394cf4356e0e26c4c95c9681e01e4def77049374ac78b737193e38c1861e8042
   category: main
   optional: false
 - name: libsanitizer
@@ -7094,12 +7260,48 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13.3.0'
     libstdcxx: '>=13.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-heb74ff8_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-he8ea267_2.conda
   hash:
-    md5: c4cb22f270f501f5c59a122dc2adf20a
-    sha256: c86d130f0a3099e46ff51aa7ffaab73cb44fc420d27a96076aab3b9a326fc137
+    md5: 2b6cdf7bb95d3d10ef4e38ce0bc95dba
+    sha256: 27c4c8bf8e2dd60182d47274389be7c70446df6ed5344206266321ee749158b4
+  category: main
+  optional: false
+- name: libsecret
+  version: 0.21.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgcrypt-lib: '>=1.11.0,<2.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsecret-0.21.7-h1e2da66_0.conda
+  hash:
+    md5: 70fc6d1bbf942b3d617646ac0359d9d8
+    sha256: 2f4c634536ee8bccfb9f57b0248ef754d2ad4daa587673b76277cd515a2cbf1c
+  category: main
+  optional: false
+- name: libsndfile
+  version: 1.2.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    lame: '>=3.100,<3.101.0a0'
+    libflac: '>=1.4.3,<1.5.0a0'
+    libgcc-ng: '>=12'
+    libogg: '>=1.3.4,<1.4.0a0'
+    libopus: '>=1.3.1,<2.0a0'
+    libstdcxx-ng: '>=12'
+    libvorbis: '>=1.3.7,<1.4.0a0'
+    mpg123: '>=1.32.1,<1.33.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
+  hash:
+    md5: ef1910918dd895516a769ed36b5b3a4e
+    sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
   category: main
   optional: false
 - name: libsodium
@@ -7121,48 +7323,49 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     freexl: '>=2.0.0,<3.0a0'
-    geos: '>=3.13.0,<3.13.1.0a0'
+    geos: '>=3.13.1,<3.13.2.0a0'
     libgcc: '>=13'
     librttopo: '>=1.1.0,<1.2.0a0'
-    libsqlite: '>=3.46.1,<4.0a0'
+    libsqlite: '>=3.49.1,<4.0a0'
     libstdcxx: '>=13'
-    libxml2: '>=2.12.7,<3.0a0'
+    libxml2: '>=2.13.6,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    proj: '>=9.5.0,<9.6.0a0'
+    proj: '>=9.6.0,<9.7.0a0'
     sqlite: ''
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_11.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-he17ca71_14.conda
   hash:
-    md5: 43a7f3df7d100e8fc280e6636680a870
-    sha256: 11d8537d472c5fc25176fda7af6b9aa47f37ba98d0467b77cb713be18ed847ea
+    md5: d010b5907ed39fdb93eb6180ab925115
+    sha256: 82f7f5f4498a561edf84146bfcff3197e8b2d8796731d354446fc4fd6d058e94
   category: main
   optional: false
 - name: libsqlite
-  version: 3.47.0
+  version: 3.49.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.49.1-hee588c1_2.conda
   hash:
-    md5: b6f02b52a174e612e89548f4663ce56a
-    sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
+    md5: 962d6ac93c30b1dfc54c9cccafd1003e
+    sha256: a086289bf75c33adc1daed3f1422024504ffb5c3c8b3285c49f025c29708ed16
   category: main
   optional: false
 - name: libssh2
-  version: 1.11.0
+  version: 1.11.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
   hash:
-    md5: 1f5a58e686b13bcfde88b93f547d23fe
-    sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+    md5: be2de152d8073ef1c01b7728475f2fe7
+    sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
   category: main
   optional: false
 - name: libstdcxx
@@ -7170,11 +7373,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc: 14.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-h8f9b012_2.conda
   hash:
-    md5: 234a5554c53625688d51062645337328
-    sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
+    md5: a78c856b6dc6bf4ea8daeb9beaaa3fb0
+    sha256: 8f5bd92e4a24e1d35ba015c5252e8f818898478cb3bc50bd8b12ab54707dc4da
   category: main
   optional: false
 - name: libstdcxx-ng
@@ -7183,27 +7387,45 @@ package:
   platform: linux-64
   dependencies:
     libstdcxx: 14.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_2.conda
   hash:
-    md5: 8371ac6457591af2cf6159439c1fd051
-    sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+    md5: c75da67f045c2627f59e6fcb5f4e3a9b
+    sha256: e86f38b007cf97cc2c67cd519f2de12a313c4ee3f5ef11652ad08932a5e34189
+  category: main
+  optional: false
+- name: libsystemd0
+  version: '257.4'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libcap: '>=2.75,<2.76.0a0'
+    libgcc: '>=13'
+    libgcrypt-lib: '>=1.11.0,<2.0a0'
+    liblzma: '>=5.6.4,<6.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.4-h4e0b6ca_1.conda
+  hash:
+    md5: 04bcf3055e51f8dde6fab9672fb9fca0
+    sha256: 5aa2ba63747ad3b6e717f025c9d2ab4bb32c0d366e1ef81669ffa73b1d9af4a2
   category: main
   optional: false
 - name: libthrift
-  version: 0.20.0
+  version: 0.21.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libevent: '>=2.1.12,<2.1.13.0a0'
-    libgcc-ng: '>=13'
-    libstdcxx-ng: '>=13'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.20.0-h0e7cc3e_1.conda
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
   hash:
-    md5: d0ed81c4591775b70384f4cc78e05cd1
-    sha256: 3e70dfda31a3ce28310c86cc0001f20abb78c917502e12c94285a1337fe5b9f0
+    md5: dcb95c0a98ba9ff737f7ae482aef7833
+    sha256: ebb395232973c18745b86c9a399a4725b2c39293c9a91b8e59251be013db42f0
   category: main
   optional: false
 - name: libtiff
@@ -7213,30 +7435,86 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.22,<1.23.0a0'
+    libdeflate: '>=1.23,<1.24.0a0'
     libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
     libstdcxx: '>=13'
     libwebp-base: '>=1.4.0,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hd9ff511_3.conda
   hash:
-    md5: 63872517c98aa305da58a757c443698e
-    sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
+    md5: 0ea6510969e1296cc19966fad481f6de
+    sha256: b224e16b88d76ea95e4af56e2bc638c603bd26a770b98d117d04541d3aafa002
   category: main
   optional: false
-- name: libutf8proc
-  version: 2.8.0
+- name: libudev1
+  version: '257.4'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libcap: '>=2.75,<2.76.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.4-hbe16f8c_1.conda
   hash:
-    md5: ede4266dc02e875fe1ea77b25dd43747
-    sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+    md5: d6716795cd81476ac2f5465f1b1cde75
+    sha256: 56e55a7e7380a980b418c282cb0240b3ac55ab9308800823ff031a9529e2f013
+  category: main
+  optional: false
+- name: libunwind
+  version: 1.6.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.4.0'
+    libstdcxx-ng: '>=9.4.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.6.2-h9c3ff4c_0.tar.bz2
+  hash:
+    md5: a730b2badd586580c5752cc73842e068
+    sha256: f2ac872920833960e514ce9efd8f7c08ce66dd870738d73839d1bce1ac497de6
+  category: main
+  optional: false
+- name: liburing
+  version: '2.9'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.9-h84d6215_0.conda
+  hash:
+    md5: ecd409e7bfcf4ee73f74d7a2cc91a4c3
+    sha256: bfa34a5a929d792dfcfbbe2d9ee21bd870d73d646512e21c871dab0b80194468
+  category: main
+  optional: false
+- name: libusb
+  version: 1.0.28
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libudev1: '>=257.4'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.28-hb9d3cd8_0.conda
+  hash:
+    md5: 7a7bac62e1c9adad991745d23bde0485
+    sha256: 9c718694bb520960f467bd82e7af512c180d6681b8fb7ef25a2401ecf343ac68
+  category: main
+  optional: false
+- name: libutf8proc
+  version: 2.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.10.0-h4c51ac1_0.conda
+  hash:
+    md5: aeccfff2806ae38430638ffbb4be9610
+    sha256: 8e41563ee963bf8ded06da45f4e70bf42f913cb3c2e79364eb3218deffa3cd74
   category: main
   optional: false
 - name: libuuid
@@ -7251,27 +7529,54 @@ package:
     sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   category: main
   optional: false
+- name: libuv
+  version: 1.50.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.50.0-hb9d3cd8_0.conda
+  hash:
+    md5: 771ee65e13bc599b0b62af5359d80169
+    sha256: b4a8890023902aef9f1f33e3e35603ad9c2f16c21fdb58e968fa6c1bd3e94c0b
+  category: main
+  optional: false
 - name: libva
   version: 2.22.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libdrm: '>=2.4.123,<2.5.0a0'
+    libdrm: '>=2.4.124,<2.5.0a0'
     libegl: '>=1.7.0,<2.0a0'
     libgcc: '>=13'
     libgl: '>=1.7.0,<2.0a0'
     libglx: '>=1.7.0,<2.0a0'
-    libxcb: '>=1.16,<2.0.0a0'
+    libxcb: '>=1.17.0,<2.0a0'
     wayland: '>=1.23.1,<2.0a0'
     wayland-protocols: ''
-    xorg-libx11: '>=1.8.9,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxfixes: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
+    xorg-libx11: '>=1.8.11,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h4f16b4b_2.conda
   hash:
-    md5: 139262125a3eac8ff6eef898598745a3
-    sha256: 0bd81019e02cce8d9d4077c96b82ca03c9b0ece67831c7437f977ca1f5a924a3
+    md5: 2c65566e79dc11318ce689c656fb551c
+    sha256: e0df324fb02fa05a05824b8db886b06659432b5cff39495c59e14a37aa23d40f
+  category: main
+  optional: false
+- name: libvorbis
+  version: 1.3.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.3.0'
+    libogg: '>=1.3.4,<1.4.0a0'
+    libstdcxx-ng: '>=9.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
+  hash:
+    md5: 309dec04b70a3cc0f1e84a4013683bc0
+    sha256: 53080d72388a57b3c31ad5805c93a7328e46ff22fab7c44ad2a86d712740af33
   category: main
   optional: false
 - name: libvpx
@@ -7288,15 +7593,16 @@ package:
   category: main
   optional: false
 - name: libwebp-base
-  version: 1.4.0
+  version: 1.5.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.5.0-h851e524_0.conda
   hash:
-    md5: b26e8aa824079e1be0294e7152ca4559
-    sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+    md5: 63f790534398730f59e1b899c3644d4a
+    sha256: c45283fd3e90df5f0bd3dbcd31f59cdd2b001d424cf30a07223655413b158eaf
   category: main
   optional: false
 - name: libxcb
@@ -7327,21 +7633,39 @@ package:
     sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   category: main
   optional: false
+- name: libxkbcommon
+  version: 1.8.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libxcb: '>=1.17.0,<2.0a0'
+    libxml2: '>=2.13.6,<3.0a0'
+    xkeyboard-config: ''
+    xorg-libxau: '>=1.0.12,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.8.1-hc4a0caf_0.conda
+  hash:
+    md5: e7e5b0652227d646b44abdcbd989da7b
+    sha256: 61a282353fcc512b5643ee58898130f5c7f8757c329a21fe407a3ef397d449eb
+  category: main
+  optional: false
 - name: libxml2
-  version: 2.13.4
+  version: 2.13.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     icu: '>=75.1,<76.0a0'
     libgcc: '>=13'
-    libiconv: '>=1.17,<2.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.6.4,<6.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.4-hb346dea_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.6-h8d12d68_0.conda
   hash:
-    md5: 69b90b70c434b916abf5a1d5ee5d55fb
-    sha256: a111cb7f2deb6e20ebb475e8426ce5291451476f55f0dec6c220aa51e5a5784f
+    md5: 328382c0e0ca648e5c189d5ec336c604
+    sha256: db8af71ea9c0ae95b7cb4a0f59319522ed2243942437a1200ceb391493018d85
   category: main
   optional: false
 - name: libxslt
@@ -7404,30 +7728,41 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     uc-micro-py: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_1.conda
   hash:
-    md5: f1b64ca4faf563605cf6f6ca93f9ff3f
-    sha256: aa99d44e8c83865026575a8af253141c53e0b3ab05f053befaa7757c8525064f
+    md5: b02fe519b5dc0dc55e7299810fcdfb8e
+    sha256: d975a2015803d4fdaaae3f53e21f64996577d7a069eb61c6d2792504f16eb57b
+  category: main
+  optional: false
+- name: llvm-openmp
+  version: 20.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-20.1.1-h024ca30_1.conda
+  hash:
+    md5: cfae5693f2ee2117e75e5e533451e04c
+    sha256: 4275d3b10e5c722a9321769e3aee91b9f879e0c527661d90cc38fa6320a9e765
   category: main
   optional: false
 - name: llvmlite
-  version: 0.43.0
+  version: 0.44.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libllvm14: '>=14.0.6,<14.1.0a0'
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py310h1a6248f_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py310h1a6248f_1.conda
   hash:
-    md5: 8153f0ba820cca5bae3101d1bc178d95
-    sha256: 071ce1a0fed522a19990b1cb49cba01d5b03f0e851a1ea0c364622267e32bca1
+    md5: 7ea40d06d6a4a970a449728a806e3308
+    sha256: 47fd93916c73f4f6c3f3c26de517614984537299f8f3c8a4b58933cb28bf4af2
   category: main
   optional: false
 - name: locket
@@ -7443,7 +7778,7 @@ package:
   category: main
   optional: false
 - name: lonboard
-  version: 0.10.3
+  version: 0.10.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -7454,12 +7789,12 @@ package:
     ipywidgets: '>=7.6.0'
     numpy: '>=1.14'
     pyproj: '>=3.3'
-    python: '>=3.8.0,<4.0.0'
+    python: '>=3.9,<4.0.0'
     traitlets: '>=5.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/lonboard-0.10.3-pyh5bfe37b_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/lonboard-0.10.4-pyh80e38bb_0.conda
   hash:
-    md5: 2eae9b142ddbc9a29f353cf9ed28adb7
-    sha256: 80a037d2cc3fc5fa16c07f0e8e7ba2dbe49ad2b50103a02b15f8fe0f85dc746c
+    md5: 963be37fb0de18ab20c5c105af77ee17
+    sha256: d38d8aa7869e31c1623d3d3c9f7d3913a88b2195fe7d70ca903be4b93d5cc9d3
   category: main
   optional: false
 - name: lsprotocol
@@ -7469,29 +7804,29 @@ package:
   dependencies:
     attrs: '>=21.3.0'
     cattrs: '!=23.2.1'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/lsprotocol-2023.0.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/lsprotocol-2023.0.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 9a540725973d27fc0b4101585a8fdfa8
-    sha256: 163564614a24807504dc33a9ddeb470d511f900f62aa84e323d651ef6d26086d
+    md5: b18e46e02cfedac7a70cb063ab37b37c
+    sha256: 5ba1c1b3079a7079e8451795db3b48668a01958cbb3aae92131ca22da298fb40
   category: main
   optional: false
 - name: lxml
-  version: 5.3.0
+  version: 5.3.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libxml2: '>=2.12.7,<3.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
     libxslt: '>=1.1.39,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/lxml-5.3.0-py310h6ee67d5_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/lxml-5.3.1-py310h6ee67d5_0.conda
   hash:
-    md5: 423e016c73ff42c834d11a72c62142e8
-    sha256: e95d092080e39ee762826205a84c5bdb95785fc9ebe6a9063c4713028177d265
+    md5: 7e36d0ccff40ba091baa9af7e08644e0
+    sha256: c1759d4b53ffe4b4757f328fd9272d6746fed13bdccc1a0e9ea1507c3b8ae393
   category: main
   optional: false
 - name: lz4
@@ -7501,26 +7836,27 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py310hb259640_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py310h80b8a69_2.conda
   hash:
-    md5: 7a591c0d64176ea154d53eac3ad7f66d
-    sha256: 432b919e052fd0e0687ae7395f147629ba708457e17e491db1d7a286a83d6f41
+    md5: 2b8aa03bc9deca99d7e5d26ce27bb93d
+    sha256: 7a1807e906846b633e0e2aeba720edf4f98df8d6bb886ddcc091fa0e3a622139
   category: main
   optional: false
 - name: lz4-c
-  version: 1.9.4
+  version: 1.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   hash:
-    md5: 318b08df404f9c9be5712aaa5a6f0bb0
-    sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+    md5: 9de5350a85c4a20c685259b889aa6393
+    sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
   category: main
   optional: false
 - name: lzo
@@ -7536,17 +7872,17 @@ package:
   category: main
   optional: false
 - name: mako
-  version: 1.3.5
+  version: 1.3.9
   manager: conda
   platform: linux-64
   dependencies:
     importlib-metadata: ''
     markupsafe: '>=0.9.2'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.5-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.9-pyhd8ed1ab_0.conda
   hash:
-    md5: 29fddbfa0e2361636a98de4f46ead2ac
-    sha256: f0b982e18e31ad373dd8f22ef5ffa0ae112fc13c573a5eb614814b4081c3ddcb
+    md5: 422113c902cc5181ccaafbb4b827e492
+    sha256: 56ac22e0800b44600662de49f8bc241b2d785820e44d96eebb6eae7e072c8a99
   category: main
   optional: false
 - name: mapclassify
@@ -7560,10 +7896,10 @@ package:
     python: '>=3.9'
     scikit-learn: '>=1.0'
     scipy: '>=1.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.1-pyhd8ed1ab_1.conda
   hash:
-    md5: e75920f936efb86f64517d144d610107
-    sha256: ce49505ac5c1d2d0bab6543b057c7cf698b0135ef92cd0eb151a41ea09d24c8c
+    md5: c48bbb2bcc3f9f46741a7915d67e6839
+    sha256: c498a016b233be5a7defee443733a82d5fe41b83016ca8a136876a64fd15564b
   category: main
   optional: false
 - name: markdown
@@ -7585,11 +7921,11 @@ package:
   platform: linux-64
   dependencies:
     mdurl: '>=0.1,<1'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+    md5: fee3164ac23dfca50cfcc8b85ddefb81
+    sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
   category: main
   optional: false
 - name: markupsafe
@@ -7601,32 +7937,31 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py310h89163eb_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py310h89163eb_1.conda
   hash:
-    md5: 5415555830a54d9b4a1307e3e9d942c7
-    sha256: cd30ab169cf8685a405d5ff65d6b6887603b5d3c9acfc844b5ff5ff09de21213
+    md5: 8ce3f0332fd6de0d737e2911d329523f
+    sha256: 0bed20ec27dcbcaf04f02b2345358e1161fb338f8423a4ada1cf0f4d46918741
   category: main
   optional: false
 - name: mashumaro
-  version: '3.14'
+  version: '3.15'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     typing_extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/mashumaro-3.14-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mashumaro-3.15-pyhd8ed1ab_1.conda
   hash:
-    md5: 5693c50446050456fca1e960182ad531
-    sha256: 25831c3b7a48fde53726980300101214d6a0384dc894ca21c3f855b248036ca9
+    md5: 74892c08f23df6a473b28652f7d07532
+    sha256: 7bb4b40afeb34d2c71b6d3c296a280ea8624980b52dc13d9cb8b72bfeb8fe21a
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.9.2
+  version: 3.10.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    certifi: '>=2020.06.20'
     contourpy: '>=1.0.1'
     cycler: '>=0.10'
     fonttools: '>=4.22.0'
@@ -7643,10 +7978,10 @@ package:
     python_abi: 3.10.*
     qhull: '>=2020.2,<2020.3.0a0'
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py310h68603db_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.1-py310h68603db_0.conda
   hash:
-    md5: 4a8c5dd75815384ddbc3aee99ccd7b50
-    sha256: ae2c9f4999b9f2ccd1c82ac54c17a7782807d4308b40e3366e0ca78444c1e195
+    md5: 29cf3f5959afb841eda926541f26b0fb
+    sha256: f211079f3346a225ba0d1a4754eb856ed3c0bdbf17d6502c55390d22a2c86cb5
   category: main
   optional: false
 - name: matplotlib-inline
@@ -7654,12 +7989,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
   hash:
-    md5: 779345c95648be40d22aaa89de7d4254
-    sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
+    md5: af6ab708897df59bd6e7283ceab1b56b
+    sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
   category: main
   optional: false
 - name: mdit-py-plugins
@@ -7668,11 +8003,11 @@ package:
   platform: linux-64
   dependencies:
     markdown-it-py: '>=1.0.0,<4.0.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 5387f2cfa28f8a3afa3368bb4ba201e8
-    sha256: 5cedc99412278b37e9596f1f991d49f5a1663fe79767cf814a288134a1400ba9
+    md5: af2060041d4f3250a7eb6ab3ec0e549b
+    sha256: c63ed79d9745109c0a70397713b0c07f06e7d3561abcb122cfc80a141ab3b449
   category: main
   optional: false
 - name: mdurl
@@ -7680,11 +8015,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 776a8dd9e824f77abac30e6ef43a8f7a
-    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+    md5: 592132998493b3ff25fd7479396e8351
+    sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
   category: main
   optional: false
 - name: mercantile
@@ -7693,12 +8028,12 @@ package:
   platform: linux-64
   dependencies:
     click: '>=3.0'
-    python: '>=3.6'
+    python: '>=3.9'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: aa20d014b5bd1924727dd86467648a27
-    sha256: 372275c3b0b0e5028cd25a87a23b23311b3412e556f8ee1768473e7634fb94ea
+    md5: 9820756deea38bd213240fd0556d44b8
+    sha256: 42ab9a82c4e4686d7c2a2d511877895bfe946ec2c2ec66e4e1593006fa32445f
   category: main
   optional: false
 - name: metpy
@@ -7717,10 +8052,10 @@ package:
     scipy: '>=1.8.0'
     traitlets: '>=5.0.5'
     xarray: '>=0.21.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/metpy-1.6.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/metpy-1.6.3-pyhd8ed1ab_1.conda
   hash:
-    md5: b529da163f23310ceb4e7a9fb5c4d41a
-    sha256: eaaa89d93c1e0d1f18377b0be73141f8edace3fafd1a6ce1a0b466aa45839abf
+    md5: 1edcfa210aeb3d5bba4331fe940f1f53
+    sha256: c980aeb0d144ae0ceb03640ddb33645bf1137f28db1303d75bd277f397844d34
   category: main
   optional: false
 - name: minizip
@@ -7728,75 +8063,108 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     libiconv: '>=1.17,<2.0a0'
-    libstdcxx-ng: '>=12'
+    liblzma: '>=5.6.3,<6.0a0'
+    libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    xz: '>=5.2.6,<6.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h05a5f5f_3.conda
   hash:
-    md5: 4474532a312b2245c5c77f1176989b46
-    sha256: 6315ea87d094418e744deb79a22331718b36a0e6e107cd7fc3c52c7922bc8133
+    md5: eec77634ccdb2ba6c231290c399b1dae
+    sha256: 9a9459024e9cdc68c799b057de021b8c652de542e24e9e48f2726578e822659c
   category: main
   optional: false
 - name: mistune
-  version: 3.0.2
+  version: 3.1.3
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
+    python: ''
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.1.3-pyh29332c3_0.conda
   hash:
-    md5: 5cbee699846772cc939bef23a0d524ed
-    sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
+    md5: 7ec6576e328bc128f4982cd646eeba85
+    sha256: a67484d7dd11e815a81786580f18b6e4aa2392f292f29183631a6eccc8dc37b3
+  category: main
+  optional: false
+- name: mkl
+  version: 2024.2.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _openmp_mutex: '>=4.5'
+    llvm-openmp: '>=19.1.2'
+    tbb: 2021.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha957f24_16.conda
+  hash:
+    md5: 1459379c79dda834673426504d52b319
+    sha256: 77906b0acead8f86b489da46f53916e624897338770dbf70b04b8f673c9273c1
   category: main
   optional: false
 - name: morecantile
-  version: 5.4.2
+  version: 6.2.0
   manager: conda
   platform: linux-64
   dependencies:
     attrs: ''
     pydantic: '>=2.0,<3.dev0'
-    pyproj: '>=3.1,<4.dev0'
-    python: '>=3.8'
+    pyproj: '>=3.1,<4.0'
+    python: '>=3.9'
     rasterio: '>=1.2.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/morecantile-5.4.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/morecantile-6.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f82cc3bfe46ec4fc363541d849d1ab67
-    sha256: f42c7d68e22ab04a9c24c354252e8d33fd10df3b3c1736013e54b3a9c92c9c91
+    md5: 8f5d0fb247a13654ef6ae3787bf7bf2b
+    sha256: af29f2603e3ed781a00ff50918f4199d2e3cf65a52a96892572b1bdfd3c25cc2
+  category: main
+  optional: false
+- name: mpg123
+  version: 1.32.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
+  hash:
+    md5: c7f302fd11eeb0987a6a5e1f3aed6a21
+    sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
   category: main
   optional: false
 - name: msal
-  version: 1.31.0
+  version: 1.32.0
   manager: conda
   platform: linux-64
   dependencies:
-    cryptography: <46,>=2.5
+    cryptography: <47,>=2.5
     pyjwt: <3,>=1.0.0
-    python: '>=3.6'
+    python: '>=3.9'
     requests: <3,>=2.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/msal-1.31.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/msal-1.32.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 29423703af5f8e9f7b5da824d83ec510
-    sha256: dcac9d2936aa21b2cc8b1985ee1fe13f2d34ebb4d6985712546526d7fc04abcb
+    md5: 47ae677eed99b0a0665bd767c25edb3d
+    sha256: 2e952dc02656ea86417921825aee8533a421e850e06887a9fa0e7939359d2036
   category: main
   optional: false
 - name: msal_extensions
-  version: 0.3.0
+  version: 1.3.1
   manager: conda
   platform: linux-64
   dependencies:
-    msal: '>=0.4.1,<2.0'
-    portalocker: ''
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/msal_extensions-0.3.0-pyh9f0ad1d_0.tar.bz2
+    libsecret: ''
+    msal: '>=1.29,<2'
+    portalocker: '>=1.6,<4'
+    pygobject: '>=3,<4'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/msal_extensions-1.3.1-py310hff52083_0.conda
   hash:
-    md5: 16db5a64c15c19dfae97f1d5695f4da9
-    sha256: fda4c3460d88b7063e6267682f77a1239e9b60aa79bd0c51ad336ae951fa44ec
+    md5: 286f81ad788b5d2d768698e500dc768d
+    sha256: 1b7f20429517473a4362cfadd6d22cf535ca66eb66bed583de90f8543a3cea73
   category: main
   optional: false
 - name: msgpack-python
@@ -7823,13 +8191,13 @@ package:
     azure-core: '>=1.24.0'
     certifi: '>=2017.4.17'
     isodate: '>=0.6.0'
-    python: '>=3.6'
+    python: '>=3.9'
     requests: '>=2.16,<3.dev0'
     requests-oauthlib: '>=0.5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/msrest-0.7.1-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/msrest-0.7.1-pyhd8ed1ab_1.conda
   hash:
-    md5: a1733821b05a030e805e9a47e48df636
-    sha256: 0541d8d56be3125551eebafe05e9a851847a1140ed7e8d7f8db393a1e28b0980
+    md5: 02344060de75f60dbd3400d64613db54
+    sha256: 36899026a1f3d3f718341f26f9a0f8fa1470f3653f9fd3a3c9e66bffe8ef9421
   category: main
   optional: false
 - name: msrestazure
@@ -7839,16 +8207,16 @@ package:
   dependencies:
     adal: '>=0.6.0,<2.0.0'
     msrest: '>=0.6.0,<2.0.0'
-    python: '>=3.6'
+    python: '>=3.9'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/msrestazure-0.6.4-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/msrestazure-0.6.4-pyhd8ed1ab_1.conda
   hash:
-    md5: b916ba380f3ce164ad27767cdbcf594c
-    sha256: b769f08ad6ff9316a973b8d0a960882fe5a54be8860f0492599c518884b1e069
+    md5: 3998dc5d1d6df738ae1ec85b2d9b8233
+    sha256: 88b3b7478a3d33a25ea99cfb0cd5354966d03e405a0f2cec46246c4b7c1439f2
   category: main
   optional: false
 - name: multidict
-  version: 6.1.0
+  version: 6.2.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -7857,10 +8225,10 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.1.0-py310h89163eb_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.2.0-py310h89163eb_0.conda
   hash:
-    md5: 4e13be3228db4b8e1349483e821b6046
-    sha256: 5794cca253193a283e5818f3264b31946a0e0761df469d9b8623eba4f482269f
+    md5: b58e297cc037aba6f32edef76fd0e49a
+    sha256: dc678195b6d5e3beae5a0df107bcc310ecc7e93e0ac9d67b57ee9eb729090760
   category: main
   optional: false
 - name: multipledispatch
@@ -7893,11 +8261,23 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
   hash:
-    md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-    sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+    md5: 29097e7ea634a45cc5386b95cac6568f
+    sha256: 1895f47b7d68581a6facde5cb13ab8c2764c2e53a76bd746f8f98910dc4e08fe
+  category: main
+  optional: false
+- name: narwhals
+  version: 1.32.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.32.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: fd49dbbf238fc97ff41a42df6afc94b8
+    sha256: df82a457ed87bc5bf6d3d806480ca19b98cef1a801254b73e7f89c4b91a3be3e
   category: main
   optional: false
 - name: nb_conda_kernels
@@ -7918,7 +8298,7 @@ package:
   category: main
   optional: false
 - name: nbclient
-  version: 0.10.0
+  version: 0.10.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -7927,64 +8307,63 @@ package:
     nbformat: '>=5.1'
     python: '>=3.8'
     traitlets: '>=5.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 15b51397e0fe8ea7d7da60d83eb76ebc
-    sha256: 589d72d36d61a23b39d6fff2c488f93e29e20de4fc6f5d315b5f2c16e81028bf
+    md5: 6bb0d77277061742744176ab555b723c
+    sha256: a20cff739d66c2f89f413e4ba4c6f6b59c50d5c30b5f0d840c13e8c9c2df9135
   category: main
   optional: false
 - name: nbconvert
-  version: 7.16.4
+  version: 7.16.6
   manager: conda
   platform: linux-64
   dependencies:
-    nbconvert-core: 7.16.4
-    nbconvert-pandoc: 7.16.4
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.4-hd8ed1ab_1.conda
+    nbconvert-core: ==7.16.6
+    nbconvert-pandoc: ==7.16.6
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.6-hb482800_0.conda
   hash:
-    md5: ab83e3b9ca2b111d8f332e9dc8b2170f
-    sha256: e014e8a583ca2f2fc751bf9093ee95bfd203bd189bafe0f512c0262fece69bce
+    md5: aa90ea40c80d4bd3da35cb17ed668f22
+    sha256: 5480b7e05bf3079fcb7357a5a15a96c3a1649cc1371d0c468c806898a7e53088
   category: main
   optional: false
 - name: nbconvert-core
-  version: 7.16.4
+  version: 7.16.6
   manager: conda
   platform: linux-64
   dependencies:
     beautifulsoup4: ''
-    bleach: ''
+    bleach-with-css: '!=5.0.0'
     defusedxml: ''
-    entrypoints: '>=0.2.2'
+    importlib-metadata: '>=3.6'
     jinja2: '>=3.0'
     jupyter_core: '>=4.7'
     jupyterlab_pygments: ''
     markupsafe: '>=2.0'
     mistune: '>=2.0.3,<4'
     nbclient: '>=0.5.0'
-    nbformat: '>=5.1'
+    nbformat: '>=5.7'
     packaging: ''
     pandocfilters: '>=1.4.1'
     pygments: '>=2.4.1'
-    python: '>=3.8'
-    tinycss2: ''
-    traitlets: '>=5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+    python: ''
+    traitlets: '>=5.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
   hash:
-    md5: e2d2abb421c13456a9a9f80272fdf543
-    sha256: 074d858c5808e0a832acc0da37cd70de1565e8d6e17a62d5a11b3902b5e78319
+    md5: d24beda1d30748afcc87c429454ece1b
+    sha256: dcccb07c5a1acb7dc8be94330e62d54754c0e9c9cb2bb6865c8e3cfe44cf5a58
   category: main
   optional: false
 - name: nbconvert-pandoc
-  version: 7.16.4
+  version: 7.16.6
   manager: conda
   platform: linux-64
   dependencies:
-    nbconvert-core: 7.16.4
+    nbconvert-core: ==7.16.6
     pandoc: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.4-hd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.6-hed9df3c_0.conda
   hash:
-    md5: 37cec2cf68f4c09563d8bc833791096b
-    sha256: 31df882e97b227e7e57a328a36840e65ea3247023ac2ce502fd5d4b621da8dbe
+    md5: 5b0afb6c52e74a7eca2cf809a874acf4
+    sha256: 1e8923f1557c2ddb7bba915033cfaf8b8c1b7462c745172458102c11caee1002
   category: main
   optional: false
 - name: nbdime
@@ -7999,13 +8378,13 @@ package:
     jupyter_server: ''
     nbformat: ''
     pygments: ''
-    python: '>=3.6'
+    python: '>=3.9'
     requests: ''
     tornado: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nbdime-4.0.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbdime-4.0.2-pyhd8ed1ab_1.conda
   hash:
-    md5: c85813ae6abbeeddecf9ecf544f052bc
-    sha256: 9d63129f787ddf1deb8b37f328d3293a5ebfc18e9b7ed80c538fecf07f820d65
+    md5: 5217ed230c497fb71f7bb2de6d7eb27b
+    sha256: 5e75c2d71edda0ef0fdf48080e24c8570bf8b4de581a6a3c4d7e6a4a07535c95
   category: main
   optional: false
 - name: nbformat
@@ -8015,13 +8394,13 @@ package:
   dependencies:
     jsonschema: '>=2.6'
     jupyter_core: '>=4.12,!=5.0.*'
-    python: '>=3.8'
+    python: '>=3.9'
     python-fastjsonschema: '>=2.15'
     traitlets: '>=5.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 0b57b5368ab7fc7cdc9e3511fa867214
-    sha256: 36fe73da4d37bc7ac2d1540526ecd294fbd09acda04e096181ab8f1ccd2b464c
+    md5: bbe1963f1e47f594070ffe87cdf612ea
+    sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
   category: main
   optional: false
 - name: nbgitpuller
@@ -8031,25 +8410,25 @@ package:
   dependencies:
     jupyter_server: '>=1.10.1'
     notebook: '>=5.5.0'
-    python: '>=3'
+    python: '>=3.9'
     tornado: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nbgitpuller-1.2.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbgitpuller-1.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 73abf90c19790f8d6c600b0aa152c932
-    sha256: c499912bcbfd47487bb070658a9a3cf374828a3a0e6a2b435117ff6c215ab67d
+    md5: ae6581ab88e9650cae4e8d1bbdccc31f
+    sha256: 3bb49c1dc6845f0fbf4f4e6539b602ab52ccf3ca4896cae5b05a1bfd73cb5346
   category: main
   optional: false
 - name: nbstripout
-  version: 0.8.0
+  version: 0.8.1
   manager: conda
   platform: linux-64
   dependencies:
     nbformat: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbstripout-0.8.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbstripout-0.8.1-pyhd8ed1ab_0.conda
   hash:
-    md5: edd632193c642ebcda0894e7bfca5855
-    sha256: c1ca6eed682ddc1c0f7ef210f5d57a3bd527452e4d01340584ce3245c18c44c2
+    md5: 35e9b8d735ce9ee57686ec48556b1e51
+    sha256: 45e7972348924fe5fe6bddf3b72ec79b679e4dfee1c1731d4fd9692fba13ceb4
   category: main
   optional: false
 - name: nc-time-axis
@@ -8060,11 +8439,11 @@ package:
     cftime: '>=1.5'
     matplotlib-base: ''
     numpy: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/nc-time-axis-1.4.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/nc-time-axis-1.4.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 281b58948bf60a2582de9e548bcc5369
-    sha256: 345d51b39f603a6717e43a998adaac35764467a4cf2bfec8f1963b9a7ced2a36
+    md5: 9a2be7d0089f5934b550933ca0d9fe85
+    sha256: 59c43a84c80b1e9b9271fb73c495591004e243f1ee2b1dbe79f90685d2579e6f
   category: main
   optional: false
 - name: ncurses
@@ -8073,11 +8452,11 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
   hash:
-    md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
-    sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+    md5: 47e340acb35de30501a76c7c799c41d7
+    sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
   category: main
   optional: false
 - name: nest-asyncio
@@ -8085,11 +8464,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 6598c056f64dc8800d40add25e4e2c34
-    sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
+    md5: 598fd7d4d0de2455fb74f56063969a97
+    sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
   category: main
   optional: false
 - name: netcdf-fortran
@@ -8103,14 +8482,14 @@ package:
     libgfortran: ''
     libgfortran5: '>=13.3.0'
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.1-nompi_h22f9119_106.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.1-nompi_h22f9119_108.conda
   hash:
-    md5: 5b911bfe75855326bae6857451268e59
-    sha256: 4b64d3ca275be7a791b0de65459d230a8651813f2834127962da630ed3f11cdd
+    md5: 0967d692b1dd33e7d809cfa355090e4b
+    sha256: cc3c57eeede6fde7c8edbfc02ee820b320a6a6df16356105820d0575cc0b12b7
   category: main
   optional: false
 - name: netcdf4
-  version: 1.7.1
+  version: 1.7.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -8124,11 +8503,10 @@ package:
     numpy: '>=1.19,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.1-nompi_py310h9f0ad05_102.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.2-nompi_py310h9f0ad05_101.conda
   hash:
-    md5: fafb8cd70d84eab5df8d03a432890474
-    sha256: 61df40834f8012f19f96503b5842b92ea58b0a9b515ae56e6a7ee219cc52def6
+    md5: f58947ff305aa8be0b33769ee67ddb10
+    sha256: fcc97784b0dd7eac17d3fe65d5f16efca369ac01b1e05bbbfffc1659cf2f2862
   category: main
   optional: false
 - name: networkx
@@ -8136,22 +8514,25 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.4.2-pyhd8ed1ab_1.conda
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.4.2-pyh267e887_2.conda
   hash:
-    md5: 1d4c088869f206413c59acdd309908b7
-    sha256: ad3ac7c22d4f68a5a50ae584ae259af91fbf96f688bf2955750bbdb61bb88fc1
+    md5: fd40bf7f7f4bc4b647dc8512053d9873
+    sha256: 39625cd0c9747fa5c46a9a90683b8997d8b9649881b3dc88336b13b7bdd60117
   category: main
   optional: false
-- name: nomkl
-  version: '1.0'
+- name: nlohmann_json
+  version: 3.11.3
   manager: conda
   platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.11.3-he02047a_1.conda
   hash:
-    md5: 9a66894dfd07c4510beb6b3f9672ccc0
-    sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+    md5: e46f7ac4917215b49df2ea09a694a3fa
+    sha256: ce4bcced4f8eea71b7cac8bc3daac097abf7a5792f278cd811dedada199500c1
   category: main
   optional: false
 - name: notebook
@@ -8177,60 +8558,30 @@ package:
   platform: linux-64
   dependencies:
     jupyter_server: '>=1.8,<3'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 3d85618e2c97ab896b5b5e298d32b5b3
-    sha256: 9b5fdef9ebe89222baa9da2796ebe7bc02ec6c5a1f61327b651d6b92cf9a0230
-  category: main
-  optional: false
-- name: nspr
-  version: '4.36'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
-  hash:
-    md5: de9cd5bca9e4918527b9b72b6e2e1409
-    sha256: a87471d9265a7c02a98c20debac8b13afd80963968ed7b1c1c2ac7b80955ce31
-  category: main
-  optional: false
-- name: nss
-  version: '3.106'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libsqlite: '>=3.47.0,<4.0a0'
-    libstdcxx: '>=13'
-    libzlib: '>=1.3.1,<2.0a0'
-    nspr: '>=4.36,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.106-hdf54f9c_0.conda
-  hash:
-    md5: efe735c7dc47dddbb14b3433d11c6feb
-    sha256: e5dd3e57498decdef87ff641fa6b7bd5484fce3f2783811ee5ec278bc9e71281
+    md5: e7f89ea5f7ea9401642758ff50a2d9c1
+    sha256: 7b920e46b9f7a2d2aa6434222e5c8d739021dbc5cc75f32d124a8191d86f9056
   category: main
   optional: false
 - name: numba
-  version: 0.60.0
+  version: 0.61.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    llvmlite: '>=0.43.0,<0.44.0a0'
-    numpy: '>=1.22.3,<2.1'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    llvmlite: '>=0.44.0,<0.45.0a0'
+    numpy: '>=1.24,<2.2'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py310h5dc88bb_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.61.0-py310h699fe88_1.conda
   hash:
-    md5: 73e2e2c0ffad216572ce01952ff0099c
-    sha256: c76c5baa087c2be3374bdb5eee37caf0c70f390c02a48aeb5e4337b600e5e319
+    md5: 73bf45d299c017a67dd8fffab92bcaaa
+    sha256: 2be5e6ad0ffbc0781ab4241bf9ae759e0af6679d4a9e084ed671cef3cacc899d
   category: main
   optional: false
 - name: numcodecs
@@ -8252,21 +8603,22 @@ package:
   category: main
   optional: false
 - name: numexpr
-  version: 2.10.1
+  version: 2.10.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    libblas: '*'
     libgcc: '>=13'
     libstdcxx: '>=13'
-    nomkl: ''
+    mkl: '>=2024.2.2,<2025.0a0'
     numpy: '>=1.23.0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.1-py310hdb6e06b_103.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-mkl_py310ha004913_0.conda
   hash:
-    md5: 6ee9efbd4fcfb1186cf125892d3e9bff
-    sha256: 6c664d884f5bfd3aff2c5c6774e4a78146ebe86bcdf432cda214711d17797c93
+    md5: e905a0e5ba59456270021cf4e48c8d4c
+    sha256: d2858c67634376862000b832f27b2c7259c4d8aae6d07bcf167fb502aa7d27cb
   category: main
   optional: false
 - name: numpy
@@ -8294,10 +8646,10 @@ package:
   dependencies:
     numpy: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/numpy_groupies-0.11.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/numpy_groupies-0.11.2-pyhd8ed1ab_1.conda
   hash:
-    md5: f089393c03e9f3a28ac4f77eb775e17e
-    sha256: b042997131c5df079c904aee84d124ee7ede799f9bdbf720eda6d7d0a43a399a
+    md5: 7ec5afe3dc4c585abd49bb40edc96428
+    sha256: bc453d60a0eff86f500a0c114fe3996543731b019e5998e664347d2ab52ee880
   category: main
   optional: false
 - name: oauthlib
@@ -8308,23 +8660,11 @@ package:
     blinker: ''
     cryptography: ''
     pyjwt: '>=1.0.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.2.2-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.2.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 8f882b197fd9c4941a787926baea4868
-    sha256: 0cfd5146a91d3974f4abfc2a45de890371d510a77238fe553e036ec8c031dc5b
-  category: main
-  optional: false
-- name: objsize
-  version: 0.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/objsize-0.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1db3bf71afb94cb0f37dd4a5b8d99d35
-    sha256: 5472c5b47dbe7f70f4f37f3e9c0ac3bf82cffc26c6cce0edd9c9b49e9c7f8a9b
+    md5: bf5f2c90d503d43a8c45cedf766b4b8e
+    sha256: bec65607d36759e85aab2331ff7f056cb32be0bca92ee2b955aea3306330bd1b
   category: main
   optional: false
 - name: ocl-icd
@@ -8332,11 +8672,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    opencl-headers: '>=2024.10.24'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hb9d3cd8_2.conda
   hash:
-    md5: c66f837ac65e4d1cdeb80e2a1d5fcc3d
-    sha256: 0e01384423e48e5011eb6b224da8dc5e3567c87dbcefbe60cd9d5cead276cdcd
+    md5: 2e8d2b469559d6b2cb6fd4b34f9c8d7f
+    sha256: 96ddd13054032fabd54636f634d50bc74d10d8578bc946405c429b2d895db6f2
   category: main
   optional: false
 - name: odc-algo
@@ -8351,19 +8693,19 @@ package:
     distributed: ''
     numexpr: ''
     numpy: ''
-    python: '>=3.6'
+    python: '>=3.9'
     rasterio: '>=1.3.2'
     scikit-image: ''
     toolz: ''
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/odc-algo-0.2.3-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/odc-algo-0.2.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 412ad839091a2eef9b8f722a2a85cf8a
-    sha256: e7465976c86acaf0d57088ea9cb74abf614a22e23cf25db671a6898a6a9a309b
+    md5: 4a9c3c0d98cbe6ebf7f70461c16b92c6
+    sha256: 6f72079e7e151d70d8e894f6783207fbcc3e6dab600c3e732d987d4fc6d124f7
   category: main
   optional: false
 - name: odc-geo
-  version: 0.4.8
+  version: 0.4.10
   manager: conda
   platform: linux-64
   dependencies:
@@ -8371,17 +8713,17 @@ package:
     cachetools: ''
     numpy: ''
     pyproj: '>=3.0.0'
-    python: '>=3.8'
+    python: '>=3.9'
     shapely: ''
     xarray: '>=0.19'
-  url: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.10-pyhd8ed1ab_0.conda
   hash:
-    md5: abb44a416828ea4c77f53c512cbf46b1
-    sha256: 3d3c46618815efb7bd8bf73b974f300296ff260158b1f203069785474723818c
+    md5: 738e667a33308567f62981e864582d6d
+    sha256: ac055707d73d2d2a19075d8c4faef26473680f6ae51ac4a584c5ab4451a37f30
   category: main
   optional: false
 - name: odc-stac
-  version: 0.3.10
+  version: 0.3.11
   manager: conda
   platform: linux-64
   dependencies:
@@ -8391,97 +8733,128 @@ package:
     odc-geo: '>=0.4.7'
     pandas: ''
     pystac: '>=1.0.0,<2'
-    python: '>=3.8'
+    python: '>=3.9'
     rasterio: '>=1.0.0,!=1.3.0,!=1.3.1'
     toolz: ''
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/odc-stac-0.3.10-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/odc-stac-0.3.11-pyhd8ed1ab_0.conda
   hash:
-    md5: a24c95f14971ce95b6acdea9f9e4be12
-    sha256: 0bd8010e1010bfaeb34dd94f122b66b3455c47193f217c1c05e221177bdc7c48
+    md5: 4fc9e27240d58be65f4d82d9e0ffa029
+    sha256: beeb76af73beaeaa01b55e0c4f668cf49dfe6313e3f26ea96b8ffa0f90a4d794
+  category: main
+  optional: false
+- name: opencl-headers
+  version: 2024.10.24
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2024.10.24-h5888daf_0.conda
+  hash:
+    md5: 3ba02cce423fdac1a8582bd6bb189359
+    sha256: 7e1d3ad55d4ad3ddf826e205d4603b9ed40c5e655a9dfd66b56f459d7ba14db3
   category: main
   optional: false
 - name: openh264
-  version: 2.4.1
+  version: 2.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
   hash:
-    md5: 3dfcf61b8e78af08110f5229f79580af
-    sha256: 0d4eaf15fb771f25c924aef831d76eea11d90c824778fc1e7666346e93475f42
+    md5: b28cf020fd2dead0ca6d113608683842
+    sha256: 3f231f2747a37a58471c82a9a8a80d92b7fece9f3fce10901a5ac888ce00b747
   category: main
   optional: false
 - name: openjpeg
-  version: 2.5.2
+  version: 2.5.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.8.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libpng: '>=1.6.44,<1.7.0a0'
+    libstdcxx: '>=13'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
   hash:
-    md5: 7f2e286780f072ed750df46dc2631138
-    sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+    md5: 9e5816bc95d285c115a3ebc2f8563564
+    sha256: 5bee706ea5ba453ed7fd9da7da8380dd88b865c8d30b5aaec14d2b6dd32dbc39
   category: main
   optional: false
 - name: openldap
-  version: 2.6.8
+  version: 2.6.9
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cyrus-sasl: '>=2.1.27,<3.0a0'
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.3.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.8-hedd0468_0.conda
+    krb5: '>=1.21.3,<1.22.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.9-he970967_0.conda
   hash:
-    md5: dcd0ed5147d8876b0848a552b416ce76
-    sha256: 902652f7a106caa6ea9db2c44118078e23a499bf091ce8ea01d8498c156e8219
+    md5: ca2de8bbdc871bce41dbf59e51324165
+    sha256: 224f458848f792fe9e3587ee6b626d4eaad63aead0e5e6c25cbe29aba7b05c53
   category: main
   optional: false
 - name: openssl
-  version: 3.3.2
+  version: 3.4.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     ca-certificates: ''
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.1-h7b32b05_0.conda
   hash:
-    md5: 4d638782050ab6faa27275bed57e9b4e
-    sha256: cee91036686419f6dd6086902acf7142b4916e1c4ba042e9ca23e151da012b6d
+    md5: 41adf927e746dc75ecf0ef841c454e48
+    sha256: cbf62df3c79a5c2d113247ddea5658e9ff3697b6e741c210656e239ecaf1768f
+  category: main
+  optional: false
+- name: opentelemetry-api
+  version: 1.31.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    deprecated: '>=1.2.6'
+    importlib-metadata: <8.7.0,>=6.0
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-api-1.31.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 24c4e27988a95d32e89a02a2c35b4a72
+    sha256: cd384f9b810173a727f1593bb9813be050d01acd668e48b50ce2e453f5de791a
   category: main
   optional: false
 - name: orc
-  version: 2.0.2
+  version: 2.0.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
+    libgcc: '>=13'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+    libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-h669347b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-h12ee42a_2.conda
   hash:
-    md5: 1e6c10f7d749a490612404efeb179eb8
-    sha256: 8a126e0be7f87c499f0a9b5229efa4321e60fc4ae46abdec9b13240631cb1746
+    md5: 4f6f9f3f80354ad185e276c120eac3f0
+    sha256: dff5cc8023905782c86b3459055f26d4b97890e403b0698477c9fed15d8669cc
   category: main
   optional: false
 - name: orjson
-  version: 3.10.11
+  version: 3.10.16
   manager: conda
   platform: linux-64
   dependencies:
@@ -8489,10 +8862,10 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/orjson-3.10.11-py310h505e2c1_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/orjson-3.10.16-py310h505e2c1_0.conda
   hash:
-    md5: b02b4d55563256bce9667e03de693b4b
-    sha256: e0023b42234aaa66c180a4bbe4940aa0ffcee626234d1dc9e739998a692ab40e
+    md5: 29dba4c40bd93405908730981bf3750e
+    sha256: b43caf13662c673dceec22c7535c363e88137fc53e7b403e8ee2e9c25b2cb2ee
   category: main
   optional: false
 - name: overrides
@@ -8500,24 +8873,24 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     typing_utils: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
-    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
+    md5: e51f1e4089cad105b6cac64bd8166587
+    sha256: 1840bd90d25d4930d60f57b4f38d4e0ae3f5b8db2819638709c36098c6ba770c
   category: main
   optional: false
 - name: packaging
-  version: '24.1'
+  version: '24.2'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
   hash:
-    md5: cbe1bb1f21567018ce595d9c2be0f0db
-    sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
+    md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
+    sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
   category: main
   optional: false
 - name: pamela
@@ -8525,11 +8898,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pamela-1.2.0-pyhff2d567_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pamela-1.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: adb3a4c7f269923b7f2ccff0ef071102
-    sha256: 060b28a4b003681cc0b96d8edb0b1608ede432b2331659c87a5f94dd4e61bbcc
+    md5: a3a069b6dbf63e1a635f3feeffdaeb4e
+    sha256: 41b074a35b210b3395ccd10d30c301c0f7c65150353820f3a6a7d2bf8be5beaa
   category: main
   optional: false
 - name: pandas
@@ -8553,14 +8926,14 @@ package:
   category: main
   optional: false
 - name: pandoc
-  version: '3.5'
+  version: 3.6.4
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.5-ha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.6.4-ha770c72_0.conda
   hash:
-    md5: 2889e6b9c666c3a564ab90cedc5832fd
-    sha256: 56df96c2707a5ac71b2e5d3b32e38521c0bac91006d0b8948c1d347dd5c12609
+    md5: 53f2cd4128fa7053bb029bbeafbe3f2e
+    sha256: 16cbcab8a6d9a0cef47b9d3ebeced8a1a75ee54d379649e6260a333d1b2f743c
   category: main
   optional: false
 - name: pandocfilters
@@ -8576,7 +8949,7 @@ package:
   category: main
   optional: false
 - name: panel
-  version: 1.5.3
+  version: 1.6.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -8594,10 +8967,10 @@ package:
     requests: ''
     tqdm: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/panel-1.5.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/panel-1.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 058794444fc8aafcb0385788ce58e979
-    sha256: 1613bb56fb5b93094b64f0bc95476de7ceb42f4dacbf04f90bc25519b00f9878
+    md5: e52807f99bbd86f6aef02c1c954fc1c1
+    sha256: 2decd60c2276d818ca23b134491644fe067746e11dc1501dfdafc3e523564a3c
   category: main
   optional: false
 - name: pangeo-dask
@@ -8615,49 +8988,55 @@ package:
   category: main
   optional: false
 - name: pangeo-forge-recipes
-  version: 0.10.7
+  version: 0.9.4
   manager: conda
   platform: linux-64
   dependencies:
-    apache-beam: ''
-    cftime: ''
-    dask: '>=2021.11.2'
-    dask-core: '>=2021.11.2'
-    fastparquet: ''
-    fsspec: '>=2023.4.0'
+    aiohttp: ''
+    dask: ''
+    distributed: ''
+    fsspec: '>=2021.6.0'
     h5netcdf: ''
     h5py: '>=3.3.0'
+    intake: ''
+    intake-xarray: ''
     kerchunk: '>=0.0.7'
+    mypy_extensions: '>=0.4.2'
     netcdf4: ''
     numcodecs: '>=0.9.0'
     python: '>=3.8'
-    ujson: ''
+    rechunker: '>=0.4.2'
+    requests: ''
+    setuptools: ''
     xarray: '>=0.18.0'
-    zarr: '>=2.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pangeo-forge-recipes-0.10.7-pyhca7485f_0.conda
+    zarr: '>=2.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pangeo-forge-recipes-0.9.4-pyh1a96a4e_0.conda
   hash:
-    md5: c776055c0efa22d1724e5a24f4b02e25
-    sha256: 2585e9ddf2dab2fa7e061bdde1965cc781b37d80719bd540808d2d455767f1c7
+    md5: 2e4cb0b8414d2023f95124725e7910b4
+    sha256: 288df92e82d93cfa1109e7e7bf283cab444fff4b6bcbc9eef4a2fbe90f547328
   category: main
   optional: false
 - name: pango
-  version: 1.54.0
+  version: 1.56.3
   manager: conda
   platform: linux-64
   dependencies:
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.4,<2.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
+    freetype: '>=2.13.3,<3.0a0'
     fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=9.0.0,<10.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
+    harfbuzz: '>=10.4.0,<11.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.2,<3.0a0'
+    libpng: '>=1.6.47,<1.7.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.3-h861ebed_0.conda
   hash:
-    md5: 7df02e445367703cd87a574046e3a6f0
-    sha256: d362237be82d5a0d532fe66ec8d68018c3b2a9705bad6d73c2b63dae2970da02
+    md5: 6d853ca33bc46bce99ce16ccd83d0466
+    sha256: 6bc073dc2759cb00bc9e94c7142acab58432245c6e04d1cef179e8afd3b58d6f
   category: main
   optional: false
 - name: papermill
@@ -8671,46 +9050,46 @@ package:
     entrypoints: ''
     nbclient: '>=0.2.0'
     nbformat: '>=5.2.0'
-    python: '>=3.7'
+    python: '>=3.9'
     pyyaml: ''
     requests: ''
     tenacity: '>=5.0.2'
     tqdm: '>=4.32.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/papermill-2.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/papermill-2.6.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 7e2150bca46f713bb6e290ac1b26ed1d
-    sha256: 64e05023f00762bc3f4cd9ed9bedfb6b2af03f645e9a98ff2904ed690686f566
+    md5: a5d72a5d14079f052d4f3bf7fb4593a7
+    sha256: 587c0cdf179626143612a6bbdf855e9783374b3eed5341ed42368be1c055e8fc
   category: main
   optional: false
 - name: param
-  version: 2.1.1
+  version: 2.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/param-2.1.1-pyhff2d567_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/param-2.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: bd991333d5bc659bb82bfb5a5d4c1576
-    sha256: db644c81c1f47e1fa8134d5de935ec4269d765fbef8d44bd454eb187c7524472
+    md5: 8bd46aebe85bd9c5f30affd520ab441f
+    sha256: 857c0e09b51d5c81d5a2144d4a5bd3dc15f81a52f1bf3da9290baff3deae6b5d
   category: main
   optional: false
 - name: paramiko
-  version: 3.5.0
+  version: 3.5.1
   manager: conda
   platform: linux-64
   dependencies:
     bcrypt: '>=3.2'
     cryptography: '>=3.3'
     pynacl: '>=1.5'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.5.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 3a359c35a1f9ec2859fbddcabcfd4c4d
-    sha256: f2c3ac882c1123a71479c15ecec0c632aa004bc8a8c10daf25d69461ea1da38a
+    md5: 4e6bea7eee94bb9d8a599385215719f9
+    sha256: 1499e558d31536707fdd7d0b569dbe29ae6e3aa8f2fdce9ea6f3df3ce4c1aaf1
   category: main
   optional: false
 - name: parcels
-  version: 3.1.0
+  version: 3.1.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -8731,11 +9110,11 @@ package:
     tqdm: ''
     trajan: ''
     xarray: '>=0.10.8'
-    zarr: '>=2.11.0,!=2.18.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/parcels-3.1.0-pyh6fe113f_1.conda
+    zarr: '>=2.11.0,!=2.18.0,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/parcels-3.1.2-pyh6fe113f_0.conda
   hash:
-    md5: b4152da63d30f914628df40c07f7f04f
-    sha256: 129a54c3e11120add97cff680aefc2c012697dae5e04fd8dba87c926e2f14f3c
+    md5: 1fabf4fba92d7905ed6bbc9b6fd939fc
+    sha256: 4131dde2813e28ade029b86aa5d88309c5f75cbe0144977b821448e3bb227b88
   category: main
   optional: false
 - name: parso
@@ -8743,11 +9122,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 81534b420deb77da8833f2289b8d47ac
-    sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
+    md5: 5c092057b6badd30f75b06244ecd01c9
+    sha256: 17131120c10401a99205fc6fe436e7903c0fa092f1b3e80452927ab377239bcc
   category: main
   optional: false
 - name: partd
@@ -8769,25 +9148,24 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 17064acba08d3686f1135b5ec1b32b12
-    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+    md5: 617f15191456cc6a13db418a275435e5
+    sha256: 9f64009cdf5b8e529995f18e03665b03f5d07c0b17445b8badef45bde76249ee
   category: main
   optional: false
 - name: patsy
-  version: 0.5.6
+  version: 1.0.1
   manager: conda
   platform: linux-64
   dependencies:
     numpy: '>=1.4.0'
-    python: '>=3.6'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/patsy-0.5.6-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhd8ed1ab_1.conda
   hash:
-    md5: a5b55d1cb110cdcedc748b5c3e16e687
-    sha256: 35ad5cab1d9c08cf98576044bf28f75e62f8492afe6d1a89c94bbe93dc8d7258
+    md5: ee23fabfd0a8c6b8d6f3729b47b2859d
+    sha256: ab52916f056b435757d46d4ce0a93fd73af47df9c11fd72b74cc4b7e1caca563
   category: main
   optional: false
 - name: pcre2
@@ -8806,19 +9184,21 @@ package:
   category: main
   optional: false
 - name: pendulum
-  version: 2.1.2
+  version: 3.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
-    python-dateutil: '>=2.6,<3.0'
+    python-dateutil: '>=2.6'
     python_abi: 3.10.*
-    pytzdata: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pendulum-2.1.2-py310h2372a71_6.conda
+    time-machine: '>=2.6.0'
+    tzdata: '>=2020.1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pendulum-3.0.0-py310h505e2c1_1.conda
   hash:
-    md5: 1942f8904121c1a88bb94777a1cbde3b
-    sha256: f7bffc1bb9bcc9cec514ea0ec84e94aa4a29d2ce11574e7ddfc439b8329e81fd
+    md5: 4476819fc2a700a98b4fa755f83390ae
+    sha256: 17232090df1d309512601af755d49511cd97630a04cef2860b2a7b45c39840d8
   category: main
   optional: false
 - name: pexpect
@@ -8827,11 +9207,11 @@ package:
   platform: linux-64
   dependencies:
     ptyprocess: '>=0.5'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 629f3203c99b32e0988910c93e77f3b6
-    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+    md5: d0d408b1f18883a944376da5cf8101ea
+    sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
   category: main
   optional: false
 - name: pickleshare
@@ -8839,11 +9219,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
   hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+    md5: 11a9d1d09a3615fc07c3faf79bc0b943
+    sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
   category: main
   optional: false
 - name: pillow
@@ -8880,13 +9260,13 @@ package:
     numpy: '>=1.19'
     packaging: ''
     pillow: ''
-    python: '>=3.7'
+    python: '>=3.9'
     slicerator: '>=1.1.0'
     tifffile: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pims-0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pims-0.7-pyhd8ed1ab_1.conda
   hash:
-    md5: b0acc7e1a2514298728307d560f04235
-    sha256: 40135209a3be74257df4fb340d25230a20d8ccdbfca8c5f4695b6ed8bd426bee
+    md5: 146adfd93cac5e7c6b5def8f39c917cd
+    sha256: cc9521b3a517c9c0f5097a96ed2285b89ba3ee291320a26100261fea2130f8bf
   category: main
   optional: false
 - name: pint
@@ -8899,10 +9279,10 @@ package:
     platformdirs: '>=2.1.0'
     python: '>=3.9'
     typing_extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.4-pyhd8ed1ab_1.conda
   hash:
-    md5: cb091db43679e633dc2a4b83cdd72069
-    sha256: 965a4e1a5d976ee244a84ed72e3ae3573335b7f5cf0cb5603a195842d319e7e6
+    md5: a566694ac0ab8f25e7f40a5d24070a1a
+    sha256: 4595b54c19a46a8fc320d01e71000cee8bbfa47d9494fd2c8041d5c86f721b09
   category: main
   optional: false
 - name: pint-xarray
@@ -8912,39 +9292,52 @@ package:
   dependencies:
     numpy: '>=1.17'
     pint: '>=0.16'
-    python: '>=3.8'
+    python: '>=3.9'
     xarray: '>=0.16.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pint-xarray-0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pint-xarray-0.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 54398492a68901ff0ec45fea86ce83cc
-    sha256: e033d6782e601bff993eef6883d2f016215b5da37ad593088f514d2822ed7845
+    md5: 33499983bfdbeb4bc996ffa707c56228
+    sha256: 259dc84b5d498a5aa073c5cb0a9e59fa26028525d79beb4dc495e46c2be7661e
   category: main
   optional: false
 - name: pip
-  version: 24.3.1
+  version: 25.0.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8,<3.13.0a0'
+    python: '>=3.9,<3.13.0a0'
     setuptools: ''
     wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-25.0.1-pyh8b19718_0.conda
   hash:
-    md5: 5dd546fe99b44fda83963d15f84263b7
-    sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
+    md5: 79b5c1440aedc5010f687048d9103628
+    sha256: 585940f09d87787f79f73ff5dff8eb2af8a67e5bec5eebf2f553cd26c840ba69
   category: main
   optional: false
 - name: pixman
-  version: 0.43.2
+  version: 0.44.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.44.2-h29eaf8c_0.conda
   hash:
-    md5: 71004cbf7924e19c02746ccde9fd7123
-    sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
+    md5: 5e2a7acfa2c24188af39e7944e1b3604
+    sha256: 747c58db800d5583fee78e76240bf89cbaeedf7ab1ef339c2990602332b9c4be
+  category: main
+  optional: false
+- name: pkginfo
+  version: 1.12.1.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: dc702b2fae7ebe770aff3c83adb16b63
+    sha256: 353fd5a2c3ce31811a6272cd328874eb0d327b1eafd32a1e19001c4ad137ad3a
   category: main
   optional: false
 - name: pkgutil-resolve-name
@@ -8952,11 +9345,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
   hash:
-    md5: 405678b942f2481cecdb3e010f4925d9
-    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
+    md5: 5a5870a74432aa332f7d32180633ad05
+    sha256: adb2dde5b4f7da70ae81309cce6188ed3286ff280355cf1931b45d91164d2ad8
   category: main
   optional: false
 - name: planetary-computer
@@ -8969,40 +9362,40 @@ package:
     pydantic: '>=1.7.3'
     pystac: '>=1.0.0'
     pystac-client: '>=0.2.0'
-    python: '>=3.7'
+    python: '>=3.9'
     python-dotenv: ''
     pytz: '>=2020.5'
     requests: '>=2.25.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/planetary-computer-1.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/planetary-computer-1.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: bcd66071f31063cd200f0ba4620a9926
-    sha256: 672833457cac1a934400b5ef9f5f77d2175b84096ec3a057b33e599c4bacd1b9
+    md5: 9477c2eb3a49f043c828384f277f29a6
+    sha256: e5cec11b9fdfafd7955fbfceddff95598d249195ac77994e5f9203ddb67ecf68
   category: main
   optional: false
 - name: platformdirs
-  version: 4.3.6
+  version: 4.3.7
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.7-pyh29332c3_0.conda
   hash:
-    md5: fd8f2b18b65bbf62e8f653100690c8d2
-    sha256: c81bdeadc4adcda216b2c7b373f0335f5c78cc480d1d55d10f21823590d7e46f
+    md5: e57da6fe54bb3a5556cf36d199ff07d8
+    sha256: ae7d3e58224d53d6b59e1f5ac5809803bb1972f0ac4fb10cd9b8c87d4122d3e0
   category: main
   optional: false
 - name: plotly
-  version: 5.24.1
+  version: 6.0.1
   manager: conda
   platform: linux-64
   dependencies:
+    narwhals: '>=1.15.1'
     packaging: ''
-    python: '>=3.6'
-    tenacity: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotly-5.24.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/plotly-6.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 81bb643d6c3ab4cbeaf724e9d68d0a6a
-    sha256: 39cef6d3056211840709054b90badfa4efd6f61ea37935a89ab0b549a54cc83f
+    md5: 37ce02c899ff42ac5c554257b1a5906e
+    sha256: e81c39f6a7a8aa1fa5d1c22019f779c5bddad5adb88bba2b6cf5c3ca75c5666c
   category: main
   optional: false
 - name: pluggy
@@ -9010,11 +9403,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
   hash:
-    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
-    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
+    md5: e9dcbce5f45f9ee500e728ae58b605b6
+    sha256: 122433fc5318816b8c69283aaf267c73d87aa2d09ce39f64c9805c9a3b264819
   category: main
   optional: false
 - name: ply
@@ -9022,23 +9415,23 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_2.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
   hash:
-    md5: 18c6deb6f9602e32446398203c8f0e91
-    sha256: d8faaf4dcc13caed560fa32956523b35928a70499a2d08c51320947d637e3a41
+    md5: fd5062942bfa1b0bd5e0d2a4397b099e
+    sha256: bae453e5cecf19cab23c2e8929c6e30f4866d996a8058be16c797ed4b935461f
   category: main
   optional: false
 - name: pmtiles
-  version: 3.4.0
+  version: 3.4.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pmtiles-3.4.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pmtiles-3.4.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 05b92d0fce8fcb37d66f16212720ced8
-    sha256: 538be144eebdb338fb2fec1400ce559c3af6af4f16efcae514a3fcc2d3271cb3
+    md5: 78311b95d025ac61cd009c1fe3010730
+    sha256: bf6b2e7827c5533c700e84119a1a03e8f4f21058f5f5f86c96850aef75ed7f70
   category: main
   optional: false
 - name: pooch
@@ -9048,95 +9441,29 @@ package:
   dependencies:
     packaging: '>=20.0'
     platformdirs: '>=2.5.0'
-    python: '>=3.7'
+    python: '>=3.9'
     requests: '>=2.19.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 8dab97d8a9616e07d779782995710aed
-    sha256: f2ee98740ac62ff46700c3cae8a18c78bdb3d6dd80832c6e691e789b844830d8
-  category: main
-  optional: false
-- name: poppler
-  version: 24.08.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libcurl: '>=8.9.1,<9.0a0'
-    libgcc-ng: '>=13'
-    libglib: '>=2.80.3,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libstdcxx-ng: '>=13'
-    libtiff: '>=4.6.0,<4.8.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    nspr: '>=4.35,<5.0a0'
-    nss: '>=3.103,<4.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    poppler-data: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.08.0-h47131b8_1.conda
-  hash:
-    md5: 0854b9ff0cc10a1f6f67b0f352b8e75a
-    sha256: b32fe787525236908e21885fef8d77e8ebdbbe6694b2fb89ed799444ebda3178
-  category: main
-  optional: false
-- name: poppler-data
-  version: 0.4.12
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
-  hash:
-    md5: d8d7293c5b37f39b2ac32940621c6592
-    sha256: 2f227e17b3c0346112815faa605502b66c1c4511a856127f2899abf15a98a2cf
+    md5: b3e783e8e8ed7577cf0b6dee37d1fbac
+    sha256: bedda6b36e8e42b0255179446699a0cf08051e6d9d358dd0dd0e787254a3620e
   category: main
   optional: false
 - name: portalocker
-  version: 1.2.1
+  version: 2.10.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/portalocker-1.2.1-py_0.tar.bz2
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/portalocker-2.10.1-py310hff52083_1.conda
   hash:
-    md5: e4e99de4f98fb9bd7dd74c82e74dd682
-    sha256: ff0c5ad5dc50051209ce4ad96d450287a744d8a2b66ad7f1cd5de530d4f07460
-  category: main
-  optional: false
-- name: postgresql
-  version: '17.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=75.1,<76.0a0'
-    krb5: '>=1.21.3,<1.22.0a0'
-    libgcc: '>=13'
-    libpq: '17.0'
-    libxml2: '>=2.12.7,<3.0a0'
-    libxslt: '>=1.1.39,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    openldap: '>=2.6.8,<2.7.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tzcode: ''
-    tzdata: ''
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-17.0-h1122569_4.conda
-  hash:
-    md5: 028ea131f116f13bb2a4a382b5863a04
-    sha256: 83565b4966d86d39b8628f9137d0918fac8ae2f3241a48da145be444426ed057
+    md5: c7c67f1defa43b60fe1ec45bbac2bd27
+    sha256: 959d3149f9dab8aeee13d65b3a580e04c496e79e344e3f3d3292cfdb14015245
   category: main
   optional: false
 - name: prefect
-  version: 2.20.4
+  version: 3.2.14
   manager: conda
   platform: linux-64
   dependencies:
@@ -9146,84 +9473,109 @@ package:
     apprise: '>=1.1.0,<2.0.0'
     asgi-lifespan: '>=1.0,<3.0'
     asyncpg: '>=0.23,<1.0.0'
+    cachetools: '>=5.3,<6.0'
     click: '>=8.0,<8.2'
-    cloudpickle: '>=2.0,<3.0'
+    cloudpickle: '>=2.0,<4.0'
     coolname: '>=1.0.4,<3.0.0'
-    croniter: '>=1.0.12,<2.0.0'
+    croniter: '>=1.0.12,<5.0.0'
     cryptography: '>=36.0.1'
     dateparser: '>=1.1.1,<2.0.0'
     docker-py: '>=4.0,<8.0'
-    exceptiongroup: '>=1.2.1'
+    exceptiongroup: '>=1.0.0'
+    fastapi: '>=0.111.0,<1.0.0'
     fsspec: '>=2022.5.0'
     griffe: '>=0.49.0,<2.0.0'
-    httpcore: '>=0.15.0,<2.0.0'
+    httpcore: '>=1.0.5,<2.0.0'
     httpx: '>=0.23,!=0.23.2'
-    importlib_metadata: '>=4.4'
-    importlib_resources: '>=6.1.3,<6.5.0'
+    humanize: '>=4.9.0,<5.0.0'
+    importlib-metadata: '>=4.4'
     jinja2: '>=3.0.0,<4.0.0'
     jinja2-humanize-extension: '>=0.4.0'
     jsonpatch: '>=1.32,<2.0'
-    jsonschema: '>=3.2.0,<5.0.0'
+    jsonschema: '>=4.0.0,<5.0.0'
+    opentelemetry-api: '>=1.27.0,<2.0'
     orjson: '>=3.7,<4.0'
     packaging: '>=21.3,<24.3'
     pathspec: '>=0.8.0'
-    pendulum: '>=2.1.2,<3.0.0'
-    pydantic: '>=1.10.0,!=1.10.14,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0'
-    pydantic-core: '>=2.17.0,<3.0.0'
-    python: '>=3.7'
+    pendulum: '>=3.0.0,<4'
+    prometheus_client: '>=0.20.0'
+    pydantic: '>=2.7,<3.0.0'
+    pydantic-core: '>=2.12.0,<3.0.0'
+    pydantic-extra-types: '>=2.8.2,<3.0.0'
+    pydantic-settings: '>2.2.1'
+    python: '>=3.9'
     python-dateutil: '>=2.8.2,<3.0.0'
     python-graphviz: '>=0.20.1'
-    python-kubernetes: '>=24.2.0,<29.0.0'
-    python-multipart: '>=0.0.7'
     python-slugify: '>=5.0,<9.0'
-    pytz: '>=2021.1,<2024'
+    python-socks: '>=2.5.3,<3.0'
+    python-tzdata: ''
+    python-uv: '>=0.6.0'
+    pytz: '>=2021.1,<2025'
     pyyaml: '>=5.4.1,<7.0.0'
     readchar: '>=4.0.0,<5.0.0'
+    rfc3339-validator: '>=0.1.4,<0.2.0'
     rich: '>=11.0,<14.0'
     ruamel.yaml: '>=0.17.0'
     sniffio: '>=1.3.0,<2.0.0'
-    sqlalchemy: '>=1.4.22,!=1.4.33,<3.0.0'
-    starlette: '>=0.27.0,<0.28.0'
+    sqlalchemy: '>=2.0,<3.0.0'
     toml: '>=0.10.0'
     typer: '>=0.12.0,!=0.12.2,<0.13.0'
     typing_extensions: '>=4.5.0,<5.0.0'
     ujson: '>=5.8.0,<6.0.0'
     uvicorn: '>=0.14.0,!=0.29.0'
     websockets: '>=10.4,<14.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/prefect-2.20.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prefect-3.2.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 1b747f1b2f6a91d46807a3f5ac594d61
-    sha256: 12948ecf0cb4b1f21d079c2567fdccc0dcd83cc368ed1ea5dd1c4b565512f698
+    md5: 486d13dbb27d2995980f093590d8cf4c
+    sha256: 229fa9578620ae5258ba594bd9a443b1431be01d0a6790fcb1ad53dcb9901975
   category: main
   optional: false
 - name: proj
-  version: 9.5.0
+  version: 9.6.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libcurl: '>=8.10.0,<9.0a0'
+    gtest: '>=1.16.0,<1.16.1.0a0'
+    libcurl: '>=8.12.1,<9.0a0'
     libgcc: '>=13'
-    libsqlite: '>=3.46.1,<4.0a0'
+    libsqlite: '>=3.49.1,<4.0a0'
     libstdcxx: '>=13'
-    libtiff: '>=4.6.0,<4.8.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
     sqlite: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.0-h12925eb_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.6.0-h0054346_0.conda
   hash:
-    md5: 8c29983ebe50cc7e0998c34bc7614222
-    sha256: 936de8754054d97223e87cc87b72641d2c7582d536ee9eee4b0443fa66e2733f
+    md5: c2ad1b40a59bb94a629a812c656973e1
+    sha256: a9d62fd7fcb3cda36243754f34aee73771500cfc9e81c74d18d90122cb92f214
   category: main
   optional: false
-- name: prometheus_client
-  version: 0.21.0
+- name: prometheus-cpp
+  version: 1.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
   hash:
-    md5: 07e9550ddff45150bfc7da146268e165
-    sha256: 01f0c3dd00081637ed920a922b17bcc8ed49608404ee466ced806856e671f6b9
+    md5: a83f6a2fdc079e643237887a37460668
+    sha256: 013669433eb447548f21c3c6b16b2ed64356f726b5f77c1b39d5ba17a8a4b8bc
+  category: main
+  optional: false
+- name: prometheus_client
+  version: 0.21.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3e01e386307acc60b2f89af0b2e161aa
+    sha256: bc8f00d5155deb7b47702cb8370f233935704100dbc23e30747c161d1b6cf3ab
   category: main
   optional: false
 - name: prompt-toolkit
@@ -9252,7 +9604,7 @@ package:
   category: main
   optional: false
 - name: propcache
-  version: 0.2.0
+  version: 0.2.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -9260,42 +9612,39 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.2.0-py310ha75aee5_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.2.1-py310h89163eb_1.conda
   hash:
-    md5: d38aa9579b7210c646e6faef1aed5bbb
-    sha256: 51a86f2b584c387cad87b5392ab3e85b322803a52b213255bee77b58f0659cd2
+    md5: ff4090c5ecf2e74e011c7c2404090ac5
+    sha256: ed06b08001335e1959d56c25a1c31871df0a56206d4c64b7309d015682dca08f
   category: main
   optional: false
 - name: proto-plus
-  version: 1.25.0
+  version: 1.26.1
   manager: conda
   platform: linux-64
   dependencies:
-    protobuf: '>=3.19.0,<6.0.0dev'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/proto-plus-1.25.0-pyhd8ed1ab_0.conda
+    protobuf: '>=3.19.0,<7.0.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/proto-plus-1.26.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 36147996294573f1e8f9fea08e5938de
-    sha256: ec841b8e78ac65ac9ec86daf2d7e5d5f8d632818d9e03487dd1462779704d61d
+    md5: 6fcfcf4432cd80d05ee9c6e20830bd36
+    sha256: 88217ba299be4a56c0534ccdef676390b76ca10b07ac26d16940d9a944d6212c
   category: main
   optional: false
 - name: protobuf
-  version: 4.25.3
+  version: 5.28.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
     libgcc: '>=13'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libstdcxx: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.25.3-py310h0e2eeba_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-5.28.3-py310hf71b8c6_0.conda
   hash:
-    md5: 3e274aa9ac708a9f34ee2a0009c01e5b
-    sha256: 03361d8328089e3f0b762e887fefb74bb74f3d81325f8c448054a90adb0bc6c8
+    md5: 084db219a9da4261b3308d120b9b552a
+    sha256: ce9c1d73b2c972c35a8435eddeab61c70732c96c540f2451584252d55f17eb89
   category: main
   optional: false
 - name: pscript
@@ -9341,17 +9690,17 @@ package:
   category: main
   optional: false
 - name: psygnal
-  version: 0.11.1
+  version: 0.12.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     typing_extensions: ''
     wrapt: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/psygnal-0.11.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/psygnal-0.12.0-pyhd8ed1ab_0.conda
   hash:
-    md5: b49c6ca5e5661b5473f91ac01782e487
-    sha256: fc12b32c36c522d263bf24dbced4c755925198fa153bbddd7181b68e3443a468
+    md5: 293d719dbe39b9c986fb717b6063c0fd
+    sha256: d986108e6a68049f22af2563dcddce12e71590edb000bf5fb80c23b453b48899
   category: main
   optional: false
 - name: pthread-stubs
@@ -9372,24 +9721,44 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+    md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+    sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
   category: main
   optional: false
 - name: pugixml
-  version: '1.14'
+  version: '1.15'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
   hash:
-    md5: 2c97dd90633508b422c11bd3018206ab
-    sha256: ea5f2d593177318f6b19af05018c953f41124cbb3bf21f9fdedfdb6ac42913ae
+    md5: b11a4c6bf6f6f44e5e143f759ffa2087
+    sha256: 23c98a5000356e173568dc5c5770b53393879f946f3ace716bbdefac2a8b23d2
+  category: main
+  optional: false
+- name: pulseaudio-client
+  version: '17.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    dbus: '>=1.13.6,<2.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.2,<3.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    libsndfile: '>=1.2.2,<1.3.0a0'
+    libsystemd0: '>=257.4'
+    libxcb: '>=1.17.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hac146a9_1.conda
+  hash:
+    md5: 66b1fa9608d8836e25f9919159adc9c6
+    sha256: d2377bb571932f2373f593b7b2fc3b9728dc6ae5b993b1b65d7f2c8bb39a0b49
   category: main
   optional: false
 - name: pure_eval
@@ -9397,49 +9766,47 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 0f051f09d992e0d08941706ad519ee0e
-    sha256: dcfcb3cee1ae0a89729601582cc3edea20ba13c9493967a03a693c67567af0c8
+    md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
+    sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
   category: main
   optional: false
 - name: pyarrow
-  version: 16.1.0
+  version: 19.0.1
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow-acero: 16.1.0.*
-    libarrow-dataset: 16.1.0.*
-    libarrow-substrait: 16.1.0.*
-    libparquet: 16.1.0.*
-    numpy: '>=1.19,<3'
-    pyarrow-core: 16.1.0
+    libarrow-acero: 19.0.1.*
+    libarrow-dataset: 19.0.1.*
+    libarrow-substrait: 19.0.1.*
+    libparquet: 19.0.1.*
+    pyarrow-core: 19.0.1
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-16.1.0-py310hb7f781d_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-19.0.1-py310hff52083_0.conda
   hash:
-    md5: fdb4acd5dd835ffadde6a8fffe4dff6c
-    sha256: d417cf50d3090f22ad63f7641fb4d4efc6fd1cb77d2412fac4649b801b9bf585
+    md5: 96aab335d44df02cd3aaba0c7dd1a645
+    sha256: 0e9fcf42e2a2563eb071d8b6a6809fa4067cceec5dd3989787a7b354bf3e1a62
   category: main
   optional: false
 - name: pyarrow-core
-  version: 16.1.0
+  version: 19.0.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libarrow: 16.1.0.*
+    libarrow: 19.0.1.*
     libgcc: '>=13'
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    numpy: '>=1.19,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-16.1.0-py310hac404ae_6_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-19.0.1-py310hac404ae_0_cpu.conda
   hash:
-    md5: d1200399b0a5fe0cf0eb31f3991ede0c
-    sha256: 83235db29b43fbc0b5e58927e5b9da932b706551be1268ad038382b0d85c37ad
+    md5: 08bfbf49d206e2fbcccd7b92d2526a2a
+    sha256: b5c63e67ebc1ae151e728759f96fc01b818f6b7de0ee62526448bdd9d85caa47
   category: main
   optional: false
 - name: pyarrow-hotfix
@@ -9448,11 +9815,11 @@ package:
   platform: linux-64
   dependencies:
     pyarrow: '>=0.14'
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_1.conda
   hash:
-    md5: ccc06e6ef2064ae129fab3286299abda
-    sha256: 9b767969d059c106aac6596438a7e7ebd3aa1e2ff6553d4b7e05126dfebf4bd6
+    md5: 49c3b8c3b2578f35a7034f75f30d0041
+    sha256: 9ff4e520cff831d34adcf8d791f735972d804572f223ad21b9652ad0886968a6
   category: main
   optional: false
 - name: pyasn1
@@ -9460,11 +9827,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
   hash:
-    md5: 960ae8a1852b4e0fbeafe439fa7f4eab
-    sha256: 7f8d61f80e548ed29e452bb51742f0370614f210156cd8355b89803c3f3999d5
+    md5: 09bb17ed307ad6ab2fd78d32372fdd4e
+    sha256: d06051df66e9ab753683d7423fcef873d78bb0c33bd112c3d5be66d529eddf06
   category: main
   optional: false
 - name: pyasn1-modules
@@ -9473,11 +9840,27 @@ package:
   platform: linux-64
   dependencies:
     pyasn1: '>=0.4.6,<0.7.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.4.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.4.1-pyhd8ed1ab_1.conda
   hash:
-    md5: f781c31cdff5c086909f8037ed0b0472
-    sha256: 2dd9d70e055cdc51b5b2dcf3f0e9c0c44599b6155928033886f4efebfdda03f3
+    md5: 1c6476fdb96e6c3db6c3f7693cdba78e
+    sha256: 565e961fce215ccf14f863c3030eda5b83014489679d27166ff97144bf977810
+  category: main
+  optional: false
+- name: pycairo
+  version: 1.27.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.0,<2.0a0'
+    libgcc: '>=13'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.27.0-py310h25ff670_0.conda
+  hash:
+    md5: 97d04aa121ff0b2ec6c1c6cb32b11e2f
+    sha256: fe2a2edd89076008a3601741de52e8f89b2bca1e0ba9f874520cee687c22c77a
   category: main
   optional: false
 - name: pycamhd
@@ -9487,12 +9870,12 @@ package:
   dependencies:
     av: '>=0.4.0'
     numpy: ''
-    python: ''
+    python: '>=3.9'
     requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pycamhd-0.7.0-py_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pycamhd-0.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 49407af9fedc76cd0046b331acf8c1c9
-    sha256: cfe72a6bbeddbd174227f14e70957c748dd19f96f0f4a7ab9e096b8aa2696b71
+    md5: 7290431f75f464956da2417fe5b1f327
+    sha256: cfc452942d083fa59d8417db2e1e8c42d1022854d06270600c5a5cc1772c8438
   category: main
   optional: false
 - name: pycparser
@@ -9500,11 +9883,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
   hash:
-    md5: 844d9eb3b43095b031874477f7d70088
-    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
+    md5: 12c566707c80111f9799308d9e265aef
+    sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
   category: main
   optional: false
 - name: pycrs
@@ -9512,11 +9895,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pycrs-1.0.2-py_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycrs-1.0.2-pyhd8ed1ab_1.conda
   hash:
-    md5: ffb4ee4b7ef67bd415df4cb92d53ab68
-    sha256: 2fac3839be8ef9c7353b1e4b49720c206237fa382e8aff8911f344910371f111
+    md5: e2292fbcbf321621e2af5121f02d887e
+    sha256: 6affbf960e8d2e6214b1eff3fa93c8ea5b6cdb425fbf375bc09ca77624fc60e3
   category: main
   optional: false
 - name: pyct
@@ -9525,33 +9908,34 @@ package:
   platform: linux-64
   dependencies:
     param: '>=1.7.0'
-    python: '>=3.7'
+    python: '>=3.9'
     pyyaml: ''
     requests: ''
     setuptools: '>=61.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyct-0.5.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 24c245c82396be3297c0aa26b69e18d8
-    sha256: 0e1e17a37d53be84c33b88218f10afb5f8137f19a727fdc56e45ae0b8b439a57
+    md5: dcd4770a9dff3c3bb2e21cb0108af3d0
+    sha256: 456d1fb91e00ea0b55efa63c64d80b18489b0b71bffaa72c7a19bed0c637b9f4
   category: main
   optional: false
 - name: pydantic
-  version: 2.9.2
+  version: 2.10.6
   manager: conda
   platform: linux-64
   dependencies:
     annotated-types: '>=0.6.0'
-    pydantic-core: 2.23.4
-    python: '>=3.7'
+    pydantic-core: 2.27.2
+    python: '>=3.9'
     typing-extensions: '>=4.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.9.2-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.12.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.6-pyh3cfb1c2_0.conda
   hash:
-    md5: 1eb533bb8eb2199e3fef3e4aa147319f
-    sha256: 1b7b0dc9f6af4da156bf22b0263be70829364a08145c696d3670facff2f6441a
+    md5: c69f87041cf24dfc8cb6bf64ca7133c7
+    sha256: 9a78801a28959edeb945e8270a4e666577b52fac0cf4e35f88cf122f73d83e75
   category: main
   optional: false
 - name: pydantic-core
-  version: 2.23.4
+  version: 2.27.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -9560,46 +9944,58 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.23.4-py310h505e2c1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.27.2-py310h505e2c1_0.conda
   hash:
-    md5: f53ab8b7b08a48331d8ea5d0ecf9df51
-    sha256: ce24d3860d430be37bd9981307917f187d40e354aa31ccf3192dfa1b76e2f909
+    md5: 3f804346d970a0343c46afc21cf5f16e
+    sha256: 6c58cdbb007f2dc8b0a8d96eacaba45bedf6ddfe9ed4558c40f899cb3438f3cb
+  category: main
+  optional: false
+- name: pydantic-extra-types
+  version: 2.10.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    pydantic: '>=2.5.2'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.10.3-pyh3cfb1c2_0.conda
+  hash:
+    md5: a59d358a1a8580cf65c9bf5f538cb011
+    sha256: d1bb1838f0fd64577bd431e3cb3a4d7971e1e78a592f37917972fe2f415ee49f
+  category: main
+  optional: false
+- name: pydantic-settings
+  version: 2.8.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    pydantic: '>=2.7.0'
+    python: '>=3.9'
+    python-dotenv: '>=0.21.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.8.1-pyh3cfb1c2_0.conda
+  hash:
+    md5: 88715188749bfac9fa92aec9c747d62c
+    sha256: 84b78dcdc75d7dacd8c85df9a7fef42ff5684897217b46beef6c516afb2550dc
   category: main
   optional: false
 - name: pydap
-  version: '3.5'
+  version: 3.5.4
   manager: conda
   platform: linux-64
   dependencies:
     beautifulsoup4: ''
     docopt-ng: ''
-    importlib-metadata: ''
-    importlib-resources: ''
     jinja2: ''
     lxml: ''
     numpy: ''
-    python: '>=3.9'
+    python: '>=3.10'
     requests: ''
+    requests-cache: ''
+    scipy: ''
     webob: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pydap-3.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydap-3.5.4-pyhecae5ae_0.conda
   hash:
-    md5: 308214e9f1c2183363b6c49ecf757422
-    sha256: f431b034fa889526b31f6d8ad04e3e0f7b3f88a4eaf45fa6c21e8e404276939d
-  category: main
-  optional: false
-- name: pydot
-  version: 1.4.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    graphviz: ''
-    pyparsing: '>=2.1.4'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydot-1.4.2-py310hff52083_4.conda
-  hash:
-    md5: 86d7b31e8c9de50f5f29eebeb818043d
-    sha256: b70c6885402357efbe6b14b04bc92799a819d8b3b4b31cbe998b95340e6325c0
+    md5: 02a194a79b44b148592fd799fa51d81f
+    sha256: 3a340864e663c4b077765cb2811031eb5103baa24099b8e44b44d22327f3d60c
   category: main
   optional: false
 - name: pyepsg
@@ -9607,16 +10003,16 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
+    python: '>=3.9'
     requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pyepsg-0.4.0-py_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pyepsg-0.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: c3de0e5a1931c6732457300d2832f02f
-    sha256: fb2581c8a56ac969fa4ce3becbbd9e8d3de3510216e79429fe1a0a7331a3a723
+    md5: 2a34129aac7b9aeaff958abc1abdd84c
+    sha256: 45955add91644e51ad2352b0113fae5951f5e1a54045c16f413cb4d74787ef68
   category: main
   optional: false
 - name: pyerfa
-  version: 2.0.1.4
+  version: 2.0.1.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -9625,10 +10021,10 @@ package:
     numpy: '>=1.19,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyerfa-2.0.1.4-py310hf462985_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyerfa-2.0.1.5-py310hf462985_0.conda
   hash:
-    md5: 3bc9a72a742b1c8aad126ea41a8be8c7
-    sha256: b7955e150d7c29d6c3ab95ce77d1b1017da3e32f74a6d43b1bd8b77e443eb0a8
+    md5: 2e9b1a459f1e0d43fbc005eaf53c6856
+    sha256: 3fc71e8fbd55ea4e1ead5b271f682696de0de1e6a685297e03b974a34d51da1f
   category: main
   optional: false
 - name: pygls
@@ -9638,67 +10034,73 @@ package:
   dependencies:
     cattrs: '>=23.1.2'
     lsprotocol: 2023.0.1
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygls-1.3.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygls-1.3.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 1503700d2ecae45a19d02c6d3592f982
-    sha256: 9aace0a9c8f30cea5908e85e8f6a24663c98c27c11b1d0cdc5892062eabc6811
+    md5: d6f5edd64c90d2e875467e2e9cb93128
+    sha256: cdbc88aaf006880fe88668180f29f6d287277a21298669679cf892b2a1dc5f38
   category: main
   optional: false
 - name: pygments
-  version: 2.18.0
+  version: 2.19.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b7f5c092b8f9800150d998a71b76d5a1
-    sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
+    md5: 232fb4577b6687b2d503ef8e254270c9
+    sha256: 28a3e3161390a9d23bc02b4419448f8d27679d9e2c250e29849e37749c8de86b
   category: main
   optional: false
-- name: pyjwt
-  version: 2.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.9.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 5ba575830ec18d5c51c59f403310e2c7
-    sha256: b6f47cd0737cb1f5aca10be771641466ec1a3be585382d44877140eb2cb2dd46
-  category: main
-  optional: false
-- name: pykdtree
-  version: 1.3.13
+- name: pygobject
+  version: 3.50.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.0,<2.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libgcc: '>=13'
+    libgirepository: ''
+    libglib: '>=2.82.1,<3.0a0'
+    libiconv: ''
+    pycairo: ''
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pygobject-3.50.0-py310hfdab9c6_1.conda
+  hash:
+    md5: fa17557b7db77789c3ae087650f14f31
+    sha256: e2bf7b1ad771c7dbff57a7f050c2439757d11b4af14f1400e4d54c6a8892bf57
+  category: main
+  optional: false
+- name: pyjwt
+  version: 2.10.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.10.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 84c5c40ea7c5bbc6243556e5daed20e7
+    sha256: 158d8911e873e2a339c27768933747bf9c2aec1caa038f1b7b38a011734a956f
+  category: main
+  optional: false
+- name: pykdtree
+  version: 1.4.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
     libgcc: '>=13'
     numpy: '>=1.19,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pykdtree-1.3.13-py310hf462985_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pykdtree-1.4.1-py310hf462985_0.conda
   hash:
-    md5: 4f1c137b6ea5e8c7ce95c28b053843cc
-    sha256: 73a5837d11f28882302f995a226d99cdb7d145511721fa830e170e44e8982959
-  category: main
-  optional: false
-- name: pykrb5
-  version: 0.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cryptography: '>=1.3'
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pykrb5-0.5.1-py310h98feede_1.conda
-  hash:
-    md5: 0329fda0ebbccee7b3e9dbf4a377d0ce
-    sha256: 356d17f3dcff255a43e03ba30dac77d7ff55be83a11548c9885bcb12b6b5d409
+    md5: fda1853eeba3573d41d830a17aebf112
+    sha256: 46bf4f6b268b96286634ee583c8e87bda9710589721f850660c0a263315a99ce
   category: main
   optional: false
 - name: pykube-ng
@@ -9708,45 +10110,29 @@ package:
   dependencies:
     google-auth: ''
     jsonpath-ng: ''
-    python: '>=3.8'
+    python: '>=3.9'
     pyyaml: ''
     requests: '>=2.12'
     requests-oauthlib: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pykube-ng-23.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pykube-ng-23.6.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 7ca3c9091e794abf04819096909e9e1f
-    sha256: 624c0b6626a6bffa50706f0cfab4297972712ca448ad586aff3f047462635404
+    md5: 00a15f88bab0c96e72d1ad7b75abcad1
+    sha256: a07b3caa3a61cbfda153e3b7655faad40fb8df4dff627b793287fe46c9ec92e6
   category: main
   optional: false
 - name: pymbolic
-  version: '2022.2'
+  version: 2024.2.2
   manager: conda
   platform: linux-64
   dependencies:
-    numpy: ''
-    python: '>=3.6'
-    pytools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pymbolic-2022.2-pyhd8ed1ab_0.conda
+    immutabledict: ''
+    python: '>=3.10'
+    pytools: '>=2024.1.16'
+    typing_extensions: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pymbolic-2024.2.2-pyhecae5ae_0.conda
   hash:
-    md5: b2e55b3de35c94a32a83f79a0733f5b4
-    sha256: eac07e515393f891e0d4031d14db4d3609febc30a4e3536172cec412480c249b
-  category: main
-  optional: false
-- name: pymongo
-  version: 4.10.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    dnspython: <3.0.0,>=1.16.0
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pymongo-4.10.1-py310hf71b8c6_0.conda
-  hash:
-    md5: 09bbae4fe4c6f959718aca3af7e8f111
-    sha256: 33a704e053c2b49a37bd1e2d0a88a1b6a7f970447ef243d5292478b735fc9c6e
+    md5: 1dd864454446dfe0c000452fdf1e5726
+    sha256: 2a32e44230db42a1c02e6a41208e043e589d76412b6b02fed39632dcb71c4fa2
   category: main
   optional: false
 - name: pynacl
@@ -9774,71 +10160,75 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libgdal-core: '>=3.9.2,<3.10.0a0'
+    libgdal-core: '>=3.10.0,<3.11.0a0'
     libstdcxx: '>=13'
     numpy: ''
     packaging: ''
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.10.0-py310h63d473e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.10.0-py310h0aed7a2_1.conda
   hash:
-    md5: dd84f1a11871c11871b237883fc55e8a
-    sha256: af25b691fbd65ef6f36c9b641938129916e0c108c3589bfc4b8dd69e61abb4fa
+    md5: 95459fb36d2c19b491361f0a2b6feaf1
+    sha256: e7e66bac7ffbbd10a2abef7cea842bb7629adbf6d8b73dcc40079473d3aed77f
   category: main
   optional: false
 - name: pyopenssl
-  version: 24.2.1
+  version: 25.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    cryptography: '>=41.0.5,<44'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.2.1-pyhd8ed1ab_2.conda
+    cryptography: '>=41.0.5,<45'
+    python: '>=3.9'
+    typing-extensions: '>=4.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-25.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 85fa2fdd26d5a38792eb57bc72463f07
-    sha256: 6618aaa9780b723abfda95f3575900df99dd137d96c80421ad843a5cbcc70e6e
+    md5: 195fbabc5cc805f2cc10cb881a19cf8b
+    sha256: 18a487af2ae5e2c380a8bb3fe38da2b4dc3aa8d033aa75202442e1075e6f635b
   category: main
   optional: false
 - name: pyorbital
-  version: 1.8.3
+  version: 1.9.2
   manager: conda
   platform: linux-64
   dependencies:
+    defusedxml: ''
     numpy: '>=1.6.0,!=1.14.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyorbital-1.8.3-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+    requests: ''
+    scipy: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pyorbital-1.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: b8800b68eed43d48c43531de338c92af
-    sha256: e19a1dc431c908d5f4337d8b517a60a3cb1b18f956b0a1b9c94063ac0a62435a
+    md5: db0bffe72b31908055c3d50ae3fe0182
+    sha256: 0e1a43df60b1e89d24f1494b67b72f34b713f0a5ac8c991e06b2e1010098e4ed
   category: main
   optional: false
 - name: pyparsing
-  version: 3.2.0
+  version: 3.2.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 035c17fbf099f50ff60bf2eb303b0a83
-    sha256: b846e3965cd106438cf0b9dc0de8d519670ac065f822a7d66862e9423e0229cb
+    md5: 4a8479437c6e3407aaece60d9c9a820d
+    sha256: 1a28878f9fc1b65004160c7f6ed447ef0cd3e492a0880745e97ab9aee66f2c4a
   category: main
   optional: false
 - name: pyproj
-  version: 3.7.0
+  version: 3.7.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     certifi: ''
     libgcc: '>=13'
-    proj: '>=9.5.0,<9.6.0a0'
+    proj: '>=9.6.0,<9.7.0a0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py310h2e9f774_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py310h71d0299_1.conda
   hash:
-    md5: 42a3ea3c283d930ae6d156b97ffe4740
-    sha256: 16a69974015cdcacef2a82d3efcf30dcd556d2dbdf3deab7641495b78625c1af
+    md5: e54b1eaeb50ad1767680181a8575a8db
+    sha256: ec5f371389d7b57cd835144410d04f7af192487b4ff36e032c07b6c032ed383d
   category: main
   optional: false
 - name: pyresample
@@ -9860,10 +10250,10 @@ package:
     pyyaml: ''
     setuptools: '>=3.2'
     shapely: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyresample-1.31.0-py310h5eaa309_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyresample-1.31.0-py310hf71b8c6_3.conda
   hash:
-    md5: e55211876cac59b127437cfdceff1807
-    sha256: ec8b71ce1afd0385af8e3c667b734ab4dbd213b94cfa315ee0c32469c107c5a4
+    md5: 50633469bbf50354206f77f431d17029
+    sha256: 13d0503dd827e09758251b29e231d86a85b9235bc5c8f7750dcb2a65db2a2b22
   category: main
   optional: false
 - name: pyshp
@@ -9871,11 +10261,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyshp-2.3.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 92a889dc236a5197612bc85bee6d7174
-    sha256: 41eced0d5e855bc52018f200b239d627daa38ad78a655ffa2f1efd95b07b6bce
+    md5: 856b387c270e9eaf6e41e978057a2b62
+    sha256: a721b3663d1917f3c9caa01069d23c44b0a378a6d3639f7e4f7b06887a9ac9bf
   category: main
   optional: false
 - name: pysocks
@@ -9884,11 +10274,11 @@ package:
   platform: linux-64
   dependencies:
     __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   hash:
-    md5: 2a7de29fb590ca14b5243c4c812c8025
-    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    md5: 461219d1a5bd61342293efa2c0c90eac
+    sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   category: main
   optional: false
 - name: pyspectral
@@ -9907,42 +10297,27 @@ package:
     scipy: '>=1.6.0'
     setuptools: ''
     tqdm: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pyspectral-0.13.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyspectral-0.13.5-pyhd8ed1ab_1.conda
   hash:
-    md5: fb231e26b0d64d3bf989a3cc96c3c7d8
-    sha256: 21d19499972990dcc574ea39b7128e837a03b040b3a014b8843786f6af088bcc
-  category: main
-  optional: false
-- name: pyspnego
-  version: 0.11.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cryptography: ''
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    ruamel.yaml: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyspnego-0.11.1-py310hff52083_0.conda
-  hash:
-    md5: 16254b8fce76625ba4978d59473457eb
-    sha256: c495622d7bf58be919799faa2b97ceabe98d027a5a70200e543d775c041c9ea6
+    md5: 2856e9ffa2b0b23c8392970f27b4faf5
+    sha256: 6fedb865691df2e9d9bd7af066f16cf5d07402a6cc2f216f090b884533611630
   category: main
   optional: false
 - name: pystac
-  version: 1.11.0
+  version: 1.12.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
     python-dateutil: '>=2.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pystac-1.11.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-1.12.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 33c5e6aa8842a539826bd1bcb405001c
-    sha256: 51603c07c4935110872f450d4663a14e5b59e1c8fedd815f60fcd910738ea22c
+    md5: 1b4762b30f995f8a74d3857793a297d3
+    sha256: bcd0bd9a8ba5a643a3013c56d2309ed4bc959585fb8df40f3c0f156625398f4b
   category: main
   optional: false
 - name: pystac-client
-  version: 0.8.5
+  version: 0.8.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -9950,14 +10325,14 @@ package:
     python: '>=3.10'
     python-dateutil: '>=2.8.2'
     requests: '>=2.28.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.8.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.8.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 68fb9ba6beefb406896a642bf2a77e79
-    sha256: 37bd343a90605a2705d2dbabe4a588d57d75d909e77f0560b312a0f24772c0ca
+    md5: fd59657d432a890db3e65989d569e46a
+    sha256: 8127741c911325564a805407a1bb2fcd480c2284893957c9f4a56dd5160ef795
   category: main
   optional: false
 - name: pytest
-  version: 8.3.3
+  version: 8.3.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -9966,16 +10341,16 @@ package:
     iniconfig: ''
     packaging: ''
     pluggy: <2,>=1.5
-    python: '>=3.8'
+    python: '>=3.9'
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.5-pyhd8ed1ab_0.conda
   hash:
-    md5: c03d61f31f38fdb9facf70c29958bf7a
-    sha256: e99376d0068455712109d233f5790458ff861aeceb458bfda74e353338e4d815
+    md5: c3c9316209dec74a705a36797970c6be
+    sha256: 963524de7340c56615583ba7b97a6beb20d5c56a59defb59724dc2a3105169c9
   category: main
   optional: false
 - name: python
-  version: 3.10.15
+  version: 3.10.16
   manager: conda
   platform: linux-64
   dependencies:
@@ -9984,21 +10359,21 @@ package:
     ld_impl_linux-64: '>=2.36.1'
     libffi: '>=3.4,<4.0a0'
     libgcc: '>=13'
+    liblzma: '>=5.6.3,<6.0a0'
     libnsl: '>=2.0.1,<2.1.0a0'
-    libsqlite: '>=3.46.1,<4.0a0'
+    libsqlite: '>=3.47.0,<4.0a0'
     libuuid: '>=2.38.1,<3.0a0'
     libxcrypt: '>=4.4.36'
     libzlib: '>=1.3.1,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
-    openssl: '>=3.3.2,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.15-h4a871b0_2_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.16-he725a3c_1_cpython.conda
   hash:
-    md5: 98059097f62e97be9aed7ec904055825
-    sha256: c1e5e93b887d8cd1aa31d24b9620cb7eb6645c08c97b15ffc844fd6c29051420
+    md5: b887811a901b3aa622a92caf03bc8917
+    sha256: 3f90a2d5062a73cd2dd8a0027718aee1db93f7975b9cfe529e2c9aeec2db262e
   category: main
   optional: false
 - name: python-blosc
@@ -10019,7 +10394,7 @@ package:
   category: main
   optional: false
 - name: python-box
-  version: 7.2.0
+  version: 7.3.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -10030,10 +10405,10 @@ package:
     python_abi: 3.10.*
     ruamel.yaml: ''
     toml: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-box-7.2.0-py310ha75aee5_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-box-7.3.2-py310ha75aee5_0.conda
   hash:
-    md5: a57f2795ad861a6d2356ae964123e5a1
-    sha256: 382fb0f2f65b667fbfad870ec49547b5edb31cead07f5e56571b15dfb701c635
+    md5: 44c7f1ecc35244f979348a29146ff2ce
+    sha256: befbec29c52e08d98a85d5a746f7fb1357d94e3766852a167476462c13990a6b
   category: main
   optional: false
 - name: python-dateutil
@@ -10050,19 +10425,19 @@ package:
   category: main
   optional: false
 - name: python-dotenv
-  version: 1.0.1
+  version: 1.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.0-pyh29332c3_1.conda
   hash:
-    md5: c2997ea9360ac4e015658804a7a84f94
-    sha256: 2d4c80364f03315d606a50eddd493dbacc078e21412c2462c0f781eec49b572c
+    md5: 27d816c6981a8d50090537b761de80f4
+    sha256: 7d927317003544049c97e7108e8ca5f2be5ff0ea954f5c84c8bbeb243b663fc8
   category: main
   optional: false
 - name: python-duckdb
-  version: 1.1.3
+  version: 1.2.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -10071,10 +10446,10 @@ package:
     libstdcxx: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.1.3-py310hf71b8c6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.2.1-py310hf71b8c6_0.conda
   hash:
-    md5: 1c07ae5896495839be2503ef31628c5f
-    sha256: 0af8fabe998df691b317d7ac0455b30d6d64ce240e5bcedeb16b9ae8cf3a1533
+    md5: a386d22875bb071c793bdb31eb318f34
+    sha256: 98b19757ef0205fe2c2ef335778bb93b57be26105444a9b95d5cab0f398c959c
   category: main
   optional: false
 - name: python-eccodes
@@ -10098,15 +10473,15 @@ package:
   category: main
   optional: false
 - name: python-fastjsonschema
-  version: 2.20.0
+  version: 2.21.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b98d2018c01ce9980c03ee2850690fab
-    sha256: 7d8c931b89c9980434986b4deb22c2917b58d9936c3974139b9c10ae86fdfe60
+    md5: 38e34d2d1d9dca4fb2b9a0a04f604e2c
+    sha256: 1b09a28093071c1874862422696429d0d35bd0b8420698003ac004746c5e82a2
   category: main
   optional: false
 - name: python-geotiepoints
@@ -10132,13 +10507,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6,<4.0'
+    python: '>=3.9,<4.0'
     python-gnupg: '>=0.4.7,<0.5.0'
     requests: '>=2.25.1,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-gist-0.10.6-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/python-gist-0.10.6-pyhd8ed1ab_1.conda
   hash:
-    md5: d166ece084acb7c59988847a02b1e498
-    sha256: e19b74515085d60ae72508e84a3d6cbbd4128f47bf9e236a06b3941891fa9e63
+    md5: 8fe1012cce9240c63500b8087655249a
+    sha256: 7e1870c0c868069e318f244d14db82915c434875e1b8f410057ea8e3dd1892c9
   category: main
   optional: false
 - name: python-gnupg
@@ -10159,46 +10534,11 @@ package:
   platform: linux-64
   dependencies:
     graphviz: '>=2.46.1'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyhe28f650_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyh91182bf_2.conda
   hash:
-    md5: 881be78ca9f3f2f5f6aa45d9b38a799f
-    sha256: 0eca3595a52dd7ad83ebca1ee738af50bf21dbd70d623583b0185d84074e21af
-  category: main
-  optional: false
-- name: python-gssapi
-  version: 1.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    decorator: ''
-    krb5: '>=1.21.3,<1.22.0a0'
-    libgcc: '>=13'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-gssapi-1.9.0-py310h695cd88_0.conda
-  hash:
-    md5: ad55798789718fc59f8ded94e2cf1a4a
-    sha256: 074074673a5a5e602b4f878f7d860168c7a66abbf46a27ab81680f09d6ae3d0a
-  category: main
-  optional: false
-- name: python-hdfs
-  version: 2.7.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    docopt: ''
-    fastavro: '>=0.21.19'
-    pandas: '>=0.14.1'
-    python: '>=3.7'
-    requests: '>=2.7.0'
-    requests-kerberos: '>=0.7.0'
-    six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.7.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: c43e50d900680f7bfbb0237317b9983f
-    sha256: 09eb22ebcbd42fe4ee517cfed707ceb92cc8a4ca3102ed8fa1d44d5bc3e914eb
+    md5: f822f0e13849c2283f72ec4aa120eeaa
+    sha256: c8f5d3d23b5962524217f33549add8d6c5af22fe839b49603f4588771154a51c
   category: main
   optional: false
 - name: python-json-logger
@@ -10214,49 +10554,50 @@ package:
   category: main
   optional: false
 - name: python-jsonpath
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-jsonpath-1.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-jsonpath-1.3.0-pyhff2d567_0.conda
   hash:
-    md5: 14e19678b15886c27dd7bae60d5254f6
-    sha256: fda8967d652fa124a1288b24b4cdefaee607a2a3e7eda9cfc74f82affe6514d2
+    md5: 23d1f2196e8531b29b12dddeeb6fe0f1
+    sha256: df3f9581eedfdada390d4b2639fc6821c87b13be2d0f141a47a814aa4422e5ce
   category: main
   optional: false
 - name: python-kubernetes
-  version: 28.1.0
+  version: 32.0.1
   manager: conda
   platform: linux-64
   dependencies:
     certifi: '>=14.05.14'
+    durationpy: '>=0.7'
     google-auth: '>=1.0.1'
     oauthlib: '>=3.2.2'
-    python: '>=3.6'
+    python: '>=3.9'
     python-dateutil: '>=2.5.3'
     pyyaml: '>=5.4.1'
     requests: ''
     requests-oauthlib: ''
     six: '>=1.9.0'
-    urllib3: '>=1.24.2,<2.0'
+    urllib3: '>=1.24.2'
     websocket-client: '>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-kubernetes-28.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-kubernetes-32.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 19e0767d01e052487650c0341c186219
-    sha256: 559098188048ea52739815b2311b06bf381bf4c7a7924baaf2e99de0c01b2113
+    md5: d93b25519ea3ea3fb735060c7bbd9f14
+    sha256: 6d341f4c4fb5066dac6a8a522e12692cb93ec77132ac2265773d8684f59955e9
   category: main
   optional: false
 - name: python-multipart
-  version: 0.0.17
+  version: 0.0.20
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.17-pyhff2d567_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.20-pyhff2d567_0.conda
   hash:
-    md5: a08ea55eb3ad403b12639cd3a4a8d28f
-    sha256: f351636a91163de28cf602c755abd1b5ad858e4a790c3a30d5a5aa1066c0550c
+    md5: a28c984e0429aff3ab7386f7de56de6f
+    sha256: 1b03678d145b1675b757cba165a0d9803885807792f7eb4495e48a38858c3cca
   category: main
   optional: false
 - name: python-pdal
@@ -10266,15 +10607,15 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libpdal-core: '>=2.8.0,<2.9.0a0'
+    libpdal-core: '>=2.8.4,<2.9.0a0'
     libstdcxx: '>=13'
     numpy: '>=1.19,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-pdal-3.4.5-py310h9c14f8f_12.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-pdal-3.4.5-py310h944fe6c_14.conda
   hash:
-    md5: beb60b0e19ce59719d99c33579249947
-    sha256: 254b79eda9f314661962a7291dcb5299d2b854b8c76f0d2001482b5652024aa7
+    md5: 031a12752a8c09666b613b8158f42aef
+    sha256: 2ba5f3906397e4cb15b480cf21de361aa2df89d6d63d2cb362480614bd966a6d
   category: main
   optional: false
 - name: python-slugify
@@ -10282,24 +10623,49 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     text-unidecode: '>=1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 4b11845622b3c3178c0e989235b53975
-    sha256: a1270bfd4f1d648766c8f95403f208e50d34af94761bc553a960102c6bff9fa0
+    md5: a4059bc12930bddeb41aef71537ffaed
+    sha256: a84f270426ae7661f79807b107dedb9829c79bd45f77a3033aa021e10556e87f
   category: main
   optional: false
-- name: python-tzdata
-  version: '2024.2'
+- name: python-socks
+  version: 2.7.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-socks-2.7.1-pyhff2d567_0.conda
   hash:
-    md5: 986287f89929b2d629bd6ef6497dc307
-    sha256: fe3f62ce2bc714bdaa222ab3f0344a2815ad9e853c6df38d15c9f25de8a3a6d4
+    md5: d7bf2bf5c9ea3417616f48ab4f3a64d9
+    sha256: b694450ece9c472634c7aa97ed7f6a7762b43ff3df15ffc08f63fe1d7d7ace34
+  category: main
+  optional: false
+- name: python-tzdata
+  version: '2025.2'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 88476ae6ebd24f39261e0854ac244f33
+    sha256: e8392a8044d56ad017c08fec2b0eb10ae3d1235ac967d0aab8bd7b41c4a5eaf0
+  category: main
+  optional: false
+- name: python-uv
+  version: 0.6.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    uv: 0.6.10.*
+  url: https://conda.anaconda.org/conda-forge/noarch/python-uv-0.6.10-pyhd8ed1ab_1.conda
+  hash:
+    md5: 24332063325e59b44d8b0faf0895ab92
+    sha256: 7fcb26a97fbd4baa24f798f6e7d77c01f2d63bd2971fcebc31f1740dfa5c2714
   category: main
   optional: false
 - name: python_abi
@@ -10314,43 +10680,31 @@ package:
   category: main
   optional: false
 - name: pytools
-  version: 2024.1.14
+  version: 2025.1.1
   manager: conda
   platform: linux-64
   dependencies:
     platformdirs: '>=2.2'
-    python: '>=3.8'
+    python: '>=3.10'
     siphash24: '>=1.6'
     typing-extensions: '>=4'
-    typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytools-2024.1.14-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytools-2025.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8d9d51e98099390c35e72f5b8b1747f1
-    sha256: 427dc2ad1ec0afc51aa00e2b28c09dd7bb0d4efecad11088caf0adc7f947468a
+    md5: 2555b99fa881e886ab9463148d4507ef
+    sha256: 728ae410f2f210e70cdbbcd93198f959ac23b4168583af7da7f073412d8d24a0
   category: main
   optional: false
 - name: pytz
-  version: '2023.4'
+  version: '2024.1'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 89445e229eb2d6605be88e0908afc912
-    sha256: c988e6b9032ac2f917540a1d5a2268f45c01892c392fd7eee9d5c60270337835
-  category: main
-  optional: false
-- name: pytzdata
-  version: '2020.1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pytzdata-2020.1-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 7dd824593f3a861130ac17c6571546e2
-    sha256: e7e628c1247b096e3af147b1c32d5ac328266fa95656e27b79f71bb410251356
+    md5: 3eeeeb9e4827ace8c0c1419c85d590ad
+    sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
   category: main
   optional: false
 - name: pyu2f
@@ -10358,29 +10712,29 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=2.7'
+    python: '>=3.9'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pyu2f-0.1.5-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pyu2f-0.1.5-pyhd8ed1ab_1.conda
   hash:
-    md5: caabbeaa83928d0c3e3949261daa18eb
-    sha256: 667a5a30b65a60b15f38fa4cb09efd6d2762b5a0a9563acd9555eaa5e0b953a2
+    md5: 644bd4ca9f68ef536b902685d773d697
+    sha256: 991caa5408aea018488a2c94e915c11792b9321b0ef64401f4829ebd0abfb3c0
   category: main
   optional: false
 - name: pyviz_comms
-  version: 3.0.3
+  version: 3.0.4
   manager: conda
   platform: linux-64
   dependencies:
     param: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 02b4e3a3014c1ac490ee4a4316f2d229
-    sha256: a7979e8e4936c430f5fe3d04fc2d67b42dab84fb4a502c4961a17dcb2327fec0
+    md5: 99b8cf929b145ae310b333ce3496b56b
+    sha256: 0352b6935ec73bc996829c61d1ebc7896caa31015073e43036af939fbe91a17a
   category: main
   optional: false
 - name: pywavelets
-  version: 1.7.0
+  version: 1.8.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -10389,10 +10743,10 @@ package:
     numpy: '>=1.23,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.7.0-py310hf462985_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.8.0-py310hf462985_0.conda
   hash:
-    md5: bb603a9ffd8f7e97c93c74a5e3c3febd
-    sha256: 902be1151055b0bdb0c6ea1be8de26a600c8019a93116bf1c9c531ebb7c20c24
+    md5: 4c441eff2be2e65bd67765c5642051c5
+    sha256: f23e0b5432c6d338876eca664deeb360949062ce026ddb65bcb1f31643452354
   category: main
   optional: false
 - name: pywin32-on-windows
@@ -10418,14 +10772,14 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py310ha75aee5_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py310h89163eb_2.conda
   hash:
-    md5: 0d4c5c76ae5f5aac6f0be419963a19dd
-    sha256: bf6002aef0fd9753fa6de54e82307b2d7e67a1d701dba018869471426078d5d1
+    md5: fd343408e64cf1e273ab7c710da374db
+    sha256: 5fba7f5babcac872c72f6509c25331bcfac4f8f5031f0102530a41b41336fce6
   category: main
   optional: false
 - name: pyzmq
-  version: 26.2.0
+  version: 26.3.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -10436,10 +10790,10 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py310h71f11fc_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.3.0-py310h71f11fc_0.conda
   hash:
-    md5: 0c3fe057cc758c8fa1beba31ff4e5c35
-    sha256: d5bbafe00fbed64134f5c3cc38a2f16a9dc0f24c747f81f8341c53758d8b5d96
+    md5: 930d3ad098bb986315a2f95814c5cf42
+    sha256: 25c88b22d72a134793d3e294ec1398279cb5eab420d803a3c32e29e1831b2a56
   category: main
   optional: false
 - name: qhull
@@ -10457,7 +10811,7 @@ package:
   category: main
   optional: false
 - name: rasterio
-  version: 1.4.1
+  version: 1.4.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -10469,18 +10823,18 @@ package:
     click-plugins: ''
     cligj: '>=0.5'
     libgcc: '>=13'
-    libgdal-core: '>=3.9.2,<3.10.0a0'
+    libgdal-core: '>=3.10.2,<3.11.0a0'
     libstdcxx: '>=13'
     numpy: '>=1.21,<3'
-    proj: '>=9.5.0,<9.6.0a0'
+    proj: '>=9.6.0,<9.7.0a0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     setuptools: '>=0.9.8'
     snuggs: '>=1.4.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.1-py310hf6c6cbe_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.3-py310hb0078ae_1.conda
   hash:
-    md5: bee24b6587ea52439240ce74ae6a09fc
-    sha256: 5df42c35433a82ced728c6cb8d1fafc6ce27b98f3fa31d35519d7e4a64c62d17
+    md5: 2a9ec43a016152a9ec14b0362cc0d177
+    sha256: b533abbf9ee6da76b22144a51dcd5e69df80e0cedce507967141324af83288ec
   category: main
   optional: false
 - name: rav1e
@@ -10496,15 +10850,15 @@ package:
   category: main
   optional: false
 - name: re2
-  version: 2023.09.01
+  version: 2024.07.02
   manager: conda
   platform: linux-64
   dependencies:
-    libre2-11: 2023.09.01
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_2.conda
+    libre2-11: 2024.07.02
+  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h9925aae_2.conda
   hash:
-    md5: 8f70e36268dea8eb666ef14c29bd3cda
-    sha256: f0f520f57e6b58313e8c41abc7dfa48742a05f1681f05654558127b667c769a8
+    md5: e84ddf12bde691e8ec894b00ea829ddf
+    sha256: d213c44958d49ce7e0d4d5b81afec23640cce5016685dbb2d23571a99caa4474
   category: main
   optional: false
 - name: readchar
@@ -10524,56 +10878,42 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    ncurses: '>=6.3,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+    libgcc: '>=13'
+    ncurses: '>=6.5,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
   hash:
-    md5: 47d31b792659ce70f470b5c82fdfb7a4
-    sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+    md5: 283b96675859b20a825f8fa30f311446
+    sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
   category: main
   optional: false
 - name: rechunker
-  version: 0.5.2
+  version: 0.5.3
   manager: conda
   platform: linux-64
   dependencies:
     dask-core: ''
     mypy_extensions: ''
-    python: '>=3.8'
-    zarr: '>=2.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/rechunker-0.5.2-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+    zarr: <3,>=2.11
+  url: https://conda.anaconda.org/conda-forge/noarch/rechunker-0.5.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 59ddcea7bc08b007a73bcf1a80c0d9b0
-    sha256: ece0b0ac0fff93bdc068e169cc394a5f65bb119242f15b84b06dbb1b176b21b2
-  category: main
-  optional: false
-- name: redis-py
-  version: 5.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    async-timeout: '>=4.0.2'
-    importlib-metadata: '>=1.0'
-    python: '>=3.8'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/redis-py-5.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6500d1982f80aacd0fb41ce74771fbed
-    sha256: c6864b473b8faa1c7a3bba28fafd7b1bdb85062f0c6cbd3472169479e76d77a8
+    md5: 213b9623313cb962493870e6e14d6f27
+    sha256: 870d20c8ff6b179b60bc973d7b8c92575ac6912e1bb9175ba3e372b64f749b40
   category: main
   optional: false
 - name: referencing
-  version: 0.35.1
+  version: 0.36.2
   manager: conda
   platform: linux-64
   dependencies:
     attrs: '>=22.2.0'
-    python: '>=3.8'
+    python: ''
     rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
   hash:
-    md5: 0fc8b52192a8898627c3efae1003e9f6
-    sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
+    md5: 9140f1c09dd5489549c6a33931b943c7
+    sha256: e20909f474a6cece176dfc0dc1addac265deb5fa92ea90e975fbca48085b20c3
   category: main
   optional: false
 - name: regex
@@ -10599,30 +10939,33 @@ package:
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: '>=3.8'
+    python: '>=3.9'
     urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 5ede4753180c7a550a443c430dc8ab52
-    sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
+    md5: a9b9368f3701a417eac9edbcae7cb737
+    sha256: d701ca1136197aa121bbbe0e8c18db6b5c94acbd041c2b43c70e5ae104e1d8ad
   category: main
   optional: false
-- name: requests-kerberos
-  version: 0.15.0
+- name: requests-cache
+  version: 1.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    __unix: ''
-    cryptography: '>=1.3'
-    pykrb5: '>=0.3.0'
-    pyspnego: ''
-    python: '>=3.8'
-    python-gssapi: '>=1.6.0'
-    requests: '>=1.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-kerberos-0.15.0-pyh707e725_0.conda
+    attrs: '>=21.2'
+    cattrs: '>=22.2'
+    itsdangerous: '>=2.0'
+    platformdirs: '>=2.5'
+    python: '>=3.9'
+    pyyaml: '>=6.0.1'
+    requests: '>=2.22'
+    ujson: '>=5.4'
+    url-normalize: '>=1.4'
+    urllib3: '>=1.25.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: b56c004b94c38569f79d735f1345c054
-    sha256: f80cfc7e4d8c5a07404c1bf04137cca313a539318199c3b63d2ab914b7ecb7ce
+    md5: 584e6aab3a5cffde537c575ad6a673ff
+    sha256: 97195fe57ef9ab18e368a8d1f021be4e041f97638bed90a339e068989159e877
   category: main
   optional: false
 - name: requests-oauthlib
@@ -10631,12 +10974,12 @@ package:
   platform: linux-64
   dependencies:
     oauthlib: '>=3.0.0'
-    python: '>=3.4'
+    python: '>=3.9'
     requests: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-2.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-2.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 87ce3f09ae7e1d3d0f748a1a634ea3b7
-    sha256: 3d2b0ad106ad5745445c2eb7e7f90b0ce75dc9f4d8c518eb6fd75aad3c80c2cc
+    md5: a283b764d8b155f81e904675ef5e1f4b
+    sha256: 75ef0072ae6691f5ca9709fe6a2570b98177b49d0231a6749ac4e610da934cab
   category: main
   optional: false
 - name: rfc3339-validator
@@ -10644,12 +10987,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
+    python: '>=3.9'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
   hash:
-    md5: fed45fc5ea0813240707998abe49f520
-    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
+    md5: 36de09a8d3e5d5e6f4ee63af49e59706
+    sha256: 2e4372f600490a6e0b3bac60717278448e323cab1c0fecd5f43f7c56535a99c5
   category: main
   optional: false
 - name: rfc3986-validator
@@ -10671,32 +11014,47 @@ package:
   dependencies:
     markdown-it-py: '>=2.2.0'
     pygments: '>=2.13.0,<3.0.0'
-    python: '>=3.8'
+    python: '>=3.9'
     typing_extensions: '>=4.0.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
   hash:
-    md5: bcf8cc8924b5d20ead3d122130b8320b
-    sha256: c009488fc07fd5557434c9c1ad32ab1dd50241d6a766e4b2b4125cd6498585a8
+    md5: 7aed65d4ff222bfb7335997aa40b7da5
+    sha256: 06a760c5ae572e72e865d5a87e9fe3cc171e1a9c996e63daf3db52ff1a0b4457
+  category: main
+  optional: false
+- name: rich-toolkit
+  version: 0.11.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+    rich: '>=13.7.1'
+    click: '>=8.1.7'
+    typing_extensions: '>=4.12.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.11.3-pyh29332c3_0.conda
+  hash:
+    md5: 4ba15ae9388b67d09782798347481f69
+    sha256: e558f8c254a9ff9164d069110da162fc79497d70c60f2c09a5d3d0d7101c5628
   category: main
   optional: false
 - name: rio-cogeo
-  version: 5.3.6
+  version: 5.4.1
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=7.0'
-    morecantile: '>=5.0,<6.0'
+    morecantile: '>=5.0,<7.0'
     pydantic: '>=2.0,<3.dev0'
-    python: '>=3.8'
+    python: '>=3.9'
     rasterio: '>=1.3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/rio-cogeo-5.3.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rio-cogeo-5.4.1-pyhd8ed1ab_0.conda
   hash:
-    md5: e771b73aeb202e24e532527cd13872b3
-    sha256: dc1c392deabec6ec8ea99e6d05d7ad24652271c27129cf789f044cca2a4f26e2
+    md5: 209dfe91a28acffcb917528b104e0c42
+    sha256: d0ae2dc346dec184d59dc30631bffc123964407c19911988cb382c302db61720
   category: main
   optional: false
 - name: rio-tiler
-  version: 7.2.0
+  version: 7.5.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -10711,16 +11069,16 @@ package:
     numpy: ''
     pydantic: ~=2.0
     pystac: '>=0.5.4'
-    python: '>=3.8'
+    python: '>=3.9'
     rasterio: '>=1.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rio-tiler-7.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rio-tiler-7.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d5ce9e27dc3bd8d6b73884c4c87ddd12
-    sha256: 33c3ef4a362a4d175f629cfbb8bfc417ed1cf93772c3e7e0429566a016fac5ad
+    md5: 4a82e418f2486000086540eadd910d50
+    sha256: 7159a023b25c35c869f8eee5c23f3affee6c7911ad864021c4521c8a4094dc76
   category: main
   optional: false
 - name: rioxarray
-  version: 0.17.0
+  version: 0.18.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -10728,17 +11086,17 @@ package:
     packaging: ''
     pyproj: '>=3.3'
     python: '>=3.10'
-    rasterio: '>=1.3'
+    rasterio: '>=1.3.7'
     scipy: ''
-    xarray: '>=2022.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
+    xarray: '>=2024.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.18.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 160464c6f979eb68e9a9ea31dd6b5aa6
-    sha256: 992ce1a2667dd2beac45157dcb9058775e0522ebf1a70f1563c0fd0608f9480a
+    md5: daf05c3baaae11700637ab0e9c678c00
+    sha256: 77ca13bbbd01c0649eeac57db35ddf511d16e09b53703cc28cffa0ee32bf3f25
   category: main
   optional: false
 - name: roaring-landmask
-  version: 0.9.1
+  version: 0.9.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -10748,25 +11106,25 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     xz: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/roaring-landmask-0.9.1-py310hed47299_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/roaring-landmask-0.9.2-py310hed47299_0.conda
   hash:
-    md5: f279cdb36215b63bd8d371d01e68fb77
-    sha256: cab01fbd72302ed8ac5d4d07d229ca4f0c4cacf3bc3f9dce637802bc02f10112
+    md5: 9864deda04ee83147efbb89029537c99
+    sha256: eacf6c6d3d6165bf0819abe08258c3b558cbb3948322502d2446bf921622aa92
   category: main
   optional: false
 - name: rpds-py
-  version: 0.21.0
+  version: 0.23.1
   manager: conda
   platform: linux-64
   dependencies:
+    python: ''
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.21.0-py310h505e2c1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.23.1-py310hc1293b2_0.conda
   hash:
-    md5: 060aac00c8de3dcf3d329c1a7c2250fb
-    sha256: ec1575ef0faf919b396c4d93a06c571c9b104872ebc2cb0cfc01eb822009c75b
+    md5: 55afda712d4c48108d993ded1bd4de9b
+    sha256: 775f9fe47c18f8c6c4cb706c7837cc04cdc18e6a748fd8964e132d8329975eea
   category: main
   optional: false
 - name: rsa
@@ -10775,11 +11133,11 @@ package:
   platform: linux-64
   dependencies:
     pyasn1: '>=0.1.3'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_1.conda
   hash:
-    md5: 03bf410858b2cefc267316408a77c436
-    sha256: 23214cdc15a41d14136754857fd9cd46ca3c55a7e751da3b3a48c673f0ee2a57
+    md5: 91def14612d11100329d53a75993a4d5
+    sha256: 210ff0e3aaa8ce8e9d45a5fd578ce7b2d5bcd7d3054dc779c3a159b8f72104d6
   category: main
   optional: false
 - name: ruamel.yaml
@@ -10814,45 +11172,45 @@ package:
   category: main
   optional: false
 - name: s2n
-  version: 1.5.5
+  version: 1.5.11
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.5-h3931f03_0.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.11-h072c03f_0.conda
   hash:
-    md5: 334dba9982ab9f5d62033c61698a8683
-    sha256: a6fa0afa836f8f26dea0abc180ca2549bb517932d9a88a121e707135d4bcb715
+    md5: 5e8060d52f676a40edef0006a75c718f
+    sha256: cfdd98c8f9a1e5b6f9abce5dac6d590cc9fe541a08466c9e4a26f90e00b569e3
   category: main
   optional: false
 - name: s3fs
-  version: 2024.10.0
+  version: 2025.3.0
   manager: conda
   platform: linux-64
   dependencies:
     aiobotocore: '>=2.5.4,<3.0.0'
     aiohttp: ''
-    fsspec: 2024.10.0
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.10.0-pyhd8ed1ab_0.conda
+    fsspec: 2025.3.0
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2025.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 18cc1c4f5b104400d75be999b56486a1
-    sha256: b5a8e8fb68087166abef44c185dfb8c6ad1e4b54c56e82c03a3e3b306e0ca757
+    md5: 01213585444a0b41b4cd4d9940ab1c4f
+    sha256: 5654f5050027651dd289118fc70c4c534ef64ad4378fa2876f35e9f9d6a7788a
   category: main
   optional: false
 - name: s3transfer
-  version: 0.10.3
+  version: 0.11.3
   manager: conda
   platform: linux-64
   dependencies:
-    botocore: '>=1.33.2,<2.0a.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.3-pyhd8ed1ab_0.conda
+    botocore: '>=1.36.0,<2.0a.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.11.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 0878f8e10cb8b4e069d27db48b95c3b5
-    sha256: a8d6061e31cd4e315b26ab1f6a74c618c930d3e14eb3b7c82e4077a11eae2141
+    md5: 2d1d519bcf3031d5d809411d1aa9f838
+    sha256: 35ed9da0f4562d1470ad77774a274132b648713f4fe22287029a812c8416a1a5
   category: main
   optional: false
 - name: sarsen
@@ -10877,7 +11235,7 @@ package:
   category: main
   optional: false
 - name: satpy
-  version: 0.52.1
+  version: 0.55.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -10893,45 +11251,46 @@ package:
     pyproj: ''
     pyresample: '>=1.10.3'
     pyspectral: ''
-    python: '>=3.9'
+    python: '>=3.10'
     pyyaml: ''
     trollimage: '>=1.5.1'
     trollsift: ''
     xarray: '>=0.10.1'
     zarr: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/satpy-0.52.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/satpy-0.55.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2d692be9f7d970828bb89c2900e398e2
-    sha256: e4bdefc2c147c924f6b9b9a019d8dbd0b995585a500b6abeffb18c1024f213b4
+    md5: a49a5e4797cca54db228292c259ad41e
+    sha256: 7b06544b4fb025c25282a79d5ddb23a78460f96f422dd712b3dfd8e11ba2096c
   category: main
   optional: false
 - name: scikit-image
-  version: 0.24.0
+  version: 0.25.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    imageio: '>=2.27'
-    lazy_loader: '>=0.2'
+    imageio: '>=2.33,!=2.35.0'
+    lazy-loader: '>=0.4'
+    lazy_loader: '>=0.4'
     libgcc: '>=13'
     libstdcxx: '>=13'
-    networkx: '>=2.8'
-    numpy: '>=1.19,<3'
+    networkx: '>=3.0'
+    numpy: '>=1.24'
     packaging: '>=21'
-    pillow: '>=9.0.1'
+    pillow: '>=10.1'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     pywavelets: '>=1.1.1'
-    scipy: '>=1.8'
+    scipy: '>=1.11.4'
     tifffile: '>=2022.8.12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.24.0-py310h5eaa309_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.25.2-py310h5eaa309_0.conda
   hash:
-    md5: cdd4d54cd13db50da776dfc8b0293d1a
-    sha256: 8032d270eebdd135fe71b3094cc80e641b28f5f8737be1f722a75a5a10cf484a
+    md5: 4cc3a231679ecb3c0ba20ebf3c27d12e
+    sha256: af36d684f7dade6e5bbf29c1b14858bc7647311ff3d37f3ef545066e713e124e
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.5.2
+  version: 1.6.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -10945,14 +11304,14 @@ package:
     python_abi: 3.10.*
     scipy: ''
     threadpoolctl: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.2-py310h27f47ee_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.6.1-py310h27f47ee_0.conda
   hash:
-    md5: 374383a1c0d197bdc1eee7c4973b732d
-    sha256: 777580d5ba89c5382fa63807a7981ae2261784258e84f5a9e747f5bd3d3428f3
+    md5: 618ec5a8500fb53e8e52785e06d239f4
+    sha256: 5c865487412b900d0abeb934907e5357c4a6cad19093316701ffd575980d0c54
   category: main
   optional: false
 - name: scipy
-  version: 1.14.1
+  version: 1.15.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -10967,10 +11326,10 @@ package:
     numpy: '>=1.23.5'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py310hfcf56fc_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py310h1d65ade_0.conda
   hash:
-    md5: d9b1b75a227dbc42f3fe0e8bc852b805
-    sha256: df95244cd5faf7ede8560081db49892cb8ae99e202044d9eb00e4792d9d29af0
+    md5: 8c29cd33b64b2eb78597fa28b5595c8d
+    sha256: 4cb98641f870666d365594013701d5691205a0fe81ac3ba7778a23b1cc2caa8e
   category: main
   optional: false
 - name: scooby
@@ -10978,11 +11337,59 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/scooby-0.10.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/scooby-0.10.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 9e57330f431abbb4c88a5f898a4ba223
-    sha256: e47c80ff6c06898e7f49fbea5b0fd3a97dda0c11348004ada2070071d03b34cf
+    md5: 9a31268f80dd46548da27e0a7bac9d68
+    sha256: aaed63591d6179a14b29df5ac1fcc30043b47dc7b81a5764313dc73183008b1d
+  category: main
+  optional: false
+- name: sdl2
+  version: 2.32.50
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libegl: '>=1.7.0,<2.0a0'
+    libgcc: '>=13'
+    libgl: '>=1.7.0,<2.0a0'
+    libstdcxx: '>=13'
+    sdl3: '>=3.2.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.50-h9b8e6db_1.conda
+  hash:
+    md5: 0d27110a2f613abc268e31b3c1d5fb4f
+    sha256: c253ddeafdc46bb53cdac722d1305a94bbbd9905e6a112e295ce7bb9e7a2f7e7
+  category: main
+  optional: false
+- name: sdl3
+  version: 3.2.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    dbus: '>=1.13.6,<2.0a0'
+    jack: '>=1.9.22,<1.10.0a0'
+    libdrm: '>=2.4.124,<2.5.0a0'
+    libegl: '>=1.7.0,<2.0a0'
+    libgcc: '>=13'
+    libgl: '>=1.7.0,<2.0a0'
+    libstdcxx: '>=13'
+    libudev1: '>=256.7'
+    libunwind: '>=1.6.2,<1.7.0a0'
+    liburing: '>=2.9,<2.10.0a0'
+    libusb: '>=1.0.27,<2.0a0'
+    libxkbcommon: '>=1.8.0,<2.0a0'
+    pulseaudio-client: '>=17.0,<17.1.0a0'
+    wayland: '>=1.23.1,<2.0a0'
+    xorg-libx11: '>=1.8.11,<2.0a0'
+    xorg-libxcursor: '>=1.2.3,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+    xorg-libxscrnsaver: '>=1.2.4,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.8-h3083f51_0.conda
+  hash:
+    md5: 1a851d6f325949ce4c1cd5cd9e5003a7
+    sha256: 29673874d0016bad4e26c6fbd6f34882346a6aa89138b54a3cb682aee70675c5
   category: main
   optional: false
 - name: seaborn
@@ -10992,10 +11399,10 @@ package:
   dependencies:
     seaborn-base: 0.13.2
     statsmodels: '>=0.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
   hash:
-    md5: a79d8797f62715255308d92d3a91ef2e
-    sha256: 79943fbbf1fafbf969257989a7d88638c0c3e7b89a81a75c9347c28768dd6141
+    md5: 62afb877ca2c2b4b6f9ecb37320085b6
+    sha256: ea29a69b14dd6be5cdeeaa551bf50d78cafeaf0351e271e358f9b820fcab4cb0
   category: main
   optional: false
 - name: seaborn-base
@@ -11006,12 +11413,12 @@ package:
     matplotlib-base: '>=3.4,!=3.6.1'
     numpy: '>=1.20,!=1.24.0'
     pandas: '>=1.2'
-    python: '>=3.8'
+    python: '>=3.9'
     scipy: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
   hash:
-    md5: b713b116feaf98acdba93ad4d7f90ca1
-    sha256: 5de8b9e88a0f2daf58b07e3f144da26f894e9a20071304fa37329664eb2a29a7
+    md5: fd96da444e81f9e6fcaac38590f3dd42
+    sha256: f209c9c18187570b85ec06283c72d64b8738f825b1b82178f194f4866877f8aa
   category: main
   optional: false
 - name: send2trash
@@ -11020,40 +11427,40 @@ package:
   platform: linux-64
   dependencies:
     __linux: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
   hash:
-    md5: 778594b20097b5a948c59e50ae42482a
-    sha256: c4401b071e86ddfa0ea4f34b85308db2516b6aeca50053535996864cfdee7b3f
+    md5: 938c8de6b9de091997145b3bf25cdbf9
+    sha256: 00926652bbb8924e265caefdb1db100f86a479e8f1066efe395d5552dde54d02
   category: main
   optional: false
 - name: setuptools
-  version: 75.3.0
+  version: 75.8.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
   hash:
-    md5: 2ce9825396daf72baabaade36cee16da
-    sha256: a36d020b9f32fc3f1a6488a1c4a9c13988c6468faf6895bf30ca69521a61230e
+    md5: 9bddfdbf4e061821a1a443f93223be61
+    sha256: 91d664ace7c22e787775069418daa9f232ee8bafdd0a6a080a5ed2395a6fa6b2
   category: main
   optional: false
 - name: shapely
-  version: 2.0.6
+  version: 2.0.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    geos: '>=3.13.0,<3.13.1.0a0'
+    geos: '>=3.13.1,<3.13.2.0a0'
     libgcc: '>=13'
     numpy: '>=1.19,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.6-py310had3dfd6_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.7-py310h247727d_1.conda
   hash:
-    md5: a4166b41e54d22e794859641b7cae2d0
-    sha256: f39309969c028b3b53831b4b7982d68d7de1bfdc2bf25d3330b8e4aea1494350
+    md5: a7e42b858b9635d1c32c948610186d58
+    sha256: c2412d6018a4773406e5667e7006a599699110ce930f767fd8a333f7a7108ee5
   category: main
   optional: false
 - name: shellingham
@@ -11061,11 +11468,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
   hash:
-    md5: d08db09a552699ee9e7eec56b4eb3899
-    sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
+    md5: 7c3c2a0f3ebdea2bbc35538d162b43bf
+    sha256: 0557c090913aa63cdbe821dbdfa038a321b488e22bc80196c4b3b1aace4914ef
   category: main
   optional: false
 - name: simpervisor
@@ -11073,11 +11480,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/simpervisor-1.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/simpervisor-1.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 1f6df17b16d6295a484d59e844fef6ee
-    sha256: ae06686c9b4a93c07cdbfb04d91d34c2f5e3aa3e8170922cc3b5f1fbf52e566f
+    md5: b12cd36c9eea3f4d2f77daef432bdc00
+    sha256: 9c53a1dc8c7fd2c881b98f3a9e50fa8c5d67e3ca52de12338f0d94b40da6881e
   category: main
   optional: false
 - name: siphash24
@@ -11096,15 +11503,15 @@ package:
   category: main
   optional: false
 - name: six
-  version: 1.16.0
+  version: 1.17.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e5f25f8dbc060e9a8d912e432202afc2
-    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+    md5: a451d576819089b0d672f18768be0f65
+    sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
   category: main
   optional: false
 - name: slicerator
@@ -11112,23 +11519,23 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/slicerator-1.1.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/slicerator-1.1.0-pyhd8ed1ab_1.conda
   hash:
-    md5: c356cffc6bea0c224659fa47ce14e73a
-    sha256: e02c6d48fe6c2753da3a84e9e7b02c9788df5e895b25cba73ad17a7586d087ab
+    md5: 102f1100ad3dcbcf57f789600c9c015a
+    sha256: 5340c36cb62b7c8a22c267254c037302fea2670a4fb9d29e10ba36565e2a5510
   category: main
   optional: false
 - name: smmap
-  version: 5.0.0
+  version: 5.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+    md5: 87f47a78808baf2fa1ea9c315a1e48f1
+    sha256: eb92d0ad94b65af16c73071cc00cc0e10f2532be807beb52758aab2b06eb21e2
   category: main
   optional: false
 - name: snappy
@@ -11136,12 +11543,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
   hash:
-    md5: 6b7dcc7349efd123d493d2dbe85a045f
-    sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+    md5: 3b3e64af585eadfb52bb90b553db5edf
+    sha256: ec91e86eeb2c6bbf09d51351b851e945185d70661d2ada67204c9a6419d282d3
   category: main
   optional: false
 - name: sniffio
@@ -11149,11 +11557,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 490730480d76cf9c8f8f2849719c6e2b
-    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+    md5: bf7a226e58dfb8346c70df36065d86c9
+    sha256: c2248418c310bdd1719b186796ae50a8a77ce555228b6acd32768e2543a15012
   category: main
   optional: false
 - name: snuggs
@@ -11163,11 +11571,11 @@ package:
   dependencies:
     numpy: ''
     pyparsing: '>=2.1.6'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
   hash:
-    md5: 5abeaa41ec50d4d1421a8bc8fbc93054
-    sha256: 4c2281d61c325f9208ce18e030efc94e44c9a4f0d28a6c5737ff79740e1db2d4
+    md5: 9aa358575bbd4be126eaa5e0039f835c
+    sha256: 61f9373709e7d9009e3a062b135dbe44b16e684a4fcfe2dd624143bc0f80d402
   category: main
   optional: false
 - name: sortedcontainers
@@ -11175,11 +11583,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 6d6552722448103793743dabfbda532d
-    sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+    md5: 0401a17ae845fa72c7210e206ec5647d
+    sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
   category: main
   optional: false
 - name: soupsieve
@@ -11195,7 +11603,7 @@ package:
   category: main
   optional: false
 - name: sparse
-  version: 0.15.4
+  version: 0.15.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -11203,57 +11611,59 @@ package:
     numpy: '>=1.17'
     scipy: '>=0.19'
     numba: '>=0.49'
-  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.15.4-pyh267e887_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.15.5-pyh72ffeb9_0.conda
   hash:
-    md5: 40d80cd9fa4cc759c6dba19ea96642db
-    sha256: d6698bdf9411daf3f79f3745b687b18df47b5201e3d1e486fac62722cbe0bc32
+    md5: e640762c293807bbd75c003e18d8ff0c
+    sha256: 7cd9657cffe60891f418cc86d013c7872648a274c5957e626498e4e804272ec3
   category: main
   optional: false
 - name: spdlog
-  version: 1.14.1
+  version: 1.15.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    fmt: '>=11.0.1,<12.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.14.1-hed91bc2_1.conda
+    fmt: '>=11.0.2,<12.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.1-hb29a8c4_0.conda
   hash:
-    md5: 909188c8979846bac8e586908cf1ca6a
-    sha256: 0c604fe3f78ddb2b612841722bd9b5db24d0484e30ced89fac78c0a3f524dfd6
+    md5: 3666458a0c6a5c1ab099e0813ea2dc86
+    sha256: 6a8fbb341a43c58d46cb57c6146f1443084be58dfa16583a53f87dbcbb8acea2
   category: main
   optional: false
 - name: sqlalchemy
-  version: 1.4.49
+  version: 2.0.39
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     greenlet: '!=0.4.17'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.4.49-py310h2372a71_1.conda
+    typing-extensions: '>=4.6.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.39-py310ha75aee5_1.conda
   hash:
-    md5: cdeaf46006791202a7597bf2a0e6ad9e
-    sha256: bf3834160c19a080a72f33659d3e3edb74d32e2428413d1fa513f36f3b8e081c
+    md5: ec8f30932c8dcd1923873941c3f43322
+    sha256: 267e69d64d7f1967b6c9e02ecfeb0503d5caf5b6297ba3609a7d576de06adf3e
   category: main
   optional: false
 - name: sqlite
-  version: 3.47.0
+  version: 3.49.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libsqlite: 3.47.0
+    libsqlite: 3.49.1
     libzlib: '>=1.3.1,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
     readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.47.0-h9eae976_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.49.1-h9eae976_2.conda
   hash:
-    md5: 53abf1ef70b9ae213b22caa5350f97a9
-    sha256: 8ea1a085fa95d806301aeec0df6985c3ad0852a9a46aa62dd737d228c7862f9f
+    md5: 1894a9d3a8c3ffa53f8ca09fcd2fac25
+    sha256: 85c5b96686a900411ad8bdd424dcc2efb2044f15488bb89e57dff3bfcb74cc65
   category: main
   optional: false
 - name: stac-geoparquet
@@ -11296,18 +11706,18 @@ package:
   category: main
   optional: false
 - name: stack_data
-  version: 0.6.2
+  version: 0.6.3
   manager: conda
   platform: linux-64
   dependencies:
     asttokens: ''
     executing: ''
     pure_eval: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+    md5: b1b505328da7a6b246787df4b5a49fbc
+    sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   category: main
   optional: false
 - name: stackstac
@@ -11319,27 +11729,27 @@ package:
     numpy: <3,>1.23
     pandas: <3,>=2
     pyproj: <4.0.0,>=3.0.0
-    python: '>=3.8,<4.0'
+    python: '>=3.9,<4.0'
     rasterio: <2.0.0,>=1.3.0
     xarray: '>=0.18'
-  url: https://conda.anaconda.org/conda-forge/noarch/stackstac-0.5.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/stackstac-0.5.1-pyhd8ed1ab_1.conda
   hash:
-    md5: af36ec845ee6099742f3e6c46e5c1331
-    sha256: 8774cde4f9314549f1c02d6cd66ba75837f24c9ac5ea60002e2994b68c4d0d39
+    md5: 845b4fca508ab865b902c57bf3419ca0
+    sha256: e3e23e461e7d809b7bc691cca4e58387af4de0934c5e9babfa13ada251fd28ff
   category: main
   optional: false
 - name: starlette
-  version: 0.27.0
+  version: 0.46.1
   manager: conda
   platform: linux-64
   dependencies:
-    anyio: <5,>=3.4.0
-    python: '>=3.7'
+    anyio: '>=3.6.2,<5'
+    python: '>=3.9'
     typing_extensions: '>=3.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/starlette-0.27.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/starlette-0.46.1-pyha770c72_0.conda
   hash:
-    md5: 6facb6fc201d334257db8004439705d3
-    sha256: d155b6be8071b5c29c2056dd9e7ba8fee1ce38f977450d99a925918c1af12521
+    md5: db2f992eed837d11aed1dab97af9e408
+    sha256: 821c9e23e9dffaa1519faac109c60f02ebccc6436efd58ea60b85dd7b7f6e9ec
   category: main
   optional: false
 - name: statsmodels
@@ -11363,17 +11773,17 @@ package:
   category: main
   optional: false
 - name: svt-av1
-  version: 2.3.0
+  version: 3.0.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-3.0.1-h5888daf_0.conda
   hash:
-    md5: 355898d24394b2af353eb96358db9fdd
-    sha256: df30a9be29f1a8b5a2e314dd5b16ccfbcbd1cc6a4f659340e8bc2bd4de37bc6f
+    md5: 83ae590ee23da54c162d1f0fbf05bef0
+    sha256: 43a914e4b8f413d0327dd0eb98425b7c84d9dff6642a90bdae00e60dcc11a26d
   category: main
   optional: false
 - name: sysroot_linux-64
@@ -11383,26 +11793,26 @@ package:
   dependencies:
     kernel-headers_linux-64: 3.10.0
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_18.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
   hash:
-    md5: 0ea96f90a10838f58412aa84fdd9df09
-    sha256: 23c7ab371c1b74d01a187e05aa7240e3f5654599e364a9adff7f0b02e26f471f
+    md5: 460eba7851277ec1fd80a1a24080787a
+    sha256: 69ab5804bdd2e8e493d5709eebff382a72fab3e9af6adf93a237ccf8f7dbd624
   category: main
   optional: false
 - name: tabulate
-  version: 0.8.2
+  version: 0.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.8.2-py_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_2.conda
   hash:
-    md5: 15fdc9c0625f9c9c10a2785cb5674cfe
-    sha256: 14a17b65ea05009f86c01ab18b483a142cde686c5850a50fbc68f250032fd2ff
+    md5: 959484a66b4b76befcddc4fa97c95567
+    sha256: 090023bddd40d83468ef86573976af8c514f64119b2bd814ee63a838a542720a
   category: main
   optional: false
 - name: tbb
-  version: 2022.0.0
+  version: 2021.13.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -11410,10 +11820,10 @@ package:
     libgcc: '>=13'
     libhwloc: '>=2.11.2,<2.11.3.0a0'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.0.0-hceb3a55_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-hceb3a55_1.conda
   hash:
-    md5: 79f0161f3ca73804315ca980f65d9c60
-    sha256: 2f7931cad1682d8b6bdc90dbb51edf01f6f5c33fc00392c396d63e24437df1e8
+    md5: ba7726b8df7b9d34ea80e82b097a4893
+    sha256: 65463732129899770d54b1fbf30e1bb82fdebda9d7553caf08d23db4590cd691
   category: main
   optional: false
 - name: tblib
@@ -11421,11 +11831,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 04eedddeb68ad39871c8127dd1c21f4f
-    sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
+    md5: 60ce69f73f3e75b21f1c27b1b471320c
+    sha256: 6869cd2e043426d30c84d0ff6619f176b39728f9c75dc95dca89db994548bb8a
   category: main
   optional: false
 - name: tenacity
@@ -11433,11 +11843,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 42af51ad3b654ece73572628ad2882ae
-    sha256: 0d33171e1d303b57867f0cfcffb8a35031700acb3c52b1862064d8f4e1085538
+    md5: a09f66fe95a54a92172e56a4a97ba271
+    sha256: dcf2155fb959773fb102066bfab8e7d79aff67054d142716979274a43fc85735
   category: main
   optional: false
 - name: terminado
@@ -11460,73 +11870,74 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_2.conda
   hash:
-    md5: ba8aba332d8868897ce44ad74015a7fe
-    sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
+    md5: 23b4ba5619c4752976eb7ba1f5acb7e8
+    sha256: 4770807cc5a217638c9aea3f05ea55718a82c50f32462df196b5472aff02787f
   category: main
   optional: false
 - name: threadpoolctl
-  version: 3.5.0
+  version: 3.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
   hash:
-    md5: df68d78237980a159bd7149f33c0e8fd
-    sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
+    md5: 9d64911b31d57ca443e9f1e36b04385f
+    sha256: 6016672e0e72c4cf23c0cf7b1986283bd86a9c17e8d319212d78d8e9ae42fdfd
   category: main
   optional: false
 - name: tifffile
-  version: 2024.9.20
+  version: 2025.3.13
   manager: conda
   platform: linux-64
   dependencies:
-    imagecodecs: '>=2023.8.12'
+    imagecodecs: '>=2024.12.30'
     numpy: '>=1.19.2'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2024.9.20-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2025.3.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 6de55c7859ed314159eaf2b7b4f19cc7
-    sha256: 10b70ee019158ef75f2c861724b2b2c11002643031f862b3a8ca99014607ceed
+    md5: 4660bf736145d44fe220f0f95c9d9a2a
+    sha256: a0d83bf4662ef015e1224862be57916250f7ffd969c768afcc2028daa71a1a3b
   category: main
   optional: false
 - name: tiledb
-  version: 2.26.1
+  version: 2.27.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.28.3,<0.28.4.0a0'
-    aws-sdk-cpp: '>=1.11.407,<1.11.408.0a0'
-    azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
-    azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
-    azure-storage-blobs-cpp: '>=12.12.0,<12.12.1.0a0'
-    azure-storage-common-cpp: '>=12.7.0,<12.7.1.0a0'
+    aws-crt-cpp: '>=0.29.9,<0.29.10.0a0'
+    aws-sdk-cpp: '>=1.11.489,<1.11.490.0a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-identity-cpp: '>=1.10.0,<1.10.1.0a0'
+    azure-storage-blobs-cpp: '>=12.13.0,<12.13.1.0a0'
+    azure-storage-common-cpp: '>=12.8.0,<12.8.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
+    capnproto: '>=1.0.2,<1.0.3.0a0'
     fmt: '>=11.0.2,<12.0a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcurl: '>=8.12.1,<9.0a0'
     libgcc: '>=13'
-    libgoogle-cloud: '>=2.29.0,<2.30.0a0'
-    libgoogle-cloud-storage: '>=2.29.0,<2.30.0a0'
+    libgoogle-cloud: '>=2.35.0,<2.36.0a0'
+    libgoogle-cloud-storage: '>=2.35.0,<2.36.0a0'
     libstdcxx: '>=13'
-    libwebp-base: '>=1.4.0,<2.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-    spdlog: '>=1.14.1,<1.15.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.26.1-h4c922dd_1.conda
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    openssl: '>=3.4.1,<4.0a0'
+    spdlog: '>=1.15.1,<1.16.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.27.2-he4dccf3_0.conda
   hash:
-    md5: be7dcba29f39f6bd55015871d5301ee1
-    sha256: fe92c08c9d220ecef10e365386bc26363019f4ea3db04ba6cf2bb492741652e2
+    md5: bf48b40a6f934d72c33439e4be49d5a7
+    sha256: 41f25cc98a8428e79aefe87802873cc236d48238106e061949bafaf6c1c7ddfd
   category: main
   optional: false
 - name: tiledb-py
-  version: 0.32.2
+  version: 0.33.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -11537,11 +11948,27 @@ package:
     packaging: ''
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-    tiledb: '>=2.26.1,<2.27.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.32.2-py310h5aecaf9_0.conda
+    tiledb: '>=2.27.2,<2.28.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-py-0.33.6-py310h05b0a54_0.conda
   hash:
-    md5: c5254ec0d9df0069557e3dcb9f7d9e92
-    sha256: a6c53804db946e9d6c0b39d174ff4d767ce7656352afea5c526299629c05a691
+    md5: 72d4ab9bd511b38dc473d6b6de93a89b
+    sha256: c9d44f33f3917d0573f52bb0277fc4d3d48a8a75fd7e95f4dbfe9b527103f48b
+  category: main
+  optional: false
+- name: time-machine
+  version: 2.16.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.10,<3.11.0a0'
+    python-dateutil: ''
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/time-machine-2.16.0-py310ha75aee5_0.conda
+  hash:
+    md5: 8c949818a1b2c36456fa3950358edced
+    sha256: 64813032639d0bd0e447fb369e9c76e09661d4445dd40a4449ca5ea15ab1df62
   category: main
   optional: false
 - name: tinycss2
@@ -11575,23 +12002,23 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
   hash:
-    md5: f832c45a477c78bebd107098db465095
-    sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
+    md5: b0dd904de08b7db706167240bf37b164
+    sha256: 34f3a83384ac3ac30aefd1309e69498d8a4aa0bf2d1f21c645f79b180e378938
   category: main
   optional: false
 - name: tomli
-  version: 2.0.2
+  version: 2.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: e977934e00b355ff55ed154904044727
-    sha256: 5e742ba856168b606ac3c814d247657b1c33b8042371f1a08000bdc5075bc0cc
+    md5: ac944244f1fed2eb49bae07193ae8215
+    sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
   category: main
   optional: false
 - name: toolz
@@ -11599,15 +12026,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 34feccdd4177f2d3d53c73fc44fd9a37
-    sha256: 6371cf3cf8292f2abdcc2bf783d6e70203d72f8ff0c1625f55a486711e276c75
+    md5: 40d0ed782a8aaa16ef248e68c06c168d
+    sha256: eda38f423c33c2eaeca49ed946a8d3bf466cc3364970e083a65eb2fd85258d87
   category: main
   optional: false
 - name: tornado
-  version: 6.4.1
+  version: 6.4.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -11615,23 +12042,23 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py310ha75aee5_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py310ha75aee5_0.conda
   hash:
-    md5: 260c9ae4b2d9af7d5cce7b721cba6132
-    sha256: db63e4d301ae8241343a9e04321a0a8d23e214460715faea029dd199e6f5dcc5
+    md5: 166d59aab40b9c607b4cc21c03924e9d
+    sha256: 9c2b86d4e58c8b0e7d13a7f4c440f34e2201bae9cfc1d7e1d30a5bc7ffb1d4c8
   category: main
   optional: false
 - name: tqdm
-  version: 4.67.0
+  version: 4.67.1
   manager: conda
   platform: linux-64
   dependencies:
     colorama: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 196a9e6ab4e036ceafa516ea036619b0
-    sha256: fb25b18cec1ebae56e7d7ebbd3e504f063b61a0fac17b1ca798fcaf205bdc874
+    md5: 9efbfdc37242619130ea42b1cc4ed861
+    sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
   category: main
   optional: false
 - name: traitlets
@@ -11639,11 +12066,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 3df84416a021220d8b5700c613af2dc5
-    sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
+    md5: 019a7385be9af33791c989871317e1ed
+    sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   category: main
   optional: false
 - name: traittypes
@@ -11673,14 +12100,14 @@ package:
     numpy: '>=1.23'
     pandas: '>=2'
     pyproj: '>=2.3'
-    python: '>=3.8'
+    python: '>=3.9'
     roaring-landmask: '>=0.7'
     scipy: '>=1.9'
     xarray: '>=2022.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/trajan-0.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trajan-0.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: f288b47f47bec59768b51e4741124050
-    sha256: 6a72bdc0766b95dc244e78b252950d9829220daa0e46fc17f94a1109212d0983
+    md5: 1d80a4eac493880ba5c694d97143b7eb
+    sha256: b2a45a45df42fd025c2598429881f4d7ae866ad52a9f7f2757d0e9e36c6ccaad
   category: main
   optional: false
 - name: trollimage
@@ -11698,23 +12125,23 @@ package:
     python_abi: 3.10.*
     rasterio: ''
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/trollimage-1.26.0-py310h5eaa309_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/trollimage-1.26.0-py310h5eaa309_1.conda
   hash:
-    md5: e376e3be653eeb3c237ed0bacdf87ffe
-    sha256: 9595b677b7bc20abba7bf6dc2461934d3289b8feee9793cbfbe15a19baa6cb65
+    md5: baee118e0ef135c57142888c9a56f4e6
+    sha256: 1c76b1fbaf0a2039e1cfe791fc18456eb1f6a996f622fb20df3a26203115156b
   category: main
   optional: false
 - name: trollsift
-  version: 0.5.1
+  version: 0.5.3
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-0.5.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trollsift-0.5.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 5819998373586657ba9868756c0aaf8a
-    sha256: 90266fab4f7b1fa65c353c078736e9a69cd7033e667dec06e5b5d1d11e117bec
+    md5: c0b48df7cf57173154ab599d84ad16d1
+    sha256: f49a51bb511f5fa2207c050173e08f6cc58c3265b575635ccd6840c72e26abed
   category: main
   optional: false
 - name: typer
@@ -11759,15 +12186,15 @@ package:
   category: main
   optional: false
 - name: types-python-dateutil
-  version: 2.9.0.20241003
+  version: 2.9.0.20241206
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241003-pyhff2d567_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20241206-pyhd8ed1ab_0.conda
   hash:
-    md5: 3d326f8a2aa2d14d51d8c513426b5def
-    sha256: 8489af986daebfbcd13d3748ba55431259206e37f184ab42a57e107fecd85e02
+    md5: 1dbc4a115e2ad9fb7f9d5b68397f66f9
+    sha256: 8b98cd9464837174ab58aaa912fc95d5831879864676650a383994033533b8d1
   category: main
   optional: false
 - name: typing-extensions
@@ -11776,10 +12203,10 @@ package:
   platform: linux-64
   dependencies:
     typing_extensions: 4.12.2
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
   hash:
-    md5: 52d648bd608f5737b123f510bb5514b5
-    sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+    md5: b6a408c64b78ec7b779a3e5c7a902433
+    sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
   category: main
   optional: false
 - name: typing_extensions
@@ -11787,11 +12214,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
   hash:
-    md5: ebe6952715e1d5eb567eeebf25250fa7
-    sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
+    md5: d17f13df8b65464ca316cbc000a3cb64
+    sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
   category: main
   optional: false
 - name: typing_utils
@@ -11799,48 +12226,35 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
   hash:
-    md5: eb67e3cace64c66233e2d35949e20f92
-    sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
-  category: main
-  optional: false
-- name: tzcode
-  version: 2024b
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2024b-hb9d3cd8_0.conda
-  hash:
-    md5: db124840386e1f842f93372897d1b857
-    sha256: 20c72e7ba106338d51fdc29a717a54fcd52340063232e944dcd1d38fb6348a28
+    md5: f6d7aa696c67756a650e91e15e88223c
+    sha256: 3088d5d873411a56bf988eee774559335749aed6f6c28e07bf933256afb9eb6c
   category: main
   optional: false
 - name: tzdata
-  version: 2024b
+  version: 2025b
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
   hash:
-    md5: 8ac3367aafb1cc0a068483c580af8015
-    sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+    md5: 4222072737ccff51314b5ece9c7d6f5a
+    sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
   category: main
   optional: false
 - name: tzlocal
-  version: '5.2'
+  version: '5.3'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/tzlocal-5.2-py310hff52083_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tzlocal-5.3-py310hff52083_0.conda
   hash:
-    md5: a428bfcc3bfc8f850578317c72f0d61f
-    sha256: 39fc4aaa19cb687e6ae261115b5cea1182394ef2cc5e82718c66b722092296de
+    md5: cc089c3c0a3e67b2886148c4e02bd0cf
+    sha256: 4ba87dcf6bd32e285b629010830c44e4f45dd32f1646322aa1cf663627613743
   category: main
   optional: false
 - name: uc-micro-py
@@ -11848,11 +12262,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 3b7fc78d7be7b450952aaa916fb78877
-    sha256: 54293cd94da3a6b978b353eb7897555055d925ad0008bc73e85cca19e2587ed0
+    md5: 9c96c9876ba45368a03056ddd0f20431
+    sha256: a2f837780af450d633efc052219c31378bcad31356766663fb88a99e8e4c817b
   category: main
   optional: false
 - name: ujson
@@ -11872,7 +12286,7 @@ package:
   category: main
   optional: false
 - name: unicodedata2
-  version: 15.1.0
+  version: 16.0.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -11880,10 +12294,10 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310ha75aee5_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py310ha75aee5_0.conda
   hash:
-    md5: ee18e67b0bd283f6a75369936451d6ac
-    sha256: 4fa13f63d1e3e524a793733e7802110eba62f9734667da5990a172b4dc631d08
+    md5: 1d7a4b9202cdd10d56ecdd7f6c347190
+    sha256: 0468c864c60190fdb94b4705bca618e77589d5cb9fa096de47caccd1f22b0b54
   category: main
   optional: false
 - name: uri-template
@@ -11891,11 +12305,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 0944dc65cb4a9b5b68522c3bb585d41c
-    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
+    md5: e7cb0f5745e4c5035a460248334af7eb
+    sha256: e0eb6c8daf892b3056f08416a96d68b0a358b7c46b99c8a50481b22631a4dfc0
   category: main
   optional: false
 - name: uriparser
@@ -11909,6 +12323,19 @@ package:
   hash:
     md5: d71d3a66528853c0a1ac2c02d79a0284
     sha256: 2aad2aeff7c69a2d7eecd7b662eef756b27d6a6b96f3e2c2a7071340ce14543e
+  category: main
+  optional: false
+- name: url-normalize
+  version: 1.4.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/url-normalize-1.4.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: c7b1961b139c21381764de4704b6bbfb
+    sha256: e21242ad845600a6b7f03184c25d7cb8d38e229d196da0345290fc3996e07b70
   category: main
   optional: false
 - name: urllib3
@@ -11925,20 +12352,69 @@ package:
     sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
   category: main
   optional: false
+- name: uv
+  version: 0.6.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.6.10-h0f3a69f_0.conda
+  hash:
+    md5: d819b241035dc42d91c4672a82daea24
+    sha256: 3664a844eb11b4ecadb46c129eca1ce31f77448d15b371dac071c4db50060689
+  category: main
+  optional: false
 - name: uvicorn
-  version: 0.32.0
+  version: 0.34.0
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
     click: '>=7.0'
     h11: '>=0.8'
-    python: '>=3.8'
+    python: '>=3.9'
     typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.32.0-pyh31011fe_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.34.0-pyh31011fe_0.conda
   hash:
-    md5: 3936b8ca7212040c07565e1379ced362
-    sha256: bc1dd02dfe8ba9654c7ba4f359af1a36f88fdc8299e57e25394c26075e7f5ff2
+    md5: 5d448feee86e4740498ec8f8eb40e052
+    sha256: 55c160b0cf9274e2b98bc0f7fcce548bffa8d788bc86aa02801877457040f6fa
+  category: main
+  optional: false
+- name: uvicorn-standard
+  version: 0.34.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+    httptools: '>=0.6.3'
+    python-dotenv: '>=0.13'
+    pyyaml: '>=5.1'
+    uvicorn: 0.34.0
+    uvloop: '>=0.14.0,!=0.15.0,!=0.15.1'
+    watchfiles: '>=0.13'
+    websockets: '>=10.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.34.0-h31011fe_0.conda
+  hash:
+    md5: 32a94143a7f65d76d2d5da37dcb4ed79
+    sha256: 87e1531e175e75122f9f37608eb953af4c977465ab0ae11283cc01fef954e4ec
+  category: main
+  optional: false
+- name: uvloop
+  version: 0.21.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libuv: '>=1.49.2,<2.0a0'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.21.0-py310ha75aee5_1.conda
+  hash:
+    md5: 3429ca8351fae2ebf2b898719a7353e2
+    sha256: 6aca6dc4d5f4a05569bcf228bbdec7d9ce924efceeb7b7b6c95b07af9c22b317
   category: main
   optional: false
 - name: voila
@@ -11952,17 +12428,17 @@ package:
     jupyterlab_server: '>=2.3.0,<3'
     nbclient: '>=0.4.0'
     nbconvert: '>=6.4.5,<8'
-    python: '>=3.8'
+    python: '>=3.9'
     traitlets: '>=5.0.3,<6'
     websockets: '>=9'
-  url: https://conda.anaconda.org/conda-forge/noarch/voila-0.5.8-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/voila-0.5.8-pyhd8ed1ab_2.conda
   hash:
-    md5: 9701084d46133cef517774a98761f083
-    sha256: 80602768a73d086c5ae190159bbd5e1a514e22ffb2d84d8738923b32eed20adc
+    md5: 29df6fc83ed393d9c8c332ab3d22d97a
+    sha256: 938807623ff7c5cb5b3f1cca57b60e89bee9c9140ebb13b29e046cffaca7fe8f
   category: main
   optional: false
 - name: watchfiles
-  version: 0.24.0
+  version: 1.0.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -11971,10 +12447,10 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.24.0-py310h505e2c1_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.0.4-py310h505e2c1_0.conda
   hash:
-    md5: fb107c2368d11eba3a049870bb10d62e
-    sha256: 108337231cf1693b7e7d80b492d5510abc8676d60c784d3768c437753ea19566
+    md5: c684d0977a1f4a42c9d63e24bd1f8423
+    sha256: d0c51b58271a10443b57e639ac1d2a39bee17437152905f0a7a8dcf502bd9707
   category: main
   optional: false
 - name: wayland
@@ -11994,15 +12470,14 @@ package:
   category: main
   optional: false
 - name: wayland-protocols
-  version: '1.37'
+  version: '1.42'
   manager: conda
   platform: linux-64
-  dependencies:
-    wayland: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.42-hd8ed1ab_0.conda
   hash:
-    md5: 73ec79a77d31eb7e4a3276cd246b776c
-    sha256: f6cac1efd4d2a6e30c1671f0566d4e6ac3fe2dc34c9ff7f309bbbc916520ebcf
+    md5: 602b55baa61ed0eda99277662d375c2e
+    sha256: 92ae338de325bf81f5d98075d1efc9c74e532e37d03bf4aeea50f202ad983a53
   category: main
   optional: false
 - name: wcwidth
@@ -12010,23 +12485,23 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
   hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+    md5: b68980f2495d096e71c7fd9d7ccf63e6
+    sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
   category: main
   optional: false
 - name: webcolors
-  version: 24.8.0
+  version: 24.11.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.8.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
   hash:
-    md5: eb48b812eb4fbb9ff238a6651fdbbcae
-    sha256: ec71f97c332a7d328ae038990b8090cbfa772f82845b5d2233defd167b7cc5ac
+    md5: b49f7b291e15494aafb0a7d74806f337
+    sha256: 08315dc2e61766a39219b2d82685fc25a56b2817acf84d5b390176080eaacf99
   category: main
   optional: false
 - name: webencodings
@@ -12034,11 +12509,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
   hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+    md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+    sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
   category: main
   optional: false
 - name: webob
@@ -12047,11 +12522,11 @@ package:
   platform: linux-64
   dependencies:
     legacy-cgi: '>=2.6'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/webob-1.8.9-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/webob-1.8.9-pyhd8ed1ab_1.conda
   hash:
-    md5: ff98f23ad74d2a3256debcd9df65d37d
-    sha256: 533b1188a28365bb8339ea0db02d701022b92e3703cde05810c357e766b54eb3
+    md5: 293718ddac83a0fbc0f2193ff77d1e1c
+    sha256: 75d5dc901bf80b1cdfc3ab06aa712971034a8efb426b15355c16166d0de58898
   category: main
   optional: false
 - name: websocket-client
@@ -12059,11 +12534,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
   hash:
-    md5: f372c576b8774922da83cda2b12f9d29
-    sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
+    md5: 84f8f77f0a9c6ef401ee96611745da8f
+    sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
   category: main
   optional: false
 - name: websockets
@@ -12082,29 +12557,29 @@ package:
   category: main
   optional: false
 - name: wheel
-  version: 0.44.0
+  version: 0.45.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
   hash:
-    md5: d44e3b085abcaef02983c6305b84b584
-    sha256: d828764736babb4322b8102094de38074dedfc71f5ff405c9dfee89191c14ebc
+    md5: 75cb7132eb58d97896e173ef12ac9986
+    sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
   category: main
   optional: false
 - name: whitebox
-  version: 2.3.5
+  version: 2.3.6
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=6.0'
-    python: '>=3.6'
+    python: '>=3.9'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/whitebox-2.3.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/whitebox-2.3.6-pyhd8ed1ab_0.conda
   hash:
-    md5: a67aed4c3697af8d04cc8a3467de6b3b
-    sha256: a28d3c7ab54da578e8a30740954fb461db56b09f78161f15c629d8a36382a8e8
+    md5: ba379c537399f57f2a3f2938ac5a4061
+    sha256: 7329d045f1efb72236070c8b23afdc57bc5ef6a4b0961726e094df6d596f228c
   category: main
   optional: false
 - name: whiteboxgui
@@ -12115,13 +12590,13 @@ package:
     ipyfilechooser: ''
     ipytree: ''
     ipywidgets: ''
-    python: '>=3.6'
+    python: '>=3.9'
     whitebox: ''
     xorg-libx11: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/whiteboxgui-2.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/whiteboxgui-2.3.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 96916399e481bbf4cc727ab14d539359
-    sha256: 38c8f2b8981b761472e7a811af342d4980c10629548cb3fc57fd7b8191c0ad7c
+    md5: 93e3da67a58f559204810c205b178641
+    sha256: 9e256b29d0e7b009ed73f169e2c622686d1c6655e8717975fe359a2596e2126e
   category: main
   optional: false
 - name: widgetsnbextension
@@ -12129,15 +12604,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_1.conda
   hash:
-    md5: 6372cd99502721bd7499f8d16b56268d
-    sha256: d155adc10f8c96f76d4468dbe37b33b4334dadf5cd4a95841aa009ca9bced5fa
+    md5: 237db148cc37a466e4222d589029b53e
+    sha256: a750202ae2a31d8e5ee5a5c127fcc7fa783cd0fbedbc0bf1ab549a109881fa9f
   category: main
   optional: false
 - name: wrapt
-  version: 1.16.0
+  version: 1.17.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -12145,10 +12620,10 @@ package:
     libgcc: '>=13'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py310ha75aee5_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.2-py310ha75aee5_0.conda
   hash:
-    md5: e65db89334b361f25f8e6228194ac3b7
-    sha256: 56b0a952aae1458ccbb0c62091214cc2bdb1250c580610738669f71c97688080
+    md5: 4bfec5ca281bf0c9d701e82d473be899
+    sha256: 16b76bf5d540d55297650b45dfead91c7ddd43a8f15380d9035d140aa023f3da
   category: main
   optional: false
 - name: wsproto
@@ -12157,11 +12632,11 @@ package:
   platform: linux-64
   dependencies:
     h11: '>=0.9.0,<1.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 00ba804b54f451d102f6a7615f08470d
-    sha256: 66bd3f2db31fb62a2ff1f48d2c69ccdd2fa4467741149a0ad5c0bd097e0ac0e7
+    md5: 2c7536a04d9c21e1dd05bd4a3b1e3a39
+    sha256: 37b89ef8dc05b6e06c73b60d0bc130f81d1be3a8c8eed5807c27984484ec175e
   category: main
   optional: false
 - name: x264
@@ -12190,18 +12665,18 @@ package:
   category: main
   optional: false
 - name: xarray
-  version: 2024.10.0
+  version: 2025.3.0
   manager: conda
   platform: linux-64
   dependencies:
     numpy: '>=1.24'
-    packaging: '>=23.1'
+    packaging: '>=23.2'
     pandas: '>=2.1'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 53e365732dfa053c4d19fc6b927392c4
-    sha256: a35c8291de55f96ecc9121d1ebd4995977ea2f51d9e529e97749abc108afb0e4
+    md5: 8ff602aae12466f334754064aa6d8aab
+    sha256: 2bd415ea2f71fe0458905923c4039f41107766377530301f2f95465f11f1b4d2
   category: main
   optional: false
 - name: xarray-sentinel
@@ -12210,14 +12685,14 @@ package:
   platform: linux-64
   dependencies:
     fsspec: ''
-    python: '>=3.8'
+    python: '>=3.9'
     rioxarray: ''
     xarray: '>=0.18.0'
     xmlschema: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-sentinel-0.9.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-sentinel-0.9.5-pyhd8ed1ab_1.conda
   hash:
-    md5: 100e4405ecb14aafe13fd2067fc8a89e
-    sha256: b002f19ef46208fb97dde53820f04f1e3a71635f94402b89f6304854e6db0a1c
+    md5: 7eb4ffa102ef13db16807337044b0597
+    sha256: fa3f1e22c2c28e80173cf2057e7fc079e0ff1adeb19ac6d6232c46410f4a1852
   category: main
   optional: false
 - name: xarray-spatial
@@ -12228,12 +12703,12 @@ package:
     datashader: '>=0.15.0'
     numba: ''
     numpy: ''
-    python: '>=3.8'
+    python: '>=3.9'
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 892f97df8ce15d77157696d2d38866f4
-    sha256: b6211a7e1eb3dce320b2baa11134561d29bad46a37e273bab69461f4e9d80251
+    md5: 08fb8e66d768c60c66e7f286e97413b0
+    sha256: 7d60c329e050a7a9022ba2f3bd58b920e3099e70328e22b901c3fd16d0f592a5
   category: main
   optional: false
 - name: xarrayutils
@@ -12274,7 +12749,7 @@ package:
   category: main
   optional: false
 - name: xclim
-  version: 0.53.1
+  version: 0.53.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -12298,12 +12773,12 @@ package:
     scikit-learn: '>=1.1.0'
     scipy: '>=1.9.0'
     statsmodels: '>=0.14.2'
-    xarray: '>=2023.11.0'
+    xarray: '>=2023.11.0,!=2024.10.0'
     yamale: '>=5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/xclim-0.53.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xclim-0.53.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 095e59e596d7f02edc0ea8789570bedd
-    sha256: b092f8347c6cc88c71b271d966cf93e79b31267ccd8a1cd1f7e356c3a49c0141
+    md5: 7a4f1e70913a9b9e671020d8cb0f94ba
+    sha256: c0099fa3784efab727cb582648de802d448dc12a33e07839d84139a2ae5a3ae8
   category: main
   optional: false
 - name: xcube
@@ -12336,7 +12811,7 @@ package:
     pillow: '>=6.0'
     pyjwt: '>=1.7'
     pyproj: '>=3.0'
-    python: '>=3.9'
+    python: '>=3.10'
     pyyaml: '>=5.4'
     rasterio: '>=1.2'
     requests: '>=2.25'
@@ -12349,10 +12824,10 @@ package:
     urllib3: '>=1.26'
     xarray: '>=2022.6'
     zarr: '>=2.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/xcube-1.7.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xcube-1.7.1-pyhd8ed1ab_1.conda
   hash:
-    md5: d25aa0ca4e078cb6c60f2c30e820bf6f
-    sha256: 161daf78a2b5bc7ea672fe86359f8e1cbe9a944f6889e793d5c9ce8dff215789
+    md5: cd2eb25642db82eebb7e55b5534250a1
+    sha256: 114761a109740e27b84f6207fd1fe3834fddee50ca7bfc3377995e25c1f1236b
   category: main
   optional: false
 - name: xerces-c
@@ -12380,14 +12855,14 @@ package:
     esmpy: '>=8.0.0,!=8.4.0,!=8.4.1,!=8.4.2'
     numba: '>=0.55.2'
     numpy: '>=1.16'
-    python: '>=3.8'
+    python: '>=3.9'
     shapely: ''
     sparse: '>=0.8.0'
     xarray: '>=0.16.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/xesmf-0.8.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xesmf-0.8.8-pyhd8ed1ab_1.conda
   hash:
-    md5: ecb541b6f97cdedff14644bc2b6a1605
-    sha256: 5f253e4ef9236e812b41650686a8a8f2c6316c1c3df086d448bbfae8cd826128
+    md5: 3a0254838eeda4b598c18f6b8e0551c5
+    sha256: f0f467df9e561ce14c50bbdc6d8c063e62420e4b11da2bb0fc920d747d936836
   category: main
   optional: false
 - name: xgcm
@@ -12400,10 +12875,10 @@ package:
     numpy: ''
     python: '>=3.9'
     xarray: '>=0.20.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/xgcm-0.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xgcm-0.8.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 3b4400fe7f2e6c6a969d511b39c9f2ea
-    sha256: 5193f872e60fd92d409f636329d40e99329128ff9ccce78243e7f019904ca492
+    md5: 46896a83e5c5ce639e5492559d16156c
+    sha256: e214eac3edc7f7a9be3837758bfebc6edb8c947bbdb99b70ffb405992cc6e93f
   category: main
   optional: false
 - name: xhistogram
@@ -12419,6 +12894,20 @@ package:
   hash:
     md5: bc7b89b54047f1d555163b597f0b79de
     sha256: a9fb91e84140c91542cf208a7ae5a97a5bde953e2e759c212f1d987ca9f0dacc
+  category: main
+  optional: false
+- name: xkeyboard-config
+  version: '2.43'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
+  hash:
+    md5: f725c7425d6d7c15e31f3b99a88ea02f
+    sha256: 0d89b5873515a1f05d311f37ea4e087bbccc0418afa38f2f6189e97280db3179
   category: main
   optional: false
 - name: xlayers
@@ -12449,12 +12938,12 @@ package:
     numpy: ''
     pandas: ''
     pint-xarray: ''
-    python: '>=3.7'
+    python: '>=3.9'
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xmip-0.7.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xmip-0.7.2-pyhd8ed1ab_1.conda
   hash:
-    md5: db96c0e64864d15df227be0d6b6ea146
-    sha256: 74808281a00f692eb881c27cc5530ef3f5ff2db1c7da052369ede21b9182b4b3
+    md5: ed2575dbbcac52e1f4c79669fdd7abce
+    sha256: 4a54c250b1ec3e49f942074d45a9a5c5ba5a18fb0ccc50ae86155161b9345449
   category: main
   optional: false
 - name: xmitgcm
@@ -12467,82 +12956,128 @@ package:
     fsspec: ''
     numpy: ''
     packaging: ''
-    python: '>=3.7'
+    python: '>=3.9'
     xarray: '>=0.11'
     zarr: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xmitgcm-0.5.2-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/xmitgcm-0.5.2-pyhd8ed1ab_1.conda
   hash:
-    md5: fa9bab98df6ee06367c19eac79f17603
-    sha256: 7593f6e5540be5c9233dcd29b346041cdce10937b79b17f7864dab811963a8d8
+    md5: 3de1bd6d2df04b1b8de5302eaada0bd2
+    sha256: 918bda469e779e78175a85f037ae5275a7632614a97e5a227259876535bc805d
   category: main
   optional: false
 - name: xmlschema
-  version: 3.4.2
+  version: 3.4.5
   manager: conda
   platform: linux-64
   dependencies:
     elementpath: <5.0.0,>=4.4.0
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xmlschema-3.4.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xmlschema-3.4.5-pyhd8ed1ab_0.conda
   hash:
-    md5: de317289e05a302d1a0f5336e98751a3
-    sha256: 7a55fd47327b12297f7c98ece7ecc832d48ce7c6e75a8d37cff7f246b3e68f81
+    md5: 63b5824f31d9b7dbb6164bebe70004b6
+    sha256: 17f39614d25932581baf9aad744e5f2d0a7d1423c2a6f08778acbbbf28955e3c
   category: main
   optional: false
 - name: xorg-libice
-  version: 1.1.1
+  version: 1.1.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   hash:
-    md5: 19608a9656912805b2b9a2f6bd257b04
-    sha256: ec276da68d1c4a3d34a63195b35ca5b248d4aff0812464dcd843d74649b5cec4
+    md5: fb901ff28063514abb6046c9ec2c4a45
+    sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   category: main
   optional: false
 - name: xorg-libsm
-  version: 1.2.4
+  version: 1.2.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libuuid: '>=2.38.1,<3.0a0'
-    xorg-libice: '>=1.1.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+    xorg-libice: '>=1.1.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
   hash:
-    md5: 05a8ea5f446de33006171a7afe6ae857
-    sha256: 70e903370977d44c9120a5641ab563887bd48446e9ef6fc2a3f5f60531c2cd6c
+    md5: 1c74ff8c35dcadf952a16f752ca5aa49
+    sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
   category: main
   optional: false
 - name: xorg-libx11
-  version: 1.8.10
+  version: 1.8.12
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libxcb: '>=1.17.0,<2.0a0'
-    xorg-xorgproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
   hash:
-    md5: 0b666058a179b744a622d0a4a0c56353
-    sha256: c4650634607864630fb03696474a0535f6fce5fda7d81a6462346e071b53dfa7
+    md5: db038ce880f100acc74dba10302b5630
+    sha256: 51909270b1a6c5474ed3978628b341b4d4472cd22610e5f22b506855a5e20f67
   category: main
   optional: false
 - name: xorg-libxau
-  version: 1.0.11
+  version: 1.0.12
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
   hash:
-    md5: 77cbc488235ebbaab2b6e912d3934bae
-    sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
+    md5: f6ebe2cb3f82ba6c057dde5d9debe4f7
+    sha256: ed10c9283974d311855ae08a16dfd7e56241fac632aec3b92e3cfe73cff31038
+  category: main
+  optional: false
+- name: xorg-libxcomposite
+  version: 0.4.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
+  hash:
+    md5: d3c295b50f092ab525ffe3c2aa4b7413
+    sha256: 753f73e990c33366a91fd42cc17a3d19bb9444b9ca5ff983605fa9e953baf57f
+  category: main
+  optional: false
+- name: xorg-libxcursor
+  version: 1.2.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+    xorg-libxrender: '>=0.9.11,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+  hash:
+    md5: 2ccd714aa2242315acaf0a67faea780b
+    sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
+  category: main
+  optional: false
+- name: xorg-libxdamage
+  version: 1.1.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+  hash:
+    md5: b5fcc7172d22516e1f965490e65e33a4
+    sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
   category: main
   optional: false
 - name: xorg-libxdmcp
@@ -12602,45 +13137,96 @@ package:
     sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
   category: main
   optional: false
-- name: xorg-libxrender
-  version: 0.9.11
+- name: xorg-libxinerama
+  version: 1.1.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+  hash:
+    md5: 5e2eb9bf77394fc2e5918beefec9f9ab
+    sha256: 1b9141c027f9d84a9ee5eb642a0c19457c788182a5a73c5a9083860ac5c20a8c
+  category: main
+  optional: false
+- name: xorg-libxrandr
+  version: 1.5.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-xorgproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxrender: '>=0.9.11,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
   hash:
-    md5: a7a49a8b85122b49214798321e2e96b4
-    sha256: f1217e902c0b1d8bc5d3ce65e483ebf38b049c823c9117b7198cfb16bd2b9143
+    md5: 2de7f99d6581a4a7adbff607b5c278ca
+    sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
   category: main
   optional: false
-- name: xorg-xextproto
-  version: 7.3.0
+- name: xorg-libxrender
+  version: 0.9.12
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
+    xorg-libx11: '>=1.8.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
   hash:
-    md5: bc4cd53a083b6720d61a1519a1900878
-    sha256: f302a3f6284ee9ad3b39e45251d7ed15167896564dc33e006077a896fd3458a6
+    md5: 96d57aba173e878a2089d5638016dc5e
+    sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
   category: main
   optional: false
-- name: xorg-xorgproto
-  version: '2024.1'
+- name: xorg-libxscrnsaver
+  version: 1.2.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
   hash:
-    md5: 7c21106b851ec72c037b162c216d8f05
-    sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
+    md5: 303f7a0e9e0cd7d250bb6b952cecda90
+    sha256: 58e8fc1687534124832d22e102f098b5401173212ac69eb9fd96b16a3e2c8cb2
+  category: main
+  optional: false
+- name: xorg-libxtst
+  version: 1.2.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxi: '>=1.7.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  hash:
+    md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+    sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  category: main
+  optional: false
+- name: xorg-libxxf86vm
+  version: 1.1.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.6-hb9d3cd8_0.conda
+  hash:
+    md5: 5efa5fa6243a622445fdfd72aee15efa
+    sha256: 8a4e2ee642f884e6b78c20c0892b85dd9b2a6e64a6044e903297e616be6ca35b
   category: main
   optional: false
 - name: xpublish
@@ -12657,12 +13243,12 @@ package:
     python: '>=3.9'
     toolz: ''
     uvicorn: ''
-    xarray: '!=v2023.09.0'
+    xarray: '!=2023.09.0'
     zarr: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xpublish-0.3.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xpublish-0.3.3-pyhd8ed1ab_1.conda
   hash:
-    md5: d31757f86898360e74011323e0c757b1
-    sha256: aa03f479e7e94951cdee99a615c360e1d805e6fde28b5125701c735b1025e1be
+    md5: 47aba8a7bb235982c50f84b92144264a
+    sha256: f15c343fa5de047ffce8cd9f3195d1c06f3f4a9a982521129c303a4c87790ea2
   category: main
   optional: false
 - name: xrft
@@ -12674,50 +13260,83 @@ package:
     docrep: ''
     future: ''
     numpy: ''
-    python: '>=3.6'
+    python: '>=3.9'
     scipy: ''
     xarray: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xrft-1.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xrft-1.0.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 137f63327c7836fc2c2491a86f51ea3c
-    sha256: b11e0c65e5ae3a9ff7dee0b7648f7d09c6e3ace082ffc4521a9d0d3bfc40327a
+    md5: f86464b8dce15aaedafba979b620331a
+    sha256: b722351f4e432f2b31facfd887389eda45c15b7c9b7ceb048bb85c626d903a25
   category: main
   optional: false
 - name: xyzservices
-  version: 2024.9.0
+  version: 2025.1.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.9.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 156c91e778c1d4d57b709f8c5333fd06
-    sha256: 2dd2825b5a246461a95a0affaf7e1d459f7cc0ae68ad2dd8aab360c2e5859488
+    md5: fdf07e281a9e5e10fc75b2dd444136e9
+    sha256: 9978c22319e85026d5a4134944f73bac820c948ca6b6c32af6b6985b5221cd8a
   category: main
   optional: false
 - name: xz
-  version: 5.2.6
+  version: 5.6.4
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    liblzma: 5.6.4
+    liblzma-devel: 5.6.4
+    xz-gpl-tools: 5.6.4
+    xz-tools: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.6.4-hbcc6ac9_0.conda
   hash:
-    md5: 2161070d867d1b1204ea749c8eec4ef0
-    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+    md5: bb511c87804cf7220246a3a6efc45c22
+    sha256: 91fc251034fa5199919680aa50299296d89da54b2d066fb6e6a60461c17c0c4a
+  category: main
+  optional: false
+- name: xz-gpl-tools
+  version: 5.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.6.4-hbcc6ac9_0.conda
+  hash:
+    md5: 246840b451f7a66bd68869e56b066dd5
+    sha256: 300fc4e5993a36c979e61b1a38d00f0c23c0c56d5989be537cbc7bd8658254ed
+  category: main
+  optional: false
+- name: xz-tools
+  version: 5.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.6.4-hb9d3cd8_0.conda
+  hash:
+    md5: a098f9f949af52610fdceb8e35b57513
+    sha256: 57506a312d8cfbee98217fb382822bd49794ea6318dd4e0413a0d588dc6f4f69
   category: main
   optional: false
 - name: yamale
-  version: 5.2.1
+  version: 5.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     pyyaml: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/yamale-5.2.1-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/yamale-5.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: c089f90a086b6214c5606368d0d3bad0
-    sha256: b747e78b7476e2e59963457cccffee9f2845009f9ed5a66b9aa18d490e001015
+    md5: d4b5f3a50decd28cd747f4b5f7aea33f
+    sha256: 1c85f17dad61edd3f899328d1656ae5221b46a3c581c878a4bca888aa0c88e6c
   category: main
   optional: false
 - name: yaml
@@ -12733,7 +13352,7 @@ package:
   category: main
   optional: false
 - name: yarl
-  version: 1.16.0
+  version: 1.18.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -12741,13 +13360,13 @@ package:
     idna: '>=2.0'
     libgcc: '>=13'
     multidict: '>=4.0'
-    propcache: '>=0.2.0'
+    propcache: '>=0.2.1'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.16.0-py310ha75aee5_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.18.3-py310h89163eb_1.conda
   hash:
-    md5: f0734f65184577c08c9f1ba92cd9f57f
-    sha256: d20b5fce40d7fc54fbbbde57f44ae523312236be7c1212536e01539c9e3bf4b8
+    md5: e79f8634942fa1cae3278ca1e529b92c
+    sha256: 444019585c36b861c556cc995af81106210e036333f9c68b9f9e1c8ea77a1072
   category: main
   optional: false
 - name: zarr
@@ -12760,10 +13379,10 @@ package:
     numcodecs: '>=0.10.0'
     numpy: '>=1.24,<3.0'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 41abde21508578e02e3fd492e82a05cd
-    sha256: 0fd9bf7ba90088115c52dad7b9d44fbffeabe34cb35299b2c38d5f17851fda36
+    md5: 3e9a0fee25417c432c4780b9597fc312
+    sha256: 02c045d3ab97bd5a713b0f35b05f017603d33bd728694ce3cf843c45c2906535
   category: main
   optional: false
 - name: zeromq
@@ -12776,10 +13395,10 @@ package:
     libgcc: '>=13'
     libsodium: '>=1.0.20,<1.0.21.0a0'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
   hash:
-    md5: 113506c8d2d558e733f5c38f6bf08c50
-    sha256: e67288b1c98a31ee58a5c07bdd873dbe08e75f752e1ad605d5e8c0697339903e
+    md5: 3947a35e916fcc6b9825449affbf4214
+    sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
   category: main
   optional: false
 - name: zfp
@@ -12802,11 +13421,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: cf30c2c15b82aacb07f9c09e28ff2275
-    sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
+    md5: e52c2ef711ccf31bb7f70ca87d144b9e
+    sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
   category: main
   optional: false
 - name: zipp
@@ -12836,47 +13455,31 @@ package:
   category: main
   optional: false
 - name: zlib-ng
-  version: 2.2.2
+  version: 2.2.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.2.2-h5888daf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.2.4-h7955e40_0.conda
   hash:
-    md5: 135fd3c66bccad3d2254f50f9809e86a
-    sha256: 9288b88a2448a6ef9824ff4a9f9384f45f6444b009b9fa3e5f335d0c52e86e4b
+    md5: c8a816dbf59eb8ba6346a8f10014b302
+    sha256: acab8b9165e94393bcd46ed21763877754c8d450772315502504e4a94cd6a873
   category: main
   optional: false
-- name: zstandard
-  version: 0.23.0
+- name: zstd
+  version: 1.5.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    cffi: '>=1.11'
     libgcc: '>=13'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py310ha39cb0e_1.conda
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
   hash:
-    md5: f49de34fb99934bf49ab330b5caffd64
-    sha256: fcd784735205d6c5f19dcb339f92d2eede9bc42a01ec2c384381ee1b6089d4f6
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
-  hash:
-    md5: 4d056880988120e29d75bfff282e0f45
-    sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+    md5: 6432cb5d4ac0046c3ac0a8a0f95842f9
+    sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
   category: main
   optional: false

--- a/python/environment.yml
+++ b/python/environment.yml
@@ -80,7 +80,6 @@ dependencies:
   - nbstripout
   - nc-time-axis
   - netcdf4
-  - nomkl
   - numcodecs
   - numexpr=*=mkl* # https://github.com/conda-forge/numexpr-feedstock/issues/38#issuecomment-2366841133
   - numpy

--- a/python/environment.yml
+++ b/python/environment.yml
@@ -82,6 +82,7 @@ dependencies:
   - netcdf4
   - nomkl
   - numcodecs
+  - numexpr=*=mkl* # https://github.com/conda-forge/numexpr-feedstock/issues/38#issuecomment-2366841133
   - numpy
   - odc-algo
   - odc-geo


### PR DESCRIPTION
The package `rio-tiler` depends on `numexpr`, and the default version pulled in is the `nomkl` variant, but this causes incompatibilities when trying to install `pytorch`'s `cuda` variant (see https://github.com/conda-forge/numexpr-feedstock/issues/38#issuecomment-2366841133).

Output from running `mamba install 'pytorch=2.6=cuda12*' torchvision` on the DEP Hub (truncated to relevant portion):

```bash
Looking for: ['pytorch==2.6[build=cuda12*]', 'torchvision']


Pinned packages:
  - python 3.10.*


Could not solve for environment specs
The following packages are incompatible
├─ apache-beam is installable with the potential options
...
├─ nomkl is installable and it requires
│  └─ mkl <0.a0 , which can be installed;
├─ pyarrow-core is installable with the potential options
│  ├─ pyarrow-core 16.1.0 would require
│  │  └─ libarrow [16.1.0.* *cpu|16.1.0.* *cuda] with the potential options
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [15.0.2|16.1.0|17.0.0|18.0.0|18.1.0], which can be installed (as previously explained);
│  │     ├─ libarrow [16.0.0|16.1.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow 16.1.0, which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.0|19.0.1], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.1], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.0.0], which cannot be installed (as previously explained);
│  │     └─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  ├─ pyarrow-core 16.0.0 would require
│  │  └─ libarrow [16.0.0.* *cpu|16.0.0.* *cuda], which cannot be installed (as previously explained);
│  ├─ pyarrow-core [16.0.0|16.1.0|...|19.0.1] would require
│  │  └─ python >=3.11,<3.12.0a0 , which can be installed;
│  ├─ pyarrow-core [16.0.0|16.1.0|...|19.0.1] would require
│  │  └─ python >=3.12,<3.13.0a0 , which can be installed;
│  ├─ pyarrow-core [16.0.0|16.1.0|17.0.0] would require
│  │  └─ python >=3.8,<3.9.0a0 , which can be installed;
│  ├─ pyarrow-core [16.0.0|16.1.0|...|19.0.1] would require
│  │  └─ python >=3.9,<3.10.0a0 , which can be installed;
│  ├─ pyarrow-core 17.0.0 would require
│  │  └─ libarrow [17.0.0.* *cpu|17.0.0.* *cuda] with the potential options
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [15.0.2|16.1.0|17.0.0|18.0.0|18.1.0], which can be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.0|19.0.1], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.1], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.0.0], which cannot be installed (as previously explained);
│  │     └─ libarrow [16.1.0|17.0.0], which cannot be installed (as previously explained);
│  ├─ pyarrow-core 18.0.0 would require
│  │  └─ libarrow [18.0.0.* *cpu|18.0.0.* *cuda] with the potential options
│  │     ├─ libarrow [15.0.2|16.1.0|17.0.0|18.0.0|18.1.0], which can be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow 18.0.0, which cannot be installed (as previously explained);
│  │     └─ libarrow 18.0.0, which cannot be installed (as previously explained);
│  ├─ pyarrow-core [18.0.0|18.1.0|19.0.0|19.0.1] would require
│  │  └─ python >=3.13,<3.14.0a0 , which can be installed;
│  ├─ pyarrow-core 18.1.0 would require
│  │  └─ libarrow [18.1.0.* *cpu|18.1.0.* *cuda] with the potential options
│  │     ├─ libarrow [15.0.2|16.1.0|17.0.0|18.0.0|18.1.0], which can be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.0|19.0.1], which cannot be installed (as previously explained);
│  │     ├─ libarrow [16.1.0|17.0.0|18.1.0|19.0.1], which cannot be installed (as previously explained);
│  │     └─ libarrow [16.1.0|17.0.0|18.1.0|19.0.0], which cannot be installed (as previously explained);
│  ├─ pyarrow-core 19.0.0 would require
│  │  └─ libarrow [19.0.0.* *cpu|19.0.0.* *cuda], which cannot be installed (as previously explained);
│  └─ pyarrow-core 19.0.1 would require
│     └─ libarrow [19.0.1.* *cpu|19.0.1.* *cuda], which cannot be installed (as previously explained);
└─ pytorch 2.6 cuda12* is installable with the potential options
   ├─ pytorch 2.6.0 would require
   │  ├─ libabseil >=20240722.0,<20240723.0a0 , which cannot be installed (as previously explained);
   │  └─ libtorch 2.6.0 cuda126_generic_h4a15719_200, which requires
   │     ├─ libabseil >=20240722.0,<20240723.0a0 , which cannot be installed (as previously explained);
   │     ├─ libprotobuf >=5.28.3,<5.28.4.0a0 , which conflicts with any installable versions previously reported;
   │     └─ libzlib >=1.3.1,<2.0a0 , which cannot be installed (as previously explained);
   ├─ pytorch 2.6.0 would require
   │  ├─ libabseil >=20240722.0,<20240723.0a0 , which cannot be installed (as previously explained);
   │  └─ libtorch 2.6.0 cuda126_generic_he2678a1_201, which requires
   │     ├─ libabseil >=20240722.0,<20240723.0a0 , which cannot be installed (as previously explained);
   │     └─ libprotobuf >=5.28.3,<5.28.4.0a0 , which conflicts with any installable versions previously reported;
   ├─ pytorch 2.6.0 would require
   │  └─ libprotobuf >=5.29.3,<5.29.4.0a0 , which conflicts with any installable versions previously reported;
   ├─ pytorch 2.6.0 would require
   │  └─ python >=3.11,<3.12.0a0 , which can be installed;
   ├─ pytorch 2.6.0 would require
   │  └─ python >=3.12,<3.13.0a0 , which can be installed;
   ├─ pytorch 2.6.0 would require
   │  └─ python >=3.13,<3.14.0a0 , which can be installed;
   ├─ pytorch 2.6.0 would require
   │  └─ python >=3.9,<3.10.0a0 , which can be installed;
   └─ pytorch 2.6.0 would require
      └─ libtorch [2.6.0 cuda126_mkl_h8247c52_300|2.6.0 cuda126_mkl_h9e9ac90_301], which requires
         └─ mkl >=2024.2.2,<2025.0a0 , which conflicts with any installable versions previously reported.
```

</details>

This PR specifies using the `mkl` variant of `numexpr` in the conda environment.yml to resolve this incompatibility.